### PR TITLE
Nicer pyglet import error message if version not high enough

### DIFF
--- a/vispy/app/backends/_pyglet.py
+++ b/vispy/app/backends/_pyglet.py
@@ -12,7 +12,7 @@ from distutils.version import LooseVersion
 import pyglet
 version = pyglet.version
 
-if LooseVersion(version) < LooseVersion('1.6'):
+if LooseVersion(version) < LooseVersion('1.2'):
     help = 'You can install the latest pyglet using:\n' 
     help += '    pip install http://pyglet.googlecode.com/archive/tip.zip'
     raise ImportError('Pyglet version too old (%s), need >= 1.2\n%s'


### PR DESCRIPTION
The version of pyglet that we need is not released yet. So one needs to
do "pip install http://pyglet.googlecode.com/archive/tip.zip".

Also added a note; I found that the pyglet process events function
does not really process paint events, but this might need further
investigation.
