### PR TITLE
Add flake_diff make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ script:
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
     - if [ "${TEST}" == "extra" ]; then
-        - echo "IFTEST TRUE"
+    - echo "IFTEST TRUE"
     - fi
     - if [ "${TEST}" == "extra" ]; then
         cwd=`pwd`;

--- a/.travis.yml
+++ b/.travis.yml
@@ -200,9 +200,9 @@ script:
       LPURPLE='\033[01;35m';
       LCYAN='\033[01;36m';
       WHITE='\033[01;37m';
-      echo -e "Color test:\n${RED}RED\n${GREEN}GREEN\n${YELLOW}YELLOW\n${BLUE}BLUE\n${PURPLE}PURPLE\n${CYAN}CYAN\n${GRAY}GRAY"
-      echo -e "Color test:\n${LRED}RED\n${LGREEN}GREEN\n${LYELLOW}YELLOW\n${LBLUE}BLUE\n${LPURPLE}PURPLE\n${LCYAN}CYAN\n${WHITE}WHITE"
-      echo -e "Color test: ${RESET}RESET"
+      echo -e "Color test:\n${RED}RED\n${GREEN}GREEN\n${YELLOW}YELLOW\n${BLUE}BLUE\n${PURPLE}PURPLE\n${CYAN}CYAN\n${GRAY}GRAY";
+      echo -e "Color test:\n${LRED}RED\n${LGREEN}GREEN\n${LYELLOW}YELLOW\n${LBLUE}BLUE\n${LPURPLE}PURPLE\n${LCYAN}CYAN\n${WHITE}WHITE";
+      echo -e "Color test: ${RESET}RESET";
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,11 @@ before_install:
       fi;
     
     # Approximate the amount of content added as the size difference 
-    # after merging, less the number of commits * 21
+    # after merging, less the number of commits * 22
     # (where 21 kB is approximately the per-commit overhead)
     - if [ "${TEST}" == "extra" ]; then
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} \* 21 \)`;
+          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} \* 22 \)`;
         else
           SIZE_DIFF=0;
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,10 +152,10 @@ script:
         cwd=`pwd`;
         mkdir ../flake_test;
         cd ../flake_test;
-        git clone $cwd;
+        git init;
         git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
         git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
-        git merge --no-ff --no-commit ..
+        git merge --no-ff --no-commit $cwd
         make flake_diff;
         cd $cwd;        
         make lineendings;

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ before_script:
       WHITE='\033[00;37m';
       start_test() {
         echo -e "${BLUE}======== Starting $1 ========${RESET}";
-      }
+      };
       check_output() {
         ret=$?;
         if [ $ret == 0 ]; then
@@ -167,7 +167,7 @@ before_script:
             echo -e "${RED}>>>>    $1 FAILED    <<<<${RESET}";
         fi;
         return $ret;
-      }
+      };
     
 
 
@@ -202,20 +202,20 @@ script:
         make flake_diff &&
         cd $cwd;
       fi; 
-      check_output "style tests";
+      check_output "style tests"
       
     - start_test "line endings check";
       if [ "${TEST}" == "extra" ]; then
         make lineendings;
       fi;
-      check_output "line endings check";
+      check_output "line endings check"
       
     - start_test "repository size test";
       if [ "${TEST}" == "extra" ]; then
         echo -e "\033[1;34mEstimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
-      check_output "repository size test";
+      check_output "repository size test"
       
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,10 @@ script:
       fi;
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
+    - echo ${TRAVIS_BRANCH}
+    - echo ${TRAVIS_REPO_SLUG}
+    - echo ${GIT_TARGET_EXTRA}
+    - echo ${GIT_SOURCE_EXTRA}
     - if [ "${TEST}" == "extra" ]; then
         cwd=`pwd` &&
         mkdir ../flake_test &&
@@ -158,7 +162,7 @@ script:
         git fetch origin ${GIT_SOURCE_EXTRA} &&
         git merge --no-ff --no-commit FETCH_HEAD &&
         make flake_diff &&
-        cd $cwd
+        cd $cwd;
       fi; 
       
     - if [ "${TEST}" == "extra" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,9 +164,9 @@ before_script:
       check_output() {
         ret=$?;
         if [ $ret == 0 ]; then
-            echo -e "${GREEN}>>>>    $1 passed    <<<<${RESET}";
+            echo -e "${GREEN}>>>>>>    $1 passed    <<<<<<${RESET}";
         else
-            echo -e "${RED}>>>>    $1 FAILED    <<<<${RESET}";
+            echo -e "${RED}>>>>>>    $1 FAILED    <<<<<<${RESET}";
         fi;
         return $ret;
       };
@@ -175,16 +175,16 @@ before_script:
 
 script:
     - # Nose-timer has bugs on 3+ as of Jan 2014
-    - start_test "unit tests";
-      cd ${VISPY_DIR}/../;
+    - cd ${VISPY_DIR}/../;
       if [ "${TEST}" != "extra" ]; then
+        start_test "unit tests";
         if [ "${PYTHON}" == "2.7" ]; then
           nosetests --with-timer --timer-top-n 10;
         else
           nosetests;
         fi;
+        check_output "unit tests"
       fi;
-      check_output "unit tests"
       
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - start_test "style tests";

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
         TARGET_SIZE=`du -s . | sed -e "s/\t.*//"` &&
         git pull origin ${GIT_SOURCE_EXTRA} && 
         git gc --aggressive &&
-        MERGE_SIZE=`du -s . | sed -e "s/\t.*//"` &&
+        MERGE_SIZE=`du -s . | sed -e "s/\t.*//"`;
       fi;
     
     - if [ "${TEST}" == "extra" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,21 +146,48 @@ before_script:
     # We need to create a (fake) display on Travis, let's use a funny resolution
     - export DISPLAY=:99.0
     - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
+    
+    # Help color output from each test
+    - RESET='\033[0m';
+      RED='\033[00;31m';
+      GREEN='\033[00;32m';
+      YELLOW='\033[00;33m';
+      BLUE='\033[00;34m';
+      PURPLE='\033[00;35m';
+      CYAN='\033[00;36m';
+      WHITE='\033[00;37m';
+      start_test() {
+        echo -e "${BLUE}======== Starting $1 ========${RESET}";
+      }
+      check_output() {
+        ret=$?;
+        if [ $ret == 0 ]; then
+            echo -e "${GREEN}>>>>    $1 passed    <<<<${RESET}";
+        else
+            echo -e "${RED}>>>>    $1 FAILED    <<<<${RESET}";
+        fi;
+        return $ret;
+      }
+    
 
 
 script:
-    - cd ${VISPY_DIR}/../
     - # Nose-timer has bugs on 3+ as of Jan 2014
-    - if [ "${TEST}" != "extra" ]; then
+    - start_test "unit tests";
+      cd ${VISPY_DIR}/../;
+      if [ "${TEST}" != "extra" ]; then
         if [ "${PYTHON}" == "2.7" ]; then
           nosetests --with-timer --timer-top-n 10;
         else
           nosetests;
         fi;
       fi;
+      check_output "unit tests"
+      
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
-    - cd ${SRC_DIR}
-    - if [ "${TEST}" == "extra" ]; then
+    - start_test "style tests";
+      cd ${SRC_DIR};
+      if [ "${TEST}" == "extra" ]; then
         cwd=`pwd` &&
         mkdir ../flake_test &&
         cd ../flake_test &&
@@ -175,41 +202,29 @@ script:
         make flake_diff &&
         cd $cwd;
       fi; 
+      check_output "style tests";
       
-    - if [ "${TEST}" == "extra" ]; then
+    - start_test "line endings check";
+      if [ "${TEST}" == "extra" ]; then
         make lineendings;
       fi;
+      check_output "line endings check";
       
-    - if [ "${TEST}" == "extra" ]; then
+    - start_test "repository size test";
+      if [ "${TEST}" == "extra" ]; then
         echo -e "\033[1;34mEstimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
+      check_output "repository size test";
       
-    - RESET='\033[0m';
-      RED='\033[00;31m';
-      GREEN='\033[00;32m';
-      YELLOW='\033[00;33m';
-      BLUE='\033[00;34m';
-      PURPLE='\033[00;35m';
-      CYAN='\033[00;36m';
-      GRAY='\033[00;37m';
-      LRED='\033[01;31m';
-      LGREEN='\033[01;32m';
-      LYELLOW='\033[01;33m';
-      LBLUE='\033[01;34m';
-      LPURPLE='\033[01;35m';
-      LCYAN='\033[01;36m';
-      WHITE='\033[01;37m';
-      echo -e "Color test \n${RED}RED\n ${GREEN}GREEN\n ${YELLOW}YELLOW\n ${BLUE}BLUE\n ${PURPLE}PURPLE\n ${CYAN}CYAN\n ${GRAY}GRAY";
-      echo -e "Color test \n${LRED}RED\n ${LGREEN}GREEN\n ${LYELLOW}YELLOW\n ${LBLUE}BLUE\n ${LPURPLE}PURPLE\n ${LCYAN}CYAN\n ${WHITE}WHITE";
-      echo -e "Color test ${RESET}RESET";
 
 
 
 after_success:
     # Need to run from source dir to execute appropriate "git" commands
     # Let's use the "full" test case for coveralls, best case for coverage
-    - if [ "${PYTHON}" == "2.7" ] && [ "${DEPS}" == "full" ] && [ "${TEST}" != "extra" ]; then
+    - start_test "coverage test";
+      if [ "${PYTHON}" == "2.7" ] && [ "${DEPS}" == "full" ] && [ "${TEST}" != "extra" ]; then
         echo "Running coveralls";
         cd ${SRC_DIR};
         coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ script:
         git fetch origin ${GIT_SOURCE_EXTRA} &&
         git merge --no-ff --no-commit FETCH_HEAD &&
         make flake_diff &&
-        cd $cwd &&
+        cd $cwd
       fi; 
       
     - if [ "${TEST}" == "extra" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,8 @@ install:
     - ln -s ${SRC_DIR}/setup.cfg ${VISPY_DIR}/../setup.cfg
     # Link coverage to src dir, coveralls should be run from there (needs git calls)
     - ln -s ${VISPY_DIR}/../.coverage ${SRC_DIR}/.coverage
+    - echo ${VISPY_DIR}
+    - echo ${SRC_DIR}
 
 
 before_script:
@@ -191,14 +193,14 @@ script:
         cwd=`pwd` &&
         mkdir ../flake_test &&
         cd ../flake_test &&
-        git init &&
-        git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
-        git fetch origin ${GIT_TARGET_EXTRA} &&
+        git init -q&&
+        git remote -q add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
+        git fetch -q origin ${GIT_TARGET_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
-        git tag target &&
-        git fetch origin ${GIT_SOURCE_EXTRA} &&
+        git tag -q travis_flake_target &&
+        git fetch -q origin ${GIT_SOURCE_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
-        git reset target &&
+        git reset -q travis_flake_target &&
         make flake_diff &&
         cd $cwd;
       fi; 
@@ -212,7 +214,7 @@ script:
       
     - start_test "repository size test";
       if [ "${TEST}" == "extra" ]; then
-        echo -e "\033[1;34mEstimated content size difference = ${SIZE_DIFF} kB";
+        echo -e "Estimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
       check_output "repository size test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,15 @@ script:
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
     - if [ "${TEST}" == "extra" ]; then
-        make flake;
+        cwd=`pwd`;
+        mkdir ../flake_test;
+        cd ../flake_test;
+        git clone $cwd;
+        git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
+        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
+        git merge --no-ff --no-commit ..
+        make flake_diff;
+        cd $cwd;        
         make lineendings;
         echo "Size difference ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,10 +194,10 @@ script:
         mkdir ../flake_test &&
         cd ../flake_test &&
         git init -q&&
-        git remote -q add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
+        git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
         git fetch -q origin ${GIT_TARGET_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
-        git tag -q travis_flake_target &&
+        git tag travis_flake_target &&
         git fetch -q origin ${GIT_SOURCE_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
         git reset -q travis_flake_target &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,20 +149,23 @@ script:
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
     - if [ "${TEST}" == "extra" ]; then
-    - echo "IFTEST TRUE"
-    - fi
+        cwd=`pwd` &&
+        mkdir ../flake_test &&
+        cd ../flake_test &&
+        git init &&
+        git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
+        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD &&
+        git fetch origin ${GIT_SOURCE_EXTRA} &&
+        git merge --no-ff --no-commit FETCH_HEAD &&
+        make flake_diff &&
+        cd $cwd &&
+      fi; 
+      
     - if [ "${TEST}" == "extra" ]; then
-        cwd=`pwd`;
-        mkdir ../flake_test;
-        cd ../flake_test;
-        git init;
-        git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
-        git fetch origin ${GIT_SOURCE_EXTRA};
-        git merge --no-ff --no-commit FETCH_HEAD;
-        make flake_diff;
-        cd $cwd;        
         make lineendings;
+      fi;
+      
+    - if [ "${TEST}" == "extra" ]; then
         echo "Size difference ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
         fi;
         cd ~;
         mkdir target-size-clone && cd target-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
+        git init && git remote add -t ${TRAVIS_BRANC} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
         git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD && cd ..;
         TARGET_SIZE=`du -s target-size-clone | sed -e "s/\t.*//"`;
         mkdir source-size-clone && cd source-size-clone;

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,13 +187,13 @@ script:
       fi;
       
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
-    - start_test "style tests";
-      cd ${SRC_DIR};
+    - cd ${SRC_DIR};
       if [ "${TEST}" == "extra" ]; then
+        start_test "style tests";
         cwd=`pwd` &&
         mkdir ../flake_test &&
         cd ../flake_test &&
-        git init -q&&
+        git init -q &&
         git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
         git fetch -q origin ${GIT_TARGET_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
@@ -203,21 +203,21 @@ script:
         git reset -q travis_flake_target &&
         make flake_diff &&
         cd $cwd;
+        check_output "style tests";
       fi; 
-      check_output "style tests"
       
-    - start_test "line endings check";
-      if [ "${TEST}" == "extra" ]; then
+    - if [ "${TEST}" == "extra" ]; then
+        start_test "line endings check";
         make lineendings;
+        check_output "line endings check";
       fi;
-      check_output "line endings check"
       
-    - start_test "repository size test";
-      if [ "${TEST}" == "extra" ]; then
+    - if [ "${TEST}" == "extra" ]; then
+        start_test "repository size test";
         echo -e "Estimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
+        check_output "repository size test";
       fi;
-      check_output "repository size test"
       
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
     # (where 21 kB is approximately the per-commit overhead)
     - if [ "${TEST}" == "extra" ]; then
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr (${MERGE_SIZE} - ${TARGET_SIZE}) - (${MERGE_COMMIT_COUNT} * 21)`;
+          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} * 21 \)`;
         else
           SIZE_DIFF=0;
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,21 @@ before_install:
         cd ~;
         mkdir target-size-clone && cd target-size-clone &&
         git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD && 
+        git fetch origin ${GIT_TARGET_EXTRA} && 
+        git checkout -qf FETCH_HEAD && 
+        git tag travis-merge-target &&
         TARGET_SIZE=`du -s . | sed -e "s/\t.*//"` &&
         git pull origin ${GIT_SOURCE_EXTRA} && 
-        SOURCE_SIZE=`du -s . | sed -e "s/\t.*//"`;
+        MERGE_SIZE=`du -s . | sed -e "s/\t.*//"` &&
+        MERGE_COMMIT_COUNT=`git log --pretty=oneline travis-merge-target..HEAD | wc -l`;
       fi;
     
     - if [ "${TEST}" == "extra" ]; then
-        if [ "${SOURCE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr ${SOURCE_SIZE} - ${TARGET_SIZE}`;
+        if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
+          # Approximate the amount of content added as the size difference 
+          # after merging, less the number of commits * 21
+          # (where 21 kB is approximately the per-commit overhead)
+          SIZE_DIFF=`expr (${MERGE_SIZE} - ${TARGET_SIZE}) - (${MERGE_COMMIT_COUNT} * 21)`;
         else
           SIZE_DIFF=0;
         fi;
@@ -163,9 +169,11 @@ script:
         git init &&
         git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
         git fetch origin ${GIT_TARGET_EXTRA} &&
+        git checkout -qf FETCH_HEAD &&
+        git tag target &&
         git fetch origin ${GIT_SOURCE_EXTRA} &&
         git checkout -qf FETCH_HEAD &&
-        git reset origin/${GIT_TARGET_EXTRA} &&
+        git reset target &&
         make flake_diff &&
         cd $cwd;
       fi; 
@@ -175,7 +183,10 @@ script:
       fi;
       
     - if [ "${TEST}" == "extra" ]; then
-        echo "Size difference ${SIZE_DIFF} kB";
+        echo "Branch size before merge = ${TARGET_SIZE} kB";
+        echo "Branch size after merge = ${MERGE_SIZE} kB";
+        echo "Commits in merge = ${MERGE_COMMIT_COUNT}";
+        echo "Estimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,21 +43,29 @@ before_install:
           GIT_SOURCE_EXTRA="";
         fi;
         cd ~;
-        mkdir target-size-clone && cd target-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD && cd ..;
-        TARGET_SIZE=`du -s target-size-clone | sed -e "s/\t.*//"`;
-        mkdir source-size-clone && cd source-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
-        git fetch origin ${GIT_SOURCE_EXTRA} && git checkout -qf FETCH_HEAD && cd ..;
-        SOURCE_SIZE=`du -s source-size-clone | sed -e "s/\t.*//"`;
+        mkdir target-size-clone && cd target-size-clone &&
+        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
+        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD && 
+        TARGET_SIZE=`du -s . | sed -e "s/\t.*//"` &&
+        git pull origin ${GIT_SOURCE_EXTRA} && 
+        SOURCE_SIZE=`du -s . | sed -e "s/\t.*//"`;
+      fi;
+    
+    - if [ "${TEST}" == "extra" ]; then
         if [ "${SOURCE_SIZE}" != "${TARGET_SIZE}" ]; then
           SIZE_DIFF=`expr ${SOURCE_SIZE} - ${TARGET_SIZE}`;
         else
           SIZE_DIFF=0;
         fi;
       fi;
+      
     - cd ${SRC_DIR}
+    
+    # to aid in debugging
+    - echo ${TRAVIS_BRANCH}
+    - echo ${TRAVIS_REPO_SLUG}
+    - echo ${GIT_TARGET_EXTRA}
+    - echo ${GIT_SOURCE_EXTRA}
 
 
 install:
@@ -148,19 +156,16 @@ script:
       fi;
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
-    - echo ${TRAVIS_BRANCH}
-    - echo ${TRAVIS_REPO_SLUG}
-    - echo ${GIT_TARGET_EXTRA}
-    - echo ${GIT_SOURCE_EXTRA}
     - if [ "${TEST}" == "extra" ]; then
         cwd=`pwd` &&
         mkdir ../flake_test &&
         cd ../flake_test &&
         git init &&
         git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git &&
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD &&
+        git fetch origin ${GIT_TARGET_EXTRA} &&
         git fetch origin ${GIT_SOURCE_EXTRA} &&
-        git merge --no-ff --no-commit FETCH_HEAD &&
+        git checkout -qf FETCH_HEAD &&
+        git reset origin/${GIT_TARGET_EXTRA} &&
         make flake_diff &&
         cd $cwd;
       fi; 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
         fi;
         cd ~;
         mkdir target-size-clone && cd target-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANC} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
+        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
         git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD && cd ..;
         TARGET_SIZE=`du -s target-size-clone | sed -e "s/\t.*//"`;
         mkdir source-size-clone && cd source-size-clone;
@@ -148,6 +148,9 @@ script:
       fi;
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
+    - if [ "${TEST}" == "extra" ]; then
+        - echo IFTEST: TRUE
+    - fi
     - if [ "${TEST}" == "extra" ]; then
         cwd=`pwd`;
         mkdir ../flake_test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
     # Enable python 2 and python 3 builds
     # Note that the 2.6 build doesn't get flake8, and runs old versions of
     # Pyglet and GLFW to make sure we deal with those correctly
-    - PYTHON=2.6 DEPS=full TEST=standard  # functionality
-    - PYTHON=2.7 DEPS=full TEST=standard
-    - PYTHON=2.7 DEPS=minimal TEST=standard
-    - PYTHON=3.3 DEPS=full TEST=standard
+    #- PYTHON=2.6 DEPS=full TEST=standard  # functionality
+    #- PYTHON=2.7 DEPS=full TEST=standard
+    #- PYTHON=2.7 DEPS=minimal TEST=standard
+    #- PYTHON=3.3 DEPS=full TEST=standard
     - PYTHON=3.3 DEPS=minimal TEST=extra  # test file sizes, style, line endings
 
 
@@ -149,7 +149,7 @@ script:
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)
     - cd ${SRC_DIR}
     - if [ "${TEST}" == "extra" ]; then
-        - echo IFTEST: TRUE
+        - echo "IFTEST TRUE"
     - fi
     - if [ "${TEST}" == "extra" ]; then
         cwd=`pwd`;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
     # Enable python 2 and python 3 builds
     # Note that the 2.6 build doesn't get flake8, and runs old versions of
     # Pyglet and GLFW to make sure we deal with those correctly
-    #- PYTHON=2.6 DEPS=full TEST=standard  # functionality
-    #- PYTHON=2.7 DEPS=full TEST=standard
-    #- PYTHON=2.7 DEPS=minimal TEST=standard
-    #- PYTHON=3.3 DEPS=full TEST=standard
+    - PYTHON=2.6 DEPS=full TEST=standard  # functionality
+    - PYTHON=2.7 DEPS=full TEST=standard
+    - PYTHON=2.7 DEPS=minimal TEST=standard
+    - PYTHON=3.3 DEPS=full TEST=standard
     - PYTHON=3.3 DEPS=minimal TEST=extra  # test file sizes, style, line endings
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ script:
         else
           nosetests;
         fi;
-        check_output "unit tests"
+        check_output "unit tests";
       fi;
       
     # Require strict adherence to PEP8 and pyflakes (can use "# noqa" to skip)

--- a/.travis.yml
+++ b/.travis.yml
@@ -200,9 +200,9 @@ script:
       LPURPLE='\033[01;35m';
       LCYAN='\033[01;36m';
       WHITE='\033[01;37m';
-      echo -e "Color test:\n${RED}RED\n${GREEN}GREEN\n${YELLOW}YELLOW\n${BLUE}BLUE\n${PURPLE}PURPLE\n${CYAN}CYAN\n${GRAY}GRAY";
-      echo -e "Color test:\n${LRED}RED\n${LGREEN}GREEN\n${LYELLOW}YELLOW\n${LBLUE}BLUE\n${LPURPLE}PURPLE\n${LCYAN}CYAN\n${WHITE}WHITE";
-      echo -e "Color test: ${RESET}RESET";
+      echo -e "Color test \n${RED}RED\n ${GREEN}GREEN\n ${YELLOW}YELLOW\n ${BLUE}BLUE\n ${PURPLE}PURPLE\n ${CYAN}CYAN\n ${GRAY}GRAY";
+      echo -e "Color test \n${LRED}RED\n ${LGREEN}GREEN\n ${LYELLOW}YELLOW\n ${LBLUE}BLUE\n ${LPURPLE}PURPLE\n ${LCYAN}CYAN\n ${WHITE}WHITE";
+      echo -e "Color test ${RESET}RESET";
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,26 @@ script:
         echo -e "\033[1;34mEstimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
+      
+    - RESET='\033[0m';
+      RED='\033[00;31m';
+      GREEN='\033[00;32m';
+      YELLOW='\033[00;33m';
+      BLUE='\033[00;34m';
+      PURPLE='\033[00;35m';
+      CYAN='\033[00;36m';
+      GRAY='\033[00;37m';
+      LRED='\033[01;31m';
+      LGREEN='\033[01;32m';
+      LYELLOW='\033[01;33m';
+      LBLUE='\033[01;34m';
+      LPURPLE='\033[01;35m';
+      LCYAN='\033[01;36m';
+      WHITE='\033[01;37m';
+      echo -e "Color test:\n${RED}RED\n${GREEN}GREEN\n${YELLOW}YELLOW\n${BLUE}BLUE\n${PURPLE}PURPLE\n${CYAN}CYAN\n${GRAY}GRAY"
+      echo -e "Color test:\n${LRED}RED\n${LGREEN}GREEN\n${LYELLOW}YELLOW\n${LBLUE}BLUE\n${LPURPLE}PURPLE\n${LCYAN}CYAN\n${WHITE}WHITE"
+      echo -e "Color test: ${RESET}RESET"
+
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
     # (where 21 kB is approximately the per-commit overhead)
     - if [ "${TEST}" == "extra" ]; then
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} * 21 \)`;
+          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} \* 21 \)`;
         else
           SIZE_DIFF=0;
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,18 +48,16 @@ before_install:
         git fetch origin ${GIT_TARGET_EXTRA} && 
         git checkout -qf FETCH_HEAD && 
         git tag travis-merge-target &&
+        git gc --aggressive &&
         TARGET_SIZE=`du -s . | sed -e "s/\t.*//"` &&
         git pull origin ${GIT_SOURCE_EXTRA} && 
+        git gc --aggressive &&
         MERGE_SIZE=`du -s . | sed -e "s/\t.*//"` &&
-        MERGE_COMMIT_COUNT=`git log --pretty=oneline travis-merge-target..HEAD | wc -l`;
       fi;
     
-    # Approximate the amount of content added as the size difference 
-    # after merging, less the number of commits * 22
-    # (where 21 kB is approximately the per-commit overhead)
     - if [ "${TEST}" == "extra" ]; then
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \) - \( ${MERGE_COMMIT_COUNT} \* 22 \)`;
+          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \)`;
         else
           SIZE_DIFF=0;
         fi;
@@ -183,10 +181,7 @@ script:
       fi;
       
     - if [ "${TEST}" == "extra" ]; then
-        echo "Branch size before merge = ${TARGET_SIZE} kB";
-        echo "Branch size after merge = ${MERGE_SIZE} kB";
-        echo "Commits in merge = ${MERGE_COMMIT_COUNT}";
-        echo "Estimated content size difference = ${SIZE_DIFF} kB";
+        echo -e "\033[1;34mEstimated content size difference = ${SIZE_DIFF} kB";
         test ${SIZE_DIFF} -lt 100;
       fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,11 @@ before_install:
         MERGE_COMMIT_COUNT=`git log --pretty=oneline travis-merge-target..HEAD | wc -l`;
       fi;
     
+    # Approximate the amount of content added as the size difference 
+    # after merging, less the number of commits * 21
+    # (where 21 kB is approximately the per-commit overhead)
     - if [ "${TEST}" == "extra" ]; then
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          # Approximate the amount of content added as the size difference 
-          # after merging, less the number of commits * 21
-          # (where 21 kB is approximately the per-commit overhead)
           SIZE_DIFF=`expr (${MERGE_SIZE} - ${TARGET_SIZE}) - (${MERGE_COMMIT_COUNT} * 21)`;
         else
           SIZE_DIFF=0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,8 @@ script:
         git init;
         git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
         git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
-        git merge --no-ff --no-commit $cwd
+        git fetch origin ${GIT_SOURCE_EXTRA};
+        git merge --no-ff --no-commit FETCH_HEAD;
         make flake_diff;
         cd $cwd;        
         make lineendings;

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ clean: clean-build clean-pyc clean-so clean-ctags
 flake:
 	python make flake
 
+flake_diff:
+	python make flake_diff
+
 in: inplace # just a shortcut
 inplace:
 	$(PYTHON) setup.py build_ext -i

--- a/make/make.py
+++ b/make/make.py
@@ -44,6 +44,8 @@ PAGES_REPO = 'git@github.com:vispy/vispy.github.com.git'
 IMAGES_DIR = os.path.join(ROOT_DIR, '_images')
 IMAGES_REPO = 'git@github.com:vispy/images.git'
 
+# Paths that are checked for style by flake and flake_diff
+FLAKE_CHECK_PATHS = ['vispy', 'examples', 'make']
 
 class Maker:
 
@@ -176,7 +178,7 @@ class Maker:
     def flake(self, arg):
         """ Run flake8 to find style inconsistencies. """
         os.chdir(ROOT_DIR)
-        sys.argv[1:] = ['vispy', 'examples', 'make']
+        sys.argv[1:] = FLAKE_CKECK_PATHS
         try:
             from flake8.main import main
         except ImportError:
@@ -191,6 +193,27 @@ class Maker:
                     raise  # raises SystemExit again
                 else:
                     print('flake8 test passed.')
+
+    def flake_diff(self, arg):
+        """ Run flake8, checking only lines that are modified since the last
+        git commit. """
+        test = [ 1,2,3 ]
+        print('flake8 test running...')
+        diff = subprocess.check_output(['git', 'diff'])
+        proc = subprocess.Popen(['flake8', '--diff', '--statistics', ] +
+                                [],#FLAKE_CHECK_PATHS, 
+                                stdin=subprocess.PIPE, 
+                                stdout=subprocess.PIPE)
+        proc.stdin.write(diff)
+        proc.stdin.close()
+        ret = proc.wait()
+        output = proc.stdout.read()
+        print(output)
+        if ret == 0:
+            print('flake8 test passed.')
+        else:
+            print('flake8 test failed: %d' % ret)
+            sys.exit(ret)
 
     def images(self, arg):
         """ Create images (screenshots). Subcommands:

--- a/make/make.py
+++ b/make/make.py
@@ -208,7 +208,7 @@ class Maker:
         proc.stdin.close()
         ret = proc.wait()
         output = proc.stdout.read()
-        print(output)
+        print(output.decode('utf-8'))
         if ret == 0:
             print('flake8 test passed.')
         else:

--- a/make/make.py
+++ b/make/make.py
@@ -124,10 +124,10 @@ FLAKE_OPTIONAL = set([
     'E221',  #  multiple spaces before operator
     'E222',  #  multiple spaces after operator
     'E225',  #  missing whitespace around operator
-    #'E226',  #  missing whitespace around arithmetic operator
     'E227',  #  missing whitespace around bitwise or shift operator
+    'E226',  #  missing whitespace around arithmetic operator
     'E228',  #  missing whitespace around modulo operator
-    #'E241',  #  multiple spaces after ‘,’
+    'E241',  #  multiple spaces after ‘,’
     'E251',  #  unexpected spaces around keyword / parameter equals
     'E262',  #  inline comment should start with ‘# ‘     
         
@@ -139,13 +139,11 @@ FLAKE_OPTIONAL = set([
 
     'E701',  #  multiple statements on one line (colon)
         
-    #'W291',  #  trailing whitespace
-    #'W293',  #  blank line contains whitespace
+    'W291',  #  trailing whitespace
+    'W293',  #  blank line contains whitespace
         
     'W391',  #  blank line at end of file
     ])
-
-
 
 
 class Maker:
@@ -303,7 +301,8 @@ class Maker:
         # First check _all_ code against mandatory error codes
         print('flake8: check all code against mandatory error set...')
         errors = ','.join(FLAKE_MANDATORY)
-        proc = subprocess.Popen(['flake8', '--select=' + errors] +
+        proc = subprocess.Popen(['flake8', #'--show-source', 
+                                 '--select=' + errors] +
                                 FLAKE_CHECK_PATHS, 
                                 stdout=subprocess.PIPE)
         ret = proc.wait()
@@ -313,8 +312,8 @@ class Maker:
         # Next check new code with optional error codes
         print('flake8: check new code against recommended error set...')
         diff = subprocess.check_output(['git', 'diff'])
-        errors = ','.join(FLAKE_OPTIONAL | FLAKE_RECOMMENDED)
-        proc = subprocess.Popen(['flake8', '--diff', '--select=' + errors],
+        proc = subprocess.Popen(['flake8', '--diff', #'--show-source',
+                                 '--ignore=' + errors],
                                 stdin=subprocess.PIPE, 
                                 stdout=subprocess.PIPE)
         proc.stdin.write(diff)

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -32,6 +32,6 @@ __version__ = '0.2.1'
 
 
 from .util import (dataio, _parse_command_line_arguments, config,  # noqa
-                   set_log_level, keys, sys_info)  # noqa
+           	 set_log_level, keys, sys_info)  # noqa
 
 _parse_command_line_arguments()


### PR DESCRIPTION
Idea test: have travis flake-check only code that is touched by the current PR. This allows us to keep stricter flake tests, with the same yellow-light warning. BUT: with this change, we have the option of admitting code that fails flake but nevertheless passes the eyeball test. After such code is committed to the repository, flake will no longer complain about it (unless it is touched again).

(not ready for review)