### PR TITLE
Fix for #503

### DIFF
--- a/vispy/gloo/variable.py
+++ b/vispy/gloo/variable.py
@@ -322,8 +322,8 @@ class Attribute(Variable):
             # For array-like, we need to build a proper VertexBuffer
             # to be able to upload it later to GPU memory.
             name, base, count = self.dtype
-            assert count == data.shape[1]
             data = np.array(data, dtype=base, copy=False)
+            assert count == data.shape[1]
             data = data.ravel().view([self.dtype])
             # WARNING : transform data with the right type
             # data = np.array(data,copy=False)


### PR DESCRIPTION
Added assert statement to catch wrong array size.

I also merged Cyrille's fix of the "start_shaders" example because I wasn't sure whether the tests would fail otherwise (but I presume this wasn't actually necessary).
