### PR TITLE
FIX: Shorter rep

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -202,7 +202,7 @@ class ApplicationBackend(BaseApplicationBackend):
 
     def _vispy_get_backend_name(self):
         name = QtCore.__name__.split('.')[0]
-        return name + ' (qt)'
+        return name
 
     def _vispy_process_events(self):
         app = self._vispy_get_native_app()

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -424,7 +424,7 @@ class Canvas(object):
 
     # ---------------------------------------------------------------- misc ---
     def __repr__(self):
-        return ('<Vispy canvas (%s backend) at %s>'
+        return ('<Canvas (%s) at %s>'
                 % (self.app.backend_name, hex(id(self))))
 
     def __enter__(self):

--- a/vispy/util/event.py
+++ b/vispy/util/event.py
@@ -141,6 +141,10 @@ class Event(object):
         finally:
             _event_repr_depth -= 1
 
+    def __str__(self):
+        """Shorter string representation"""
+        return self.__class__.__name__
+
 _event_repr_depth = 0
 
 

--- a/vispy/util/logs.py
+++ b/vispy/util/logs.py
@@ -317,14 +317,13 @@ def _handle_exception(ignore_callback_errors, print_callback_errors, obj,
         if this_print == 'full':
             logger.log_exception()
             if exp_type == 'callback':
-                logger.warning("Error invoking callback %s for "
-                               "event: %s" % (cb, event))
+                logger.error("Invoking %s for %s" % (cb, event))
             else:  # == 'node':
-                logger.warning("Error drawing node %s" % node)
+                logger.error("Drawing node %s" % node)
         elif this_print is not None:
             if exp_type == 'callback':
-                logger.warning("Error invoking callback %s repeat %s"
-                               % (cb, this_print))
+                logger.error("Invoking %s repeat %s"
+                             % (cb, this_print))
             else:  # == 'node':
-                logger.warning("Error drawing node %s repeat %s"
-                               % (node, this_print))
+                logger.error("Drawing node %s repeat %s"
+                             % (node, this_print))


### PR DESCRIPTION
Closes #560.

Test code:
```
from vispy.app import Canvas


class MyCanvas(Canvas):
    def on_draw(self, event):
        raise RuntimeError

x = MyCanvas(show=True)
```
Changes this output (`master`):
```
WARNING: Error invoking callback <bound method MyCanvas.on_draw of <Vispy canvas (PyQt4 (qt) backend) at 0x32dd940>> for event: <DrawEvent blocked=False handled=False native=None region=None source=<Vispy canvas (PyQt4 (qt) backend) at 0x32dd940> sources=[<Vispy canvas (PyQt4 (qt) backend) at 0x32dd940>] type=draw>
WARNING: Error invoking callback <bound method MyCanvas.on_draw of <Vispy canvas (PyQt4 (qt) backend) at 0x32dd940>> repeat 2
```
Into this:
```
RuntimeError
ERROR: Invoking <bound method MyCanvas.on_draw of <Canvas (PyQt4) at 0x237abe0>> for DrawEvent
ERROR: Invoking <bound method MyCanvas.on_draw of <Canvas (PyQt4) at 0x237abe0>> repeat 2
```
Ready for review/merge from my end.