### PR TITLE
Fixing setup (missing vispy.util.geometry)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'vispy.scenegraph.entities',
         'vispy.testing', 'vispy.testing.tests',
         'vispy.util', 'vispy.util.tests',
-        'vispy.util.dataio',
+        'vispy.util.dataio', 'vispy.util.geometry'
     ],
     package_dir={
         'vispy': 'vispy'},


### PR DESCRIPTION
The package vispy.util.geometry was missing and without it a number of examples crash...
