### PR TITLE
Make Travis use py 3.4 + fix in find_font

### DIFF
--- a/vispy/ext/fontconfig.py
+++ b/vispy/ext/fontconfig.py
@@ -108,7 +108,7 @@ def find_font(face, bold, italic):
     if result != 0:
         raise RuntimeError('No filename or FT face for "%s"' % face)
     fname = value.u.s
-    return fname
+    return fname.decode('utf-8')
 
 
 def _list_fonts():

--- a/vispy/util/image.py
+++ b/vispy/util/image.py
@@ -40,7 +40,7 @@ def make_png(data, level=6):
             size = len(data)
         chunk = np.empty(size + 12, dtype=np.ubyte)
         chunk.data[0:4] = struct.pack('!I', size)
-        chunk.data[4:8] = name  # b'CPXS' # critical, public, standard, safe 
+        chunk.data[4:8] = name  # b'CPXS' # critical, public, standard, safe
         chunk.data[8:8 + size] = data
         chunk.data[-4:] = struct.pack('!i', zlib.crc32(chunk[4:-4]))
         return chunk


### PR DESCRIPTION
was: OMG tests fail if I run locally
- in util/image.py we try to set a string into a byte object
- in ext/freetype.py (line 36) we are using `.encode('utf-8')
  on a byte object.

Maybe this is because I use Python 3.4? If this is the case, we need to add a Travis machine for 3.4.
