### PR TITLE
Run tests with same interpreter that launched test

### DIFF
--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -54,7 +54,7 @@ def _nose(mode, verbosity, coverage):
     args = ' ' + ('--verbosity=%s ' % verbosity) + covs + attrs
     # make a call to "python" so that it inherits whatever the system
     # thinks is "python" (e.g., virtualenvs)
-    cmd = ['python', '-c',
+    cmd = [sys.executable, '-c',
            'import nose; nose.main(argv="%s".split(" "))' % args]
     env = deepcopy(os.environ)
     env.update(dict(_VISPY_TESTING_TYPE=mode))


### PR DESCRIPTION
This makes the tests on the backends run with the same
Python interpreter used to launch the test. i.e. when I do
`python3 make test pyside`, the tests should be done in
Python3, not Python2.
