### PR TITLE
Added panning to TurntableCamera with right click

### DIFF
--- a/vispy/scene/cameras/cameras.py
+++ b/vispy/scene/cameras/cameras.py
@@ -578,6 +578,38 @@ class TurntableCamera(PerspectiveCamera):
             d = p2c - p1c
             self.orbit(-d[0], d[1])
 
+        elif event.type == 'mouse_move' and 2 in event.buttons:
+            if self._mode != "ortho":
+                return
+
+            p1 = np.array(event.last_event.pos)[:2]
+            p2 = np.array(event.pos)[:2]
+            p1c = event.map_to_canvas(p1)[:2]
+            p2c = event.map_to_canvas(p2)[:2]
+            dx, dy = p2c - p1c
+            dy *= -1  # Makes y point up instead of down
+
+            # Vector `forward` goes from camera to center
+            azim = self.azimuth * np.pi / 180
+            elev = self.elevation * np.pi / 180
+            forward_x = -np.sin(azim) * np.cos(elev)
+            forward_y = np.cos(azim) * np.cos(elev)
+            forward_z = -np.sin(elev)
+            forward = np.array([forward_x, forward_y, forward_z])
+
+            # Vectors `up` and `right` point up and right from camera
+            right = np.cross(forward, [0, 0, 1])
+            right /= np.linalg.norm(right)
+            up = np.cross(right, forward)
+
+            # Scale direction by screen size and orthographic width
+            dx = dx / self.viewbox.size[0] * self.width
+            dy = dy / self.viewbox.size[0] * self.width
+            delta = right * dx + up * dy
+
+            self.center = tuple(np.array(self.center) + delta)
+            self._update_camera_pos()
+
     def _update_camera_pos(self):
         """ Set the camera position / orientation based on elevation,
         azimuth, distance, and center properties.


### PR DESCRIPTION
See the following image to visualize the vectors used in the code:
![](http://2.bp.blogspot.com/_ltmZpULxXtI/TSZll_0SASI/AAAAAAAAAeY/nal05L9OOm4/s320/gluLookAt_camera.png)

This works by computing the `up` and `right` vectors of the camera in world coordinates, and then mapping the change in mouse position from pixels to vectors in the world coordinates. The camera center is then translated using these vectors. This makes the motion fell very fluid, because a point under your mouse stays under your mouse.

Note that I can't figure out how to do this reliably with a perspective projection yet. The orthographic projection actually made this fairly easy, since `camera.width` gives you the screen width in world coordinates. (I also feel like the mouse wheel should change `distance` in a perspective view, and not `fov`. I get weird clipping when I zoom all the way in or all the way out. I know in pyqtgraph that `fov` would be changed if you hold down Ctrl and use the mouse wheel.)

I think we can abstract the panning calculation into a function, and maybe call it `pan_pixels`. The function would accept what is now `dx` and `dy` in the pull request code. I don't want users to confuse it with a function like `pan` that would simply modify the `center` coordinates directly using world coordinates.