### PR TITLE
Minor fixes for vispy.geometry

### DIFF
--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -9,11 +9,12 @@ This module implements classes and methods for handling geometric data.
 from __future__ import division
 
 __all__ = ['MeshData', 'PolygonData', 'Rect', 'Triangulation', 'create_cube',
-           'create_cylinder', 'create_sphere']
+           'create_cylinder', 'create_sphere', 'create_arrow']
 
 from .polygon import PolygonData  # noqa
 from .meshdata import MeshData  # noqa
 from .rect import Rect  # noqa
 from .triangulation import Triangulation  # noqa
 from .calculations import _calculate_normals, _fast_cross_3d  # noqa
-from .generation import create_cube, create_cylinder, create_sphere  # noqa
+from .generation import create_cube, create_cylinder, create_sphere, \
+           create_arrow # noqa

--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -17,4 +17,4 @@ from .rect import Rect  # noqa
 from .triangulation import Triangulation  # noqa
 from .calculations import _calculate_normals, _fast_cross_3d  # noqa
 from .generation import create_cube, create_cylinder, create_sphere, \
-           create_arrow # noqa
+           create_arrow  # noqa

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -185,7 +185,7 @@ def create_cylinder(rows, cols, radius=[1.0, 1.0], length=1.0, offset=False):
     # just reshape: no redundant vertices...
     verts = verts.reshape((rows+1)*cols, 3)
     # compute faces
-    faces = np.empty((rows*cols*2, 3), dtype=np.uint)
+    faces = np.empty((rows*cols*2, 3), dtype=np.uint32)
     rowtemplate1 = (((np.arange(cols).reshape(cols, 1) +
                       np.array([[0, 1, 0]])) % cols)
                     + np.array([[0, 0, cols]]))
@@ -229,7 +229,7 @@ def create_cone(cols, radius=3.0, length=10.0):
     verts[-1, 2] = length
     verts = verts.reshape((cols+1), 3)  # just reshape: no redundant vertices
     # compute faces
-    faces = np.empty((cols, 3), dtype=np.uint)
+    faces = np.empty((cols, 3), dtype=np.uint32)
     template = np.array([[0, 1]])
     for pos in range(cols):
         faces[pos, :-1] = template + pos


### PR DESCRIPTION
Two minor fixes for vispy.geometry:
1) Changed create_cylinder and create_cone to explicitly set the face array datatype to np.uint32, matching the behavior of create_sphere (N.B. np.uint defaults to np.uint64 on some systems, which breaks these functions)

2) Expose the create_arrow as an external method of the geometry module, matching the behavior of the other .create_ methods.