### PR TITLE
FIX: Fix init order

### DIFF
--- a/vispy/app/backends/_pyglet.py
+++ b/vispy/app/backends/_pyglet.py
@@ -200,6 +200,7 @@ class CanvasBackend(_Window, BaseCanvasBackend):
                 screen = screen[fs]
         else:
             screen = None
+        self._initialize_sent = False
         pyglet.window.Window.__init__(self, width=size[0], height=size[1],
                                       caption=title, visible=show,
                                       config=config, vsync=vsync,
@@ -282,8 +283,10 @@ class CanvasBackend(_Window, BaseCanvasBackend):
     def on_show(self):
         if self._vispy_canvas is None:
             return
-        self._vispy_set_current()
-        self._vispy_canvas.events.initialize()
+        if not self._initialize_sent:
+            self._initialize_sent = True
+            self._vispy_set_current()
+            self._vispy_canvas.events.initialize()
         # Set location now if we must. For some reason we get weird
         # offsets in viewport if set_location is called before the
         # widget is shown.

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -233,7 +233,11 @@ class CanvasBackend(QtOpenGL.QGLWidget, BaseCanvasBackend):
             self.setFixedSize(self.size())
         if position is not None:
             self._vispy_set_position(*position)
-        if show:
+        self._init_show = show
+
+    def _vispy_init(self):
+        """Do actions that require self._vispy_canvas._backend to be set"""
+        if self._init_show:
             self._vispy_set_visible(True)
 
     @property

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -104,6 +104,16 @@ class BaseCanvasBackend(object):
         outs.append(kwargs.get('vispy_canvas', None))
         return outs
 
+    def _vispy_init(self):
+        # For any __init__-like actions that must occur *after*
+        # self._vispy_canvas._backend is not None
+
+        # Most backends won't need this. However, there are exceptions.
+        # e.g., pyqt4 with show=True, "show" can't be done until this property
+        # exists because it might call on_draw which might in turn call
+        # canvas.size... which relies on canvas._backend being set.
+        pass
+
     def _vispy_set_current(self):
         # Make this the current context
         raise NotImplementedError()

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -172,13 +172,16 @@ class Canvas(object):
     def _set_backend(self, backend):
         """ Set backend<->canvas references and autoswap
         """
+        # NOTE: Do *not* combine this with create_native above, since
+        # this private function is used to embed Qt widgets
         assert backend is not None  # should never happen
         self._backend = backend
-        self._backend._vispy_canvas = self  # it's okay to set this again
         if self._autoswap:
             # append to the end
             self.events.draw.connect((self, 'swap_buffers'),
                                      ref=True, position='last')
+        self._backend._vispy_canvas = self  # it's okay to set this again
+        self._backend._vispy_init()
 
     @property
     def context(self):

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -363,21 +363,29 @@ def test_event_order():
             x.append('init')
 
         def on_draw(self, event):
-            x.append('draw')
+            try:
+                sz = True if self.size is not None else False
+            except Exception:
+                sz = False
+            x.append('draw size=%s show=%s' % (sz, show))
 
         def on_close(self, event):
             x.append('close')
 
-    with MyCanvas() as c:
-        c.update()
-        c.app.process_events()
+    for show in (False, True):
+        # clear our storage variable
+        while x:
+            x.pop()
+        with MyCanvas(show=show) as c:
+            c.update()
+            c.app.process_events()
 
-    print(x)
-    assert_true(len(x) >= 3)
-    assert_equal(x[0], 'init')
-    assert_equal(x[1], 'draw')
-    assert_equal(x[-2], 'draw')
-    assert_equal(x[-1], 'close')
+        print(x)
+        assert_true(len(x) >= 3)
+        assert_equal(x[0], 'init')
+        assert_in('draw size=True', x[1])
+        assert_in('draw size=True', x[-2])
+        assert_equal(x[-1], 'close')
 
 
 def test_abstract():

--- a/vispy/app/tests/test_backends.py
+++ b/vispy/app/tests/test_backends.py
@@ -22,7 +22,7 @@ class DummyApplication(Application):
     def _use(self, backend_namd):
         pass
 
-        
+
 def _test_module_properties(_module=None):
     """Test application module"""
     if _module is None:
@@ -37,14 +37,15 @@ def _test_module_properties(_module=None):
             continue
         key = getattr(keys, keyname)
         assert key in vispy_keys
-    
+
     # For Qt backend, we have a common implementation
     alt_modname = ''
     if _module.__name__.split('.')[-1] in ('_pyside', '_pyqt4'):
         alt_modname = _module.__name__.rsplit('.', 1)[0] + '._qt'
-    
+
     # Test that all _vispy_x methods are there.
     exceptions = (
+        '_vispy_init',
         '_vispy_get_native_canvas',
         '_vispy_get_native_timer',
         '_vispy_get_native_app',


### PR DESCRIPTION
This addresses an issue where `on_draw` could be called before `canvas._backend` was set, which can be problematic. While fixing this and making tests more comprehensive, I also fixed an issue where `pyglet` could send more than one `on_initialize` event (whoops).

Closes #361.
