### PR TITLE
Simplify setup py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
+*.egg-info/
 doc/_build
 /_website
 /_gh-pages

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ Announcing:
 import os
 import inspect
 import vispy
-from distutils.core import setup
+from setuptools import setup
 
 
 name = 'vispy'
@@ -57,7 +57,7 @@ setup(
     
     platforms = 'any',
     provides = ['vispy'],
-    install_requires = ['numpy', 'pyOpenGl'],
+    install_requires = ['numpy', 'PyOpenGL'],
     
     packages = ['vispy',
                 'vispy.util', 


### PR DESCRIPTION
Here are some minor (?) changes to `setup.py`:
- I replaced the `__init__.py` parsing with a more Pythonic approach.
- Because the `install_requires` key is pointless with distutils, I switched to setuptools.
