### PR TITLE
Removed closeEvent for qt backend

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -317,11 +317,6 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         g = self.geometry()
         return g.width(), g.height()
 
-    def closeEvent(self, ev):
-        if self._vispy_canvas is None:
-            return
-        self._vispy_canvas.close()
-
     def sizeHint(self):
         return self.size()
 


### PR DESCRIPTION
Opening this PR for discussion:

When a canvas is closed using the Qt backend, it should be possible to show the canvas again by calling `show()` on it. It should only be closed permanently if the user requests that or if the canvas is collected.