### PR TITLE
New PanZoom linear transform

### DIFF
--- a/vispy/visuals/transforms/__init__.py
+++ b/vispy/visuals/transforms/__init__.py
@@ -7,11 +7,11 @@ use with visuals and scenes.
 """
 
 __all__ = ['NullTransform', 'STTransform', 'AffineTransform',
-           'PerspectiveTransform', 'LogTransform', 'PolarTransform',
-           'ChainTransform', 'TransformSystem']
+           'PerspectiveTransform', 'PanZoomTransform', 'LogTransform',
+           'PolarTransform', 'ChainTransform', 'TransformSystem']
 
 from .base_transform import BaseTransform  # noqa
-from .linear import (NullTransform, STTransform,  # noqa
+from .linear import (NullTransform, STTransform, PanZoomTransform,  # noqa
                      AffineTransform,  PerspectiveTransform)  # noqa
 from .nonlinear import LogTransform, PolarTransform  # noqa
 from .chain import ChainTransform  # noqa


### PR DESCRIPTION
This PR brings a `PanZoomTransform`, similar to `STTransform`, but lighter, restricted to 2D, and with a different transform order.

Also, this transform can be used like this:

``` python

pz = PanZoomTransform()

# Declare that pan and zoom are uniform variables
pz.pan = Variable('uniform vec2 u_pan', (0, 0))
pz.zoom = Variable('uniform vec2 u_zoom', (1, 1))

# Update the uniform values efficiently and intuitively
pz.pan = (1., 0.)
pz.zoom *= 2.
```
