### PR TITLE
FIX: Don't quit early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
     - cd ${VISPY_DIR}/../
     - # Nose-timer has bugs on 3+ as of Jan 2014
     - if [ "${PYTHON}" == "2.7" ]; then
-        nosetests -x --with-timer --timer-top-n 10;
+        nosetests --with-timer --timer-top-n 10;
       else
         nosetests;
       fi


### PR DESCRIPTION
I don't think `Travis` should quit early. Let's say there are 10 errors in my file that only occur on Travis, I will have to go through 10 iterations to find them all instead of 1...
