### PR TITLE
Implement a 1d sampler using pyopengl

### DIFF
--- a/doc/ext/gloooverviewgenerator.py
+++ b/doc/ext/gloooverviewgenerator.py
@@ -13,7 +13,7 @@ def clean():
     pass
 
 EXCLUDE = ['ColorBuffer', 'DepthBuffer', 'StencilBuffer']
-CLASSES = ['Program', 'VertexBuffer', 'IndexBuffer', 'Texture2D', 'Texture3D',
+CLASSES = ['Program', 'VertexBuffer', 'IndexBuffer', 'Texture1D', 'Texture2D', 'Texture3D',
            'RenderBuffer', 'FrameBuffer']
 
 

--- a/vispy/gloo/__init__.py
+++ b/vispy/gloo/__init__.py
@@ -50,7 +50,7 @@ from .context import (GLContext, get_default_config,  # noqa
                       get_current_canvas)  # noqa
 from .globject import GLObject  # noqa
 from .buffer import VertexBuffer, IndexBuffer  # noqa
-from .texture import Texture2D, TextureAtlas, Texture3D  # noqa
+from .texture import Texture1D, Texture2D, TextureAtlas, Texture3D  # noqa
 from .program import Program  # noqa
 from .framebuffer import FrameBuffer, RenderBuffer  # noqa
 from . import util  # noqa

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -359,8 +359,8 @@ class GlirParser(BaseGlirParser):
                     ob.set_attribute(*args)
                 elif cmd == 'DATA':  # VertexBuffer, IndexBuffer, Texture
                     ob.set_data(*args)
-                elif cmd == 'SIZE':  # VertexBuffer, IndexBuffer, 
-                    ob.set_size(*args)  # Texture1D, Texture2D, Texture3D, RenderBuffer
+                elif cmd == 'SIZE':  # VertexBuffer, IndexBuffer,
+                    ob.set_size(*args)  # Texture[1D, 2D, 3D], RenderBuffer
                 elif cmd == 'ATTACH':  # FrameBuffer
                     ob.attach(*args)
                 elif cmd == 'FRAMEBUFFER':  # FrameBuffer
@@ -1035,7 +1035,6 @@ def glTexSubImage1D(target, level, xoffset,
                         width[0], format, type, pixels)
 
 
-
 def glTexSubImage3D(target, level, xoffset, yoffset, zoffset,
                     format, type, pixels):
     # Import from PyOpenGL
@@ -1044,9 +1043,10 @@ def glTexSubImage3D(target, level, xoffset, yoffset, zoffset,
     _gl.glTexSubImage3D(target, level, xoffset, yoffset, zoffset,
                         width, height, depth, format, type, pixels)
 
+
 class GlirTexture3D(GlirTexture):
     _target = GL_TEXTURE_3D
-        
+
     def set_size(self, shape, format, internalformat):
         format = as_enum(format)
         if internalformat is not None:

--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from .globject import GLObject
 from .buffer import VertexBuffer, IndexBuffer, DataBuffer
-from .texture import BaseTexture, Texture2D, Texture3D
+from .texture import BaseTexture, Texture2D, Texture3D, Texture1D
 from ..util import logger
 from .util import check_enum 
 from ..ext.six import string_types
@@ -85,7 +85,7 @@ class Program(GLObject):
         'mat2':         (np.float32, 4),
         'mat3':         (np.float32, 9),
         'mat4':         (np.float32, 16),
-        # 'sampler1D':  (np.uint32, 1),
+        'sampler1D':    (np.uint32, 1),
         'sampler2D':    (np.uint32, 1),
         'sampler3D':    (np.uint32, 1),
     }
@@ -277,6 +277,8 @@ class Program(GLObject):
                     elif tex and hasattr(tex, 'set_data'):
                         tex.set_data(data)
                         return
+                    elif type == 'sampler1D':
+                        data = Texture1D(data)
                     elif type == 'sampler2D':
                         data = Texture2D(data)
                     elif type == 'sampler3D':

--- a/vispy/gloo/tests/test_program.py
+++ b/vispy/gloo/tests/test_program.py
@@ -116,9 +116,13 @@ class ProgramTest(unittest.TestCase):
         assert 'C' in program._pending_variables
         
         # Set samplers
-        program.set_shaders("uniform sampler2D T2; uniform sampler3D T3;", "f")
+        program.set_shaders("""uniform sampler1D T1;
+                            uniform sampler2D T2;
+                            uniform sampler3D T3;""", "f")
+        program['T1'] = np.zeros((10, ), np.float32)
         program['T2'] = np.zeros((10, 10), np.float32)
         program['T3'] = np.zeros((10, 10, 10), np.float32)
+        assert isinstance(program['T1'], gloo.Texture1D)
         assert isinstance(program['T2'], gloo.Texture2D)
         assert isinstance(program['T3'], gloo.Texture3D)
         

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -382,7 +382,7 @@ class Texture1D(BaseTexture):
     @property
     def width(self):
         """ Texture width """
-        return self._shape[1]
+        return self._shape[0]
 
     @property
     def glsl_type(self):

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -355,6 +355,40 @@ class BaseTexture(GLObject):
         return "<%s shape=%r format=%r at 0x%x>" % (
             self.__class__.__name__, self._shape, self._format, id(self))
 
+# --------------------------------------------------------- Texture1D class ---
+class Texture1D(BaseTexture):
+    """ one dimensional texture
+
+    Parameters
+    ----------
+
+    data : ndarray
+        Texture data shaped as W, or a tuple with the shape for
+        the texture (W).
+    shape : tuple of integers
+        Texture shape (optional), with shape W.
+    format : str | ENUM
+        The format of the texture: 'luminance', 'alpha', 'luminance_alpha',
+        'rgb', or 'rgba'. If not given the format is chosen automatically
+        based on the number of channels. When the data has one channel,
+        'luminance' is assumed.
+    """
+    _ndim = 1
+    _GLIR_TYPE = 'Texture1D'
+    
+    def __init__(self, data=None, format=None, **kwargs):
+        BaseTexture.__init__(self, data, format, **kwargs)
+
+    @property
+    def width(self):
+        """ Texture width """
+        return self._shape[1]
+
+    @property
+    def glsl_type(self):
+        """ GLSL declaration strings required for a variable to hold this data.
+        """
+        return 'uniform', 'sampler1D'
 
 # --------------------------------------------------------- Texture2D class ---
 class Texture2D(BaseTexture):

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -355,6 +355,7 @@ class BaseTexture(GLObject):
         return "<%s shape=%r format=%r at 0x%x>" % (
             self.__class__.__name__, self._shape, self._format, id(self))
 
+
 # --------------------------------------------------------- Texture1D class ---
 class Texture1D(BaseTexture):
     """ one dimensional texture
@@ -375,7 +376,7 @@ class Texture1D(BaseTexture):
     """
     _ndim = 1
     _GLIR_TYPE = 'Texture1D'
-    
+
     def __init__(self, data=None, format=None, **kwargs):
         BaseTexture.__init__(self, data, format, **kwargs)
 
@@ -389,6 +390,7 @@ class Texture1D(BaseTexture):
         """ GLSL declaration strings required for a variable to hold this data.
         """
         return 'uniform', 'sampler1D'
+
 
 # --------------------------------------------------------- Texture2D class ---
 class Texture2D(BaseTexture):


### PR DESCRIPTION
So, I implemented a 1d sampler similar to the already existing 3d sampler in the codebase by accessing ```pyopengl```. There a lot of layers and moving parts, so I'm not sure if I missed something in my implementation.

I also had to manually extract the constants ```GL_TEXTURE_1D``` and ```GL_SAMPLER_1D```. I'm assuming that they were not listed in ```_constants.py``` since they're not ```GLES2.0```? Either way, I'm not too fond of the current __extremely__ hacky solution I came up with. Would love a nicer solution