### PR TITLE
Dont use `except:`!

### DIFF
--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -63,7 +63,7 @@ def has_qt(requires_uic=False, return_which=False):
 def has_pyglet(return_which=False):
     try:
         from . import _pyglet  # noqa
-    except:
+    except Exception:
         which = None
         has = False
     else:
@@ -104,7 +104,7 @@ def has_glfw(return_why=False, return_which=False):
 def has_glut(return_which=False):
     try:
         from OpenGL import GLUT  # noqa
-    except:
+    except Exception:
         has = False
         which = None
     else:

--- a/vispy/app/backends/_glut.py
+++ b/vispy/app/backends/_glut.py
@@ -113,7 +113,7 @@ class ApplicationBackend(BaseApplicationBackend):
                     argNames=())
                 text = ctypes.c_char_p("rgba stencil double samples=8 hidpi")
                 glutInitDisplayString(text)
-            except:
+            except Exception:
                 pass
         if not self._initialized:
             glut.glutInit()  # todo: maybe allow user to give args?

--- a/vispy/util/_testing.py
+++ b/vispy/util/_testing.py
@@ -155,7 +155,7 @@ class app_opengl_context(object):
     def __exit__(self, type, value, traceback):
         try:
             self.c.close()
-        except:
+        except Exception:
             logger.warn('Failed to close canvas')
         return
 

--- a/vispy/util/event.py
+++ b/vispy/util/event.py
@@ -296,7 +296,7 @@ class EventEmitter(object):
 
                 try:
                     cb(event)
-                except:
+                except Exception:
                     # get traceback and store (so we can do postmortem
                     # debugging)
                     type, value, tb = sys.exc_info()

--- a/vispy/util/tests/test_emitter_group.py
+++ b/vispy/util/tests/test_emitter_group.py
@@ -198,10 +198,10 @@ class TestGroups(unittest.TestCase):
             else:
                 try:
                     attrs[name] = copy.deepcopy(val)
-                except:
+                except Exception:
                     try:
                         attrs[name] = copy.copy(val)
-                    except:
+                    except Exception:
                         attrs[name] = val
         if key is None:
             self.result = ev, attrs

--- a/vispy/util/tests/test_event_emitter.py
+++ b/vispy/util/tests/test_event_emitter.py
@@ -106,7 +106,7 @@ class TestEmitters(unittest.TestCase):
             self.assert_result()  # checks event type
             assert False, \
                 "Should not be able to construct emitter with non-Event class"
-        except:
+        except Exception:
             pass
 
     def test_event_kwargs(self):
@@ -433,10 +433,10 @@ class TestEmitters(unittest.TestCase):
             else:
                 try:
                     attrs[name] = copy.deepcopy(val)
-                except:
+                except Exception:
                     try:
                         attrs[name] = copy.copy(val)
-                    except:
+                    except Exception:
                         attrs[name] = val
         if key is None:
             self.result = ev, attrs


### PR DESCRIPTION
Second attempt at creating a PR against a PR. I think it worked this time.

This also triggers on KeyBoardInterrupt and SystemExit and can thus
prevent Python shutdown. Use `except Exception:` instead.
