### PR TITLE
Fixing GLFW Tests & Support for Retina Devices

### DIFF
--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -263,7 +263,7 @@ class CanvasBackend(BaseCanvasBackend):
 
         # Register callbacks
         glfw.glfwSetWindowRefreshCallback(self._id, self._on_draw)
-        glfw.glfwSetFramebufferSizeCallback(self._id, self._on_resize)
+        glfw.glfwSetWindowSizeCallback(self._id, self._on_resize)
         glfw.glfwSetKeyCallback(self._id, self._on_key_press)
         glfw.glfwSetMouseButtonCallback(self._id, self._on_mouse_button)
         glfw.glfwSetScrollCallback(self._id, self._on_mouse_scroll)
@@ -355,7 +355,7 @@ class CanvasBackend(BaseCanvasBackend):
     def _vispy_get_size(self):
         if self._id is None:
             return
-        w, h = glfw.glfwGetFramebufferSize(self._id)
+        w, h = glfw.glfwGetWindowSize(self._id)
         return w, h
 
     def _vispy_get_position(self):


### PR DESCRIPTION
(This pull request is not ready to merge yet, but is intended to continue the discussion of #551 specifically for the GLFW use-case and fixing the tests.)

Currently with GLFW, the tests fail on Retina displays:
````
======================================================================
FAIL: Test drawing to a framebuffer
----------------------------------------------------------------------
Traceback (most recent call last):
  File "vispy/gloo/tests/test_use_gloo.py", line 43, in test_use_framebuffer
    assert_equal(c.size, shape[::-1])
nose.proxy.AssertionError: Tuples differ: (600, 200) != (300, 100)

First differing element 0:
600
300

- (600, 200)
?  ^    ^
+ (300, 100)
?  ^    ^
````

Based on @lcampagn's comment: assuming `canvas.size` should return the window size, I tried changing the GLFW backend to return WindowSize instead of FrameBuffer size in both `_vispy_get_size` and `_on_resize`, that fixes all the tests.  (See the diff.)

Now, however, the rest doesn't work and the viewport (in particular) seems wrong.  This is the problem, I think:
````
vispy.gloo.set_viewport(0, 0, *event.size)
````

Should I pursue this direction?  How easy will it be to handle the glViewport sizing in a retina friendly way?  I'm starting to think it'd be easier for `canvas.size` to return the full retina framebuffer size and have a separate call for the window size.