### PR TITLE
frustrum transform: add explicit float conversion to avoid integer division

### DIFF
--- a/vispy/util/transforms.py
+++ b/vispy/util/transforms.py
@@ -7,6 +7,8 @@ Note that functions that take a matrix as input generally operate on that
 matrix in place.
 """
 
+from __future__ import division
+
 # Note: we use functions (e.g. sin) from math module because they're faster
 
 import math


### PR DESCRIPTION
I came across this minor issue when I got unexpected results when passing integer arguments to the perspective transform function.
