### PR TITLE
Feature/screenshot

### DIFF
--- a/examples/demo/screenshot.py
+++ b/examples/demo/screenshot.py
@@ -29,7 +29,7 @@ class Screenshot(object):
     def on_draw(self, event):
         self.canvas_on_draw(event)
         self.image = vispy.gloo.util._screenshot(
-            (0, 0, self.canvas.size[0], self.canvas.size[1]))
+            (0, 0, self.canvas.size[0], self.canvas.size[1]))[::-1]
         self.canvas.on_draw = self.canvas_on_draw
 
     def save(self, image_path="screenshot.png"):


### PR DESCRIPTION
A class that wraps the _screenshot function around the first on_paint frame of a Canvas.
I tried but failed to make it draw using app.process_events() like in the test framework and "make images gallery"(1).
When I run (1), it also doesn't draw, and is stuck running app.process_events() forever.
Ideally I would like to fix this, but for now it is sufficient for me to just save the image when showing the canvas with app.run()
