### PR TITLE
Fixed a few examples on OS X

### DIFF
--- a/examples/basics/visuals/cube.py
+++ b/examples/basics/visuals/cube.py
@@ -19,7 +19,7 @@ class Canvas(app.Canvas):
         self.theta = 0
         self.phi = 0
 
-        app.Canvas.__init__(self, 'Cube', keys='interactive', show=True,
+        app.Canvas.__init__(self, 'Cube', keys='interactive',
                             size=(400, 400))
         
         # Create a TransformSystem that will tell the visual how to draw
@@ -28,6 +28,8 @@ class Canvas(app.Canvas):
         self.tr_sys.visual_to_document = self.cube_transform
         
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show(True)
 
     def on_draw(self, event):
         gloo.set_viewport(0, 0, *self.size)

--- a/examples/basics/visuals/image_transforms.py
+++ b/examples/basics/visuals/image_transforms.py
@@ -56,11 +56,12 @@ class Canvas(vispy.app.Canvas):
 
         vispy.app.Canvas.__init__(self, keys='interactive')
         self.size = (800, 800)
-        self.show()
 
         for img in self.images:
             img.tr_sys = TransformSystem(self)
             img.tr_sys.visual_to_document = img.transform
+
+        self.show(True)
 
     def on_draw(self, ev):
         gloo.clear(color='black', depth=True)

--- a/examples/basics/visuals/image_visual.py
+++ b/examples/basics/visuals/image_visual.py
@@ -22,11 +22,12 @@ class Canvas(vispy.app.Canvas):
         self.image_transform = STTransform(scale=(7, 7), translate=(50, 50))
         vispy.app.Canvas.__init__(self, keys='interactive')
         self.size = (800, 800)
-        self.show()
         
         # Create a TransformSystem that will tell the visual how to draw
         self.tr_sys = TransformSystem(self)
         self.tr_sys.visual_to_document = self.image_transform
+
+        self.show(True)
 
     def on_draw(self, ev):
         gloo.clear(color='black', depth=True)

--- a/examples/basics/visuals/line.py
+++ b/examples/basics/visuals/line.py
@@ -34,7 +34,7 @@ connect[N/2, 1] = N/2  # put a break in the middle
 class Canvas(app.Canvas):
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive',
-                            size=(800, 800), show=True)
+                            size=(800, 800))
         # Create several visuals demonstrating different features of Line
         self.lines = [
             # agg-mode lines:
@@ -82,6 +82,8 @@ class Canvas(app.Canvas):
         for visual in self.visuals:
             visual.tr_sys = visuals.transforms.TransformSystem(self)
             visual.tr_sys.visual_to_document = visual.transform
+
+        self.show(True)
 
     def on_draw(self, event):
         gloo.clear('black')

--- a/examples/basics/visuals/line_plot.py
+++ b/examples/basics/visuals/line_plot.py
@@ -24,8 +24,10 @@ class Canvas(app.Canvas):
         self.line = visuals.LinePlotVisual(pos, color='w', edge_color='w',
                                            face_color=(0.2, 0.2, 1))
         app.Canvas.__init__(self, keys='interactive',
-                            size=(800, 800), show=True)
+                            size=(800, 800))
         self.tr_sys = visuals.transforms.TransformSystem(self)
+
+        self.show(True)
 
     def on_draw(self, event):
         gloo.clear('black')

--- a/examples/basics/visuals/line_transform.py
+++ b/examples/basics/visuals/line_transform.py
@@ -72,12 +72,13 @@ class Canvas(app.Canvas):
 
         app.Canvas.__init__(self, keys='interactive')
         self.size = (800, 800)
-        self.show()
         
         for line in self.lines:
             tr_sys = visuals.transforms.TransformSystem(self)
             tr_sys.visual_to_document = line.transform
             line.tr_sys = tr_sys
+
+        self.show(True)
 
     def on_draw(self, ev):
         gloo.clear('black', depth=True)

--- a/examples/demo/gloo/imshow.py
+++ b/examples/demo/gloo/imshow.py
@@ -95,7 +95,7 @@ void main()
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, show=True, size=(512, 512),
+        app.Canvas.__init__(self, size=(512, 512),
                             keys='interactive')
         self.image = Program(img_vertex, img_fragment, 4)
         self.image['position'] = (-1, -1), (-1, +1), (+1, -1), (+1, +1)
@@ -112,6 +112,8 @@ class Canvas(app.Canvas):
         self.image['image'].interpolation = 'linear'
 
         set_clear_color('black')
+
+        self.show(True)
 
     def on_resize(self, event):
         width, height = event.size

--- a/examples/demo/gloo/imshow_cuts.py
+++ b/examples/demo/gloo/imshow_cuts.py
@@ -111,7 +111,7 @@ void main()
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, show=True, size=(512, 512),
+        app.Canvas.__init__(self, size=(512, 512),
                             keys='interactive')
 
         self.image = Program(image_vertex, image_fragment, 4)
@@ -136,6 +136,8 @@ class Canvas(app.Canvas):
 
         set_state(clear_color='white', blend=True,
                   blend_func=('src_alpha', 'one_minus_src_alpha'))
+
+        self.show(True)
 
     def on_resize(self, event):
         set_viewport(0, 0, *event.size)


### PR DESCRIPTION
`self.show(True)` or `app.Canvas.__init__(self, show=True)` should
only be called after the rest of the initialisation code has run.