### PR TITLE
vispy.testing is not imported by default

### DIFF
--- a/make/make.py
+++ b/make/make.py
@@ -147,7 +147,18 @@ class Maker:
             sys.exit('Command "website" does not have subcommand "%s"' % arg)
 
     def test(self, arg):
-        """ Run all tests. """
+        """ Run tests:
+                * full - run all tests
+                * nose - run nose tests (also for each backend)
+                * any backend name (e.g. pyside, pyqt4, glut, sdl2, etc.) - 
+                  run tests for the given backend
+                * nobackend - run tests that do not require a backend
+                * extra - run extra tests (line endings and style)
+                * lineendings - test line ending consistency
+                * flake - flake style testing (PEP8 and more)
+        """
+        if not arg:
+            return self.help('test')
         from vispy import test
         try:
             test(*(arg.split()))

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -33,6 +33,23 @@ __version__ = '0.2.1'
 
 from .util import (dataio, _parse_command_line_arguments, config,  # noqa
                    set_log_level, keys, sys_info)  # noqa
-from .testing import _tester as test  # noqa
 
 _parse_command_line_arguments()
+
+
+# Define test proxy function, so we don't have to import vispy.testing now
+def test(label='full', coverage=False, verbosity=1):
+    """Test vispy software
+
+    Parameters
+    ----------
+    label : str
+        Can be one of 'full', 'nose', 'nobackend', 'extra', 'lineendings',
+        'flake', or any backend name (e.g., 'qt').
+    coverage : bool
+        Produce coverage outputs (.coverage file and printing).
+    verbosity : int
+        Verbosity level to use when running ``nose``.
+    """
+    from .testing import _tester
+    return _tester(label, coverage, verbosity)

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -132,17 +132,7 @@ def _check_line_endings():
 
 
 def _tester(label='full', coverage=False, verbosity=1):
-    """Test vispy software
-
-    Parameters
-    ----------
-    label : str
-        Can be one of 'full', 'nose', 'nobackend', 'extra', 'lineendings',
-        'flake', or any backend name (e.g., 'qt').
-    coverage : bool
-        Produce coverage outputs (.coverage file and printing).
-    verbosity : int
-        Verbosity level to use when running ``nose``.
+    """Test vispy software. See vispy.test()
     """
     from vispy.app.backends import BACKEND_NAMES as backend_names
     label = label.lower()

--- a/vispy/util/tests/test_import.py
+++ b/vispy/util/tests/test_import.py
@@ -14,7 +14,7 @@ import vispy
 
 
 # minimum that will be imported when importing vispy
-_min_modules = ['vispy', 'vispy.util', 'vispy.testing', 'vispy.ext']
+_min_modules = ['vispy', 'vispy.util', 'vispy.ext']
 
 
 def check_output(*popenargs, **kwargs):


### PR DESCRIPTION
Also made `python make test` print the test options rather than
run all tests. To run all tests, do `python make test full`.

Closes #260
