### PR TITLE
Refactored util/transforms.py translate, scale and rotate to just return

### DIFF
--- a/examples/basics/gloo/display_lines.py
+++ b/examples/basics/gloo/display_lines.py
@@ -59,12 +59,12 @@ class Canvas(app.Canvas):
         self.program['a_id'] = gloo.VertexBuffer(a_id)
         self.program['a_position'] = gloo.VertexBuffer(a_position)
 
-        self.view = np.eye(4, dtype=np.float32)
+        self.translate = 5
+        self.view = translate((0,0,-self.translate), dtype = np.float32)
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
 
-        self.translate = 5
-        translate(self.view, 0, 0, -self.translate)
+
         self.program['u_model'] = self.model
         self.program['u_view'] = self.view
 
@@ -88,11 +88,9 @@ class Canvas(app.Canvas):
 
     # ---------------------------------
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        self.model = np.eye(4, dtype=np.float32)
-        rotate(self.model, self.theta, 0, 0, 1)
-        rotate(self.model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        self.model = rotate(self.theta, (0, 0, 1)) * rotate(self.phi, (0, 1, 0))
         self.program['u_model'] = self.model
         self.update()
 
@@ -107,8 +105,7 @@ class Canvas(app.Canvas):
     def on_mouse_wheel(self, event):
         self.translate += event.delta[1]
         self.translate = max(2, self.translate)
-        self.view = np.eye(4, dtype=np.float32)
-        translate(self.view, 0, 0, -self.translate)
+        self.view = translate((0, 0, -self.translate))
         self.program['u_view'] = self.view
         self.update()
 

--- a/examples/basics/gloo/post_processing.py
+++ b/examples/basics/gloo/post_processing.py
@@ -94,12 +94,10 @@ class Canvas(app.Canvas):
 
         # Build program
         # --------------------------------------
-        view = np.eye(4, dtype=np.float32)
-        model = np.eye(4, dtype=np.float32)
-        translate(view, 0, 0, -7)
-        self.phi, self.theta = 60, 20
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        view = translate((0,0,-7))
+        self.phi, self.theta = np.radians(60), np.radians(20)
+        model = rotate(self.theta, (0, 0, 1)) * rotate(self.phi, (0, 1, 0))
+
 
         self.cube = Program(cube_vertex, cube_fragment)
         self.cube.bind(vertices)
@@ -145,11 +143,9 @@ class Canvas(app.Canvas):
         self.cube['projection'] = projection
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        model = np.eye(4, dtype=np.float32)
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        model = rotate(self.theta, (0, 0, 1)) * rotate(self.phi, (0, 1, 0))
         self.cube['model'] = model
         self.update()
 

--- a/examples/basics/gloo/rotate_cube.py
+++ b/examples/basics/gloo/rotate_cube.py
@@ -108,11 +108,10 @@ class Canvas(app.Canvas):
         self.program = gloo.Program(vert, frag)
         self.program.bind(gloo.VertexBuffer(self.vertices))
 
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0,0,-5))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
 
-        translate(self.view, 0, 0, -5)
         self.program['u_model'] = self.model
         self.program['u_view'] = self.view
 
@@ -130,11 +129,9 @@ class Canvas(app.Canvas):
 
     # ---------------------------------
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        self.model = np.eye(4, dtype=np.float32)
-        rotate(self.model, self.theta, 0, 0, 1)
-        rotate(self.model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        self.model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['u_model'] = self.model
         self.update()
 

--- a/examples/demo/gloo/atom.py
+++ b/examples/demo/gloo/atom.py
@@ -106,12 +106,11 @@ class Canvas(app.Canvas):
         self.size = 800, 800
         self.title = "Atom [zoom with mouse scroll"
 
+        self.translate = 6.5
         self.program = gloo.Program(vert, frag)
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0,0,-self.translate))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
-        self.translate = 6.5
-        translate(self.view, 0, 0, -self.translate)
 
         self.program.bind(gloo.VertexBuffer(data))
         self.program['u_model'] = self.model
@@ -134,11 +133,9 @@ class Canvas(app.Canvas):
 
     def on_timer(self, event):
         if not self.stop_rotation:
-            self.theta += .05
-            self.phi += .05
-            self.model = np.eye(4, dtype=np.float32)
-            rotate(self.model, self.theta, 0, 0, 1)
-            rotate(self.model, self.phi, 0, 1, 0)
+            self.theta += .001
+            self.phi += .001
+            self.model = rotate(self.phi, (0,1,0)) * rotate(self.theta, (0,0,1))
             self.program['u_model'] = self.model
         self.clock += np.pi / 100
         self.program['u_clock'] = self.clock

--- a/examples/demo/gloo/brain.py
+++ b/examples/demo/gloo/brain.py
@@ -111,14 +111,10 @@ class Canvas(app.Canvas):
         self.update_matrices()
 
     def update_matrices(self):
-        self.view = np.eye(4, dtype=np.float32)
-        self.model = np.eye(4, dtype=np.float32)
+        self.view = translate((0, 0, -self.translate))
+        self.model = rotate(self.phi, (0,1,0)) * rotate(self.theta, (0, 0, 1))
         self.projection = np.eye(4, dtype=np.float32)
-        
-        rotate(self.model, self.theta, 1, 0, 0)
-        rotate(self.model, self.phi, 0, 1, 0)
-        
-        translate(self.view, 0, 0, -self.translate)
+
         
         self.program['u_model'] = self.model
         self.program['u_view'] = self.view
@@ -130,7 +126,7 @@ class Canvas(app.Canvas):
 
     def on_timer(self, event):
         elapsed = default_timer() - self._t0
-        self.phi = 180 + elapsed * 50.
+        self.phi = np.radians(180) + elapsed * np.radians(50)
         self.update_matrices()
         self.update()
 

--- a/examples/demo/gloo/cloud.py
+++ b/examples/demo/gloo/cloud.py
@@ -234,12 +234,11 @@ class Canvas(app.Canvas):
         app.Canvas.__init__(self, keys='interactive')
         self.size = 800, 600
 
+        self.translate = 5
         self.program = gloo.Program(vert, frag)
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0, 0, -self.translate))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
-        self.translate = 5
-        translate(self.view, 0, 0, -self.translate)
 
         self.program.bind(gloo.VertexBuffer(data))
         self.program['u_linewidth'] = u_linewidth
@@ -264,11 +263,9 @@ class Canvas(app.Canvas):
                 self.timer.start()
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        self.model = np.eye(4, dtype=np.float32)
-        rotate(self.model, self.theta, 0, 0, 1)
-        rotate(self.model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        self.model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['u_model'] = self.model
         self.update()
 

--- a/examples/demo/gloo/donut.py
+++ b/examples/demo/gloo/donut.py
@@ -123,12 +123,12 @@ class Canvas(app.Canvas):
         self.size = 800, 800
         self.title = "D'oh ! A big donut"
 
+        self.translate = 5
         self.program = gloo.Program(vert, frag)
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0, 0, -self.translate))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
-        self.translate = 5
-        translate(self.view, 0, 0, -self.translate)
+
 
         self.program.bind(gloo.VertexBuffer(data))
         self.program['u_linewidth'] = u_linewidth
@@ -153,11 +153,9 @@ class Canvas(app.Canvas):
 
     def on_timer(self, event):
         if not self.stop_rotation:
-            self.theta += .5
-            self.phi += .5
-            self.model = np.eye(4, dtype=np.float32)
-            rotate(self.model, self.theta, 0, 0, 1)
-            rotate(self.model, self.phi, 0, 1, 0)
+            self.theta += .02
+            self.phi += .02
+            self.model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
             self.program['u_model'] = self.model
         self.clock += np.pi / 1000
         self.program['u_clock'] = self.clock

--- a/examples/demo/gloo/glsl_sandbox_cube.py
+++ b/examples/demo/gloo/glsl_sandbox_cube.py
@@ -94,23 +94,20 @@ class Canvas(app.Canvas):
         self.program.draw('triangles', faces_buffer)
 
     def init_transforms(self):
-        self.view = np.eye(4, dtype=np.float32)
+        self.theta = 0
+        self.phi = 0
+        self.view = translate((0, 0, -5))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
 
-        self.theta = 0
-        self.phi = 0
-
-        translate(self.view, 0, 0, -5)
+        
         self.program['u_model'] = self.model
         self.program['u_view'] = self.view
 
     def update_transforms(self, event):
-        self.theta += .5
-        self.phi += .5
-        self.model = np.eye(4, dtype=np.float32)
-        rotate(self.model, self.theta, 0, 0, 1)
-        rotate(self.model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        self.model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['u_model'] = self.model
         self.update()
 

--- a/examples/demo/gloo/molecular_viewer.py
+++ b/examples/demo/gloo/molecular_viewer.py
@@ -100,12 +100,11 @@ class Canvas(app.Canvas):
                             keys='interactive')
         self.size = 1200, 800
 
+        self.translate = 40
         self.program = gloo.Program(vertex, fragment)
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0, 0, -self.translate))
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
-        self.translate = 40
-        translate(self.view, 0, 0, -self.translate)
 
         fname = load_data_file('molecular_viewer/micelle.npz')
         self.load_molecule(fname)
@@ -160,13 +159,10 @@ class Canvas(app.Canvas):
             # self.
 
     def on_timer(self, event):
-        self.theta += .25
-        self.phi += .25
-        self.model = np.eye(4, dtype=np.float32)
-
-        rotate(self.model, self.theta, 0, 0, 1)
-        rotate(self.model, self.phi, 0, 1, 0)
-
+        self.theta += .005
+        self.phi += .005
+        self.model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
+        
         self.program['u_model'] = self.model
         self.update()
 

--- a/examples/demo/gloo/terrain.py
+++ b/examples/demo/gloo/terrain.py
@@ -7,8 +7,7 @@ and Scipy for Delaunay triangulation
 
 from vispy import gloo
 from vispy import app
-from vispy.util.transforms import perspective, translate, xrotate, yrotate
-from vispy.util.transforms import zrotate
+from vispy.util.transforms import perspective, translate, rotated
 import numpy as np
 from scipy.spatial import Delaunay
 
@@ -176,11 +175,13 @@ class Canvas(app.Canvas):
         elif(event.text == ' '):
             self.view = self.default_view
 
-        translate(self.view, -self.translate[0], -self.translate[1],
-                  -self.translate[2])
-        xrotate(self.view, self.rotate[0])
-        yrotate(self.view, self.rotate[1])
-        zrotate(self.view, self.rotate[2])
+        self.view = (
+            translate(-np.array(self.translate)) * 
+            rotated(self.rotate[0], (1, 0, 0)) * 
+            rotated(self.rotate[1], (0, 1, 0)) * 
+            rotated(self.rotate[2], (0, 0, 1))
+            ) * self.view
+            
 
         self.program['u_view'] = self.view
         self.update()

--- a/examples/tutorial/gloo/colored_cube.py
+++ b/examples/tutorial/gloo/colored_cube.py
@@ -55,9 +55,8 @@ class Canvas(app.Canvas):
         self.program.bind(vertices)
 
         # Build view, model, projection & normal
-        view = np.eye(4, dtype=np.float32)
+        view = translate((0, 0, -5))
         model = np.eye(4, dtype=np.float32)
-        translate(view, 0, 0, -5)
         self.program['model'] = model
         self.program['view'] = view
         self.phi, self.theta = 0, 0
@@ -75,11 +74,9 @@ class Canvas(app.Canvas):
         self.program['projection'] = projection
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        model = np.eye(4, dtype=np.float32)
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['model'] = model
         self.update()
 

--- a/examples/tutorial/gloo/lighted_cube.py
+++ b/examples/tutorial/gloo/lighted_cube.py
@@ -91,9 +91,8 @@ class Canvas(app.Canvas):
 
         # Build view, model, projection & normal
         # --------------------------------------
-        self.view = np.eye(4, dtype=np.float32)
+        self.view = translate((0, 0, -5))
         model = np.eye(4, dtype=np.float32)
-        translate(self.view, 0, 0, -5)
         normal = np.array(np.matrix(np.dot(self.view, model)).I.T)
 
         # Build program
@@ -137,11 +136,9 @@ class Canvas(app.Canvas):
         self.program['u_projection'] = projection
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        model = np.eye(4, dtype=np.float32)
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         normal = np.array(np.matrix(np.dot(self.view, model)).I.T)
         self.program['u_model'] = model
         self.program['u_normal'] = normal

--- a/examples/tutorial/gloo/outlined_cube.py
+++ b/examples/tutorial/gloo/outlined_cube.py
@@ -58,9 +58,9 @@ class Canvas(app.Canvas):
 
         # Build view, model, projection & normal
         # --------------------------------------
-        view = np.eye(4, dtype=np.float32)
+        view = translate((0, 0, -5))
         model = np.eye(4, dtype=np.float32)
-        translate(view, 0, 0, -5)
+
         self.program['u_model'] = model
         self.program['u_view'] = view
         self.phi, self.theta = 0, 0
@@ -93,11 +93,9 @@ class Canvas(app.Canvas):
         self.program['u_projection'] = projection
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        model = np.eye(4, dtype=np.float32)
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['u_model'] = model
         self.update()
 

--- a/examples/tutorial/gloo/textured_cube.py
+++ b/examples/tutorial/gloo/textured_cube.py
@@ -65,9 +65,8 @@ class Canvas(app.Canvas):
         self.program.bind(vertices)
 
         # Build view, model, projection & normal
-        view = np.eye(4, dtype=np.float32)
+        view = translate((0, 0, -5))
         model = np.eye(4, dtype=np.float32)
-        translate(view, 0, 0, -5)
         self.program['model'] = model
         self.program['view'] = view
         self.program['texture'] = checkerboard()
@@ -89,11 +88,9 @@ class Canvas(app.Canvas):
         self.program['projection'] = projection
 
     def on_timer(self, event):
-        self.theta += .5
-        self.phi += .5
-        model = np.eye(4, dtype=np.float32)
-        rotate(model, self.theta, 0, 0, 1)
-        rotate(model, self.phi, 0, 1, 0)
+        self.theta += .02
+        self.phi += .02
+        model = rotate(self.phi, (0, 1, 0)) * rotate(self.theta, (0, 0, 1))
         self.program['model'] = model
         self.update()
 

--- a/vispy/scene/transforms/linear.py
+++ b/vispy/scene/transforms/linear.py
@@ -281,7 +281,6 @@ class AffineTransform(BaseTransform):
         in the matrix.
         """
         self.matrix[...] = transforms.translate(pos[0, :3]) * self.matrix
-        #self.matrix = transforms.translate(self.matrix, *pos[0, :3])
 
     def scale(self, scale, center=None):
         """
@@ -299,15 +298,15 @@ class AffineTransform(BaseTransform):
                 transforms.scale(scale[0, :3]) *
                 transforms.translate(center) *
                 self.matrix)
-            self.matrix = m
         else:
             self.matrix[...] = transforms.scale(scale[0, :3]) * self.matrix
 
-    def rotate(self, angle, axis):
-        #tr = transforms.rotate(np.eye(4), angle, *axis)
-        #self.matrix = np.dot(tr, self.matrix)
-        #self.matrix = transforms.rotate(self.matrix, angle, *axis)
-        self.matrix[...] = transforms.rotated(angle, axis) * self.matrix
+    def rotated(self, degrees, axis):
+        self.matrix[...] = transforms.rotated(degrees, axis) * self.matrix
+
+    def rotate(self, radians, axis):
+        self.matrix[...] = transforms.rotate(radians, axis) * self.matrix
+
 
     def set_mapping(self, points1, points2):
         """ Set to a 3D transformation matrix that maps points1 onto points2.

--- a/vispy/scene/transforms/linear.py
+++ b/vispy/scene/transforms/linear.py
@@ -280,7 +280,8 @@ class AffineTransform(BaseTransform):
         The translation is applied *after* the transformations already present
         in the matrix.
         """
-        self.matrix = transforms.translate(self.matrix, *pos[0, :3])
+        self.matrix[...] = transforms.translate(pos[0, :3]) * self.matrix
+        #self.matrix = transforms.translate(self.matrix, *pos[0, :3])
 
     def scale(self, scale, center=None):
         """
@@ -291,18 +292,22 @@ class AffineTransform(BaseTransform):
         """
         scale = as_vec4(scale, default=(1, 1, 1, 1))
         if center is not None:
+            # TODO: check if the order is correct here!
             center = as_vec4(center)[0, :3]
-            m = transforms.translate(self.matrix, *(-center))
-            m = transforms.scale(m, *scale[0, :3])
-            m = transforms.translate(self.matrix, *center)
+            self.matrix[...] = (
+                transforms.translate(-center) *
+                transforms.scale(scale[0, :3]) *
+                transforms.translate(center) *
+                self.matrix)
             self.matrix = m
         else:
-            self.matrix = transforms.scale(self.matrix, *scale[0, :3])
+            self.matrix[...] = transforms.scale(scale[0, :3]) * self.matrix
 
     def rotate(self, angle, axis):
         #tr = transforms.rotate(np.eye(4), angle, *axis)
         #self.matrix = np.dot(tr, self.matrix)
-        self.matrix = transforms.rotate(self.matrix, angle, *axis)
+        #self.matrix = transforms.rotate(self.matrix, angle, *axis)
+        self.matrix[...] = transforms.rotated(angle, axis) * self.matrix
 
     def set_mapping(self, points1, points2):
         """ Set to a 3D transformation matrix that maps points1 onto points2.

--- a/vispy/scene/visuals/line/line.py
+++ b/vispy/scene/visuals/line/line.py
@@ -20,14 +20,14 @@ from .fragment import FRAGMENT_SHADER as AGG_FRAGMENT_SHADER
 
 
 vec2to4 = Function("""
-    vec4 vec2to4(vec2 input) {
-        return vec4(input, 0, 1);
+    vec4 vec2to4(vec2 inputvec) {
+        return vec4(inputvec, 0, 1);
     }
 """)
 
 vec3to4 = Function("""
-    vec4 vec3to4(vec3 input) {
-        return vec4(input, 1);
+    vec4 vec3to4(vec3 inputvec) {
+        return vec4(inputvec, 1);
     }
 """)
 

--- a/vispy/util/tests/test_transforms.py
+++ b/vispy/util/tests/test_transforms.py
@@ -13,7 +13,7 @@ def test_transforms():
 
     # Todo: this should really be more rigorous, e.g. check that the order
     # of computation is all correct
-    new_xfm = rotate(rotate(xfm, 90, 1, 0, 0), 90, -1, 0, 0)
+    new_xfm = rotated(90, (1,0,0)) * rotated(90, (-1, 0, 0))
     assert_allclose(xfm, new_xfm)
 
     new_xfm = translate((1, -1, 1)) * translate((1, -1, 1))

--- a/vispy/util/tests/test_transforms.py
+++ b/vispy/util/tests/test_transforms.py
@@ -2,26 +2,24 @@ import numpy as np
 from nose.tools import assert_equal
 from numpy.testing import assert_allclose
 
-from vispy.util.transforms import (translate, scale, xrotate, yrotate,
-                                   zrotate, rotate, ortho, frustum,
+from vispy.util.transforms import (translate, scale, rotate, ortho, frustum,
                                    perspective)
+
 
 
 def test_transforms():
     """Test basic transforms"""
     xfm = np.random.randn(4, 4).astype(np.float32)
 
-    for rot in [xrotate, yrotate, zrotate]:
-        new_xfm = rot(rot(xfm, 90), -90)
-        assert_allclose(xfm, new_xfm)
-
+    # Todo: this should really be more rigorous, e.g. check that the order
+    # of computation is all correct
     new_xfm = rotate(rotate(xfm, 90, 1, 0, 0), 90, -1, 0, 0)
     assert_allclose(xfm, new_xfm)
 
-    new_xfm = translate(translate(xfm, 1, -1), 1, -1, 1)
+    new_xfm = translate((1, -1, 1)) * translate((1, -1, 1))
     assert_allclose(xfm, new_xfm)
 
-    new_xfm = scale(scale(xfm, 1, 2, 3), 1, 1. / 2., 1. / 3.)
+    new_xfm = scale((1, 2, 3)) * scale((1, 1. / 2., 1. / 3.))
     assert_allclose(xfm, new_xfm)
 
     # These could be more complex...

--- a/vispy/util/tests/test_transforms.py
+++ b/vispy/util/tests/test_transforms.py
@@ -2,24 +2,26 @@ import numpy as np
 from nose.tools import assert_equal
 from numpy.testing import assert_allclose
 
-from vispy.util.transforms import (translate, scale, rotate, ortho, frustum,
+from vispy.util.transforms import (translate, scale, rotate, rotated, ortho, frustum,
                                    perspective)
-
-
 
 def test_transforms():
     """Test basic transforms"""
     xfm = np.random.randn(4, 4).astype(np.float32)
 
-    # Todo: this should really be more rigorous, e.g. check that the order
-    # of computation is all correct
-    new_xfm = rotated(90, (1,0,0)) * rotated(90, (-1, 0, 0))
+    # Do a series of rotations that should end up into the same orientation
+    # again, to ensure the oreder of computation is all correct
+    # i.e. if rotated would return the transposed matrix this would not work out
+    # (the translation part would be incorrect)
+    new_xfm = ( rotated(90, (1,0,0)) * rotated(90, (0,1,0)) * 
+            rotated(90,(0,0,1)) * rotated(-90,(0,1,0)) * 
+            rotated(180,(1,0,0)) ) * xfm
     assert_allclose(xfm, new_xfm)
 
-    new_xfm = translate((1, -1, 1)) * translate((1, -1, 1))
+    new_xfm = translate((1, -1, 1)) * translate((-1, 1, -1)) * xfm
     assert_allclose(xfm, new_xfm)
 
-    new_xfm = scale((1, 2, 3)) * scale((1, 1. / 2., 1. / 3.))
+    new_xfm = scale((1, 2, 3)) * scale((1, 1. / 2., 1. / 3.)) * xfm
     assert_allclose(xfm, new_xfm)
 
     # These could be more complex...


### PR DESCRIPTION
Refactored translate, scale and return to just return a matrix to be multiplied instead of the matrix multiplication being done in the method

Adapted scenen linear transforms as appropriate

Adapted examples as appropriate (except for ipython notebooks, cannot test those)