### PR TITLE
Fixed colormap example notebooks

### DIFF
--- a/examples/ipynb/colormaps.ipynb
+++ b/examples/ipynb/colormaps.ipynb
@@ -1,146 +1,163 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:45db16e59de79e2b845ae3044ac5af9e7c77ea71efa482fb1ace177b30a1f137"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# VisPy colormaps"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This notebook illustrates the colormap API provided by VisPy."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## List all colormaps"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np\n",
-      "from vispy.color import (get_colormap, get_colormaps, Colormap)\n",
-      "from IPython.display import display_html"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for cmap in get_colormaps():\n",
-      "    display_html('<h3>%s</h3>' % cmap, raw=True)\n",
-      "    display_html(get_colormap(cmap))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Discrete colormaps"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Discrete colormaps can be created by giving a list of colors, and an optional list of control points (in $[0,1]$, the first and last points need to be $0$ and $1$ respectively). The colors can be specified in many ways (1-character shortcuts, hexadecimal values, arrays or RGB values, `ColorArray` instances, and so on)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap(['r', 'g', 'b'], interpolation='discrete')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap(['r', 'g', 'y'], interpolation='discrete')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap(np.array([[0, .75, 0],\n",
-      "                   [.75, .25, .5]]), \n",
-      "         [0., .25, 1.], \n",
-      "         interpolation='discrete')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap(['r', 'g', '#123456'],\n",
-      "         interpolation='discrete')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Linear gradients"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap(['r', 'g', '#123456'])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Colormap([[1,0,0], [1,1,1], [1,0,1]], \n",
-      "               [0., .75, 1.])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VisPy colormaps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook illustrates the colormap API provided by VisPy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List all colormaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from vispy.color import (get_colormap, get_colormaps, Colormap)\n",
+    "from IPython.display import display_html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for cmap in get_colormaps():\n",
+    "    display_html('<h3>%s</h3>' % cmap, raw=True)\n",
+    "    display_html(get_colormap(cmap))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discrete colormaps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Discrete colormaps can be created by giving a list of colors, and an optional list of control points (in $[0,1]$, the first and last points need to be $0$ and $1$ respectively). The colors can be specified in many ways (1-character shortcuts, hexadecimal values, arrays or RGB values, `ColorArray` instances, and so on)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap(['r', 'g', 'b'], interpolation='zero')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap(['r', 'g', 'y'], interpolation='zero')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap(np.array([[0, .75, 0],\n",
+    "                   [.75, .25, .5]]), \n",
+    "         [0., .25, 1.], \n",
+    "         interpolation='zero')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap(['r', 'g', '#123456'],\n",
+    "         interpolation='zero')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear gradients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap(['r', 'g', '#123456'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Colormap([[1,0,0], [1,1,1], [1,0,1]], \n",
+    "               [0., .75, 1.])"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -338,7 +338,7 @@ class Colormap(BaseColormap):
     @interpolation.setter
     def interpolation(self, val):
         if val not in _interpolation_info:
-            raise ValueError('The interpolation mode can only be one of: '
+            raise ValueError('The interpolation mode can only be one of: ' +
                              ', '.join(sorted(_interpolation_info.keys())))
         # Get the information of the interpolation mode.
         info = _interpolation_info[val]


### PR DESCRIPTION
* Upgraded notebook to IPython 3.0
* Renamed `discrete` to `zero` in the notebook examples
* Fixed minor issue in colormap linear interpolation error message

Ready to merge.