### PR TITLE
More minor vispy.geometry fixes

### DIFF
--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -8,13 +8,13 @@ This module implements classes and methods for handling geometric data.
 
 from __future__ import division
 
-__all__ = ['MeshData', 'PolygonData', 'Rect', 'Triangulation', 'create_cube',
-           'create_cylinder', 'create_sphere', 'create_arrow']
+__all__ = ['MeshData', 'PolygonData', 'Rect', 'Triangulation', 'create_arrow',
+           'create_cone', 'create_cube', 'create_cylinder', 'create_sphere']
 
 from .polygon import PolygonData  # noqa
 from .meshdata import MeshData  # noqa
 from .rect import Rect  # noqa
 from .triangulation import Triangulation  # noqa
 from .calculations import _calculate_normals, _fast_cross_3d  # noqa
-from .generation import create_cube, create_cylinder, create_sphere, \
-           create_arrow  # noqa
+from .generation import create_arrow, create_cone, create_cube, \
+           create_cylinder, create_sphere  # noqa

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -217,7 +217,7 @@ def create_cone(cols, radius=3.0, length=10.0):
     cone : MeshData
         Vertices and faces computed for a cone surface.
     """
-    verts = np.empty((cols+1, 3), dtype=float)
+    verts = np.empty((cols+1, 3), dtype=np.float32)
     # compute vertexes
     th = np.linspace(2 * np.pi, 0, cols+1).reshape(1, cols+1)
     verts[:-1, 2] = 0.0

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -200,7 +200,7 @@ def create_cylinder(rows, cols, radius=[1.0, 1.0], length=1.0, offset=False):
     return MeshData(vertices=verts, faces=faces)
 
 
-def create_cone(cols, radius=3.0, length=10.0):
+def create_cone(cols, radius=1.0, length=1.0):
     """Create a cone
 
     Parameters

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -393,7 +393,7 @@ class MeshData(object):
         # I think generally this should be discouraged..
         faces = self._vertices_indexed_by_faces
         verts = {}  # used to remember the index of each vertex position
-        self._faces = np.empty(faces.shape[:2], dtype=np.uint)
+        self._faces = np.empty(faces.shape[:2], dtype=np.uint32)
         self._vertices = []
         self._vertex_faces = []
         self._face_normals = None
@@ -432,7 +432,7 @@ class MeshData(object):
             if self._faces is not None:
                 # generate self._edges from self._faces
                 nf = len(self._faces)
-                edges = np.empty(nf*3, dtype=[('i', np.uint, 2)])
+                edges = np.empty(nf*3, dtype=[('i', np.uint32, 2)])
                 edges['i'][0:nf] = self._faces[:, :2]
                 edges['i'][nf:2*nf] = self._faces[:, 1:3]
                 edges['i'][-nf:, 0] = self._faces[:, 2]
@@ -448,7 +448,7 @@ class MeshData(object):
         elif indexed == 'faces':
             if self._vertices_indexed_by_faces is not None:
                 verts = self._vertices_indexed_by_faces
-                edges = np.empty((verts.shape[0], 3, 2), dtype=np.uint)
+                edges = np.empty((verts.shape[0], 3, 2), dtype=np.uint32)
                 nf = verts.shape[0]
                 edges[:, 0, 0] = np.arange(nf) * 3
                 edges[:, 0, 1] = edges[:, 0, 0] + 1

--- a/vispy/geometry/polygon.py
+++ b/vispy/geometry/polygon.py
@@ -116,13 +116,13 @@ class PolygonData(object):
         npts = self._vertices.shape[0]
         if np.any(self._vertices[0] != self._vertices[1]):
             # start != end, so edges must wrap around to beginning.
-            edges = np.empty((npts, 2), dtype=np.uint)
+            edges = np.empty((npts, 2), dtype=np.uint32)
             edges[:, 0] = np.arange(npts)
             edges[:, 1] = edges[:, 0] + 1
             edges[-1, 1] = 0
         else:
             # start == end; no wrapping required.
-            edges = np.empty((npts-1, 2), dtype=np.uint)
+            edges = np.empty((npts-1, 2), dtype=np.uint32)
             edges[:, 0] = np.arange(npts)
             edges[:, 1] = edges[:, 0] + 1
 

--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -81,7 +81,7 @@ class Triangulation(object):
         p2 = (xmax + xa, ymin - ya)
 
         # prepend artificial points to point list
-        newpts = np.empty((self.pts.shape[0]+2, 2), dtype=np.float32)
+        newpts = np.empty((self.pts.shape[0]+2, 2), dtype=float)
         newpts[0] = p1
         newpts[1] = p2
         newpts[2:] = self.pts

--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -81,7 +81,7 @@ class Triangulation(object):
         p2 = (xmax + xa, ymin - ya)
 
         # prepend artificial points to point list
-        newpts = np.empty((self.pts.shape[0]+2, 2), dtype=float)
+        newpts = np.empty((self.pts.shape[0]+2, 2), dtype=np.float32)
         newpts[0] = p1
         newpts[1] = p2
         newpts[2:] = self.pts


### PR DESCRIPTION
I ran into another issue with vispy.geometry on 64-bit python (specifically when creating a MeshData from unindexed vertices), so I went ahead and made all the implicit-width datatypes 32-bit (haven't run into any issues yet).

I also exposed the create_cone function, so all the .generation.create_ methods are now exposed in vispy.geometry with similar default parameters.