### PR TITLE
Fix example generation

### DIFF
--- a/doc/ext/examplesgenerator.py
+++ b/doc/ext/examplesgenerator.py
@@ -109,7 +109,7 @@ def create_examples(examples):
         output_filename = os.path.join(OUTPUT_DIR, name + '.rst')
         output_dir = os.path.dirname(output_filename)
         if not os.path.isdir(output_dir):
-            os.mkdir(output_dir)
+            os.makedirs(output_dir)
         with open(output_filename, 'w') as f:
             f.write('\n'.join(lines))
 


### PR DESCRIPTION
Issue #222 reports the following error when building the docs:

```
OSError: [Errno 2] No such file or directory: '/Users/me/src/vispy/doc/examples/techniques/grids'
```

I fixed that with a single-line change. `os.makedirs` is the recursive version of `os.mkdir`. the `grids` directory was getting created, but `techniques` didn't exist.

However, I am now getting the following error:

```
Exception occurred:
  File "/home/david/build/vispy/doc/ext/glapigenerator.py", line 36, in main
    glext_const_names, glext_func_names = parse_api(gl.ext)
AttributeError: 'module' object has no attribute 'ext'
```

Also, the following works in my shell:

``` python
In [5]: from vispy.gloo import gl

In [6]: gl.ext
Out[9]: <module 'vispy.gloo.gl.ext' from '/home/david/Dropbox/.virtualenvs/frackoptima/lib/python3.4/site-packages/vispy/gloo/gl/ext.py'>
```

So it seems to me `gl.ext` is generated somewhere when importing in the shell, but not in Sphinx.
