### PR TITLE
Fallback on xrandr to get linux DPI info.

### DIFF
--- a/vispy/util/dpi/_linux.py
+++ b/vispy/util/dpi/_linux.py
@@ -4,19 +4,41 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 
+
+import re
+from subprocess import CalledProcessError
+
 from ..wrappers import run_subprocess
 
 
-def get_dpi():
-    """Get screen DPI from the OS"""
-    out = run_subprocess(['xdpyinfo'])[0]
-    for line in out.splitlines(False):
-        if 'dots per inch' in line:
-            # "    resolution:    96x96 dots per inch"
-            dpi = line.strip().split()[1].split('x')
-            assert len(dpi) == 2, dpi
-            break
+def _get_dpi_from(cmd, pattern, func):
+    """Match pattern against the output of func, passing the results as
+    floats to func.  If anything fails, return None.
+    """
+    try:
+        out, _ = run_subprocess([cmd])
+    except (OSError, CalledProcessError):
+        pass
     else:
-        raise RuntimeError('could not determine DPI')
-    dpi = sum([float(x) for x in dpi]) / 2.
-    return dpi
+        match = re.search(pattern, out)
+        if match:
+            return func(*map(float, match.groups()))
+
+
+def get_dpi():
+    """Get screen DPI from the OS.
+    """
+
+    from_xdpyinfo = _get_dpi_from(
+        'xdpyinfo', r'(\d+)x(\d+) dots per inch',
+        lambda x_dpi, y_dpi: (x_dpi + y_dpi) / 2)
+    if from_xdpyinfo is not None:
+        return from_xdpyinfo
+
+    from_xrandr = _get_dpi_from(
+        'xrandr', r'(\d+)x(\d+).*?(\d+)mm x (\d+)mm',
+        lambda x_px, y_px, x_mm, y_mm: 25.4 * (x_px / x_mm + y_px / y_mm) / 2)
+    if from_xrandr is not None:
+        return from_xrandr
+
+    raise RuntimeError('could not determine DPI')


### PR DESCRIPTION
xdpyinfo is not always available on Linux (even with a DE), whereas
xrandr is (AFAICT) at least dependency of KDE and XFCE.  But xrandr
fails when used remotely, so keep it too.
