### PR TITLE
Fix mandelbrot zooming on mouse scroll.

### DIFF
--- a/examples/demo/gloo/mandelbrot.py
+++ b/examples/demo/gloo/mandelbrot.py
@@ -175,7 +175,8 @@ class Canvas(app.Canvas):
         self.scale = max(min(self.scale, self.max_scale), self.min_scale)
         self.program["scale"] = self.scale
 
-        if mouse_coords is not None:  # Translate so the mouse point is stationary
+        # Translate so the mouse point is stationary
+        if mouse_coords is not None:
             x1, y1 = self.pixel_to_coords(x, y)
             self.translate_center(x1 - x0, y1 - y0)
 


### PR DESCRIPTION
Trying to scroll with the middle button of the mouse returns an error  

```
 ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

With this patch the example works as expected. 
