### PR TITLE
Bump VisPy version

### DIFF
--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -22,7 +22,7 @@ from __future__ import division
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']
 
 # Definition of the version number
-version_info = 0, 3, 0, ''  # major, minor, patch, extra
+version_info = 0, 4, 0, 'dev'  # major, minor, patch, extra
 
 # Nice string for the version (mimic how IPython composes its version str)
 __version__ = '-'.join(map(str, version_info)).replace('-', '.', 2).strip('-')


### PR DESCRIPTION
To 0.4.0-dev. The current indicated version (0.3.0) is wrong...

Closes #688.