### PR TITLE
Convert wx DClick into vipsy_mouse_press events

### DIFF
--- a/vispy/app/backends/_wx.py
+++ b/vispy/app/backends/_wx.py
@@ -401,6 +401,16 @@ class CanvasBackend(GLCanvas, BaseCanvasBackend):
             else:
                 evt.Skip()
             self._vispy_mouse_release(pos=pos, button=button, modifiers=mods)
+        elif evt.ButtonDClick():
+            if evt.LeftDClick():
+                button = 0
+            elif evt.MiddleDClick():
+                button = 1
+            elif evt.RightDClick():
+                button = 2
+            else:
+                evt.Skip()            
+            self._vispy_mouse_press(pos=pos, button=button, modifiers=mods)
         evt.Skip()
 
     def on_key_down(self, evt):


### PR DESCRIPTION
Wx converts the second mouse-press into a Click event.

This change converts these DClick events into standard vispy_mouse_press events, so that mouse press events are not skipped