### PR TITLE
Allow using gloo without vispy.app again

### DIFF
--- a/vispy/gloo/context.py
+++ b/vispy/gloo/context.py
@@ -212,3 +212,21 @@ class GLShared(object):
             return ref
         else:
             raise RuntimeError('No reference for available for GLShared')
+
+
+class FakeCanvas(object):
+    """ Fake canvas to allow using gloo without vispy.app
+    
+    Instantiate this class to collect GLIR commands from gloo
+    interactions. Call flush() in your draw event handler to execute
+    the commands in the active contect.
+    """
+    
+    def __init__(self):
+        self.context = GLContext()
+        set_current_canvas(self)
+    
+    def flush(self):
+        """ Flush commands. Call this after setting to context to current.
+        """
+        self.context.flush_commands()

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -570,7 +570,10 @@ class GlooFunctions(BaseGlooFunctions):
         """ The GLIR queue corresponding to the current canvas
         """
         canvas = get_current_canvas()
-        assert canvas is not None
+        if canvas is None:
+            msg = ("If you want to use gloo without vispy.app, " + 
+                   "use a gloo.context.FakeCanvas.")
+            raise RuntimeError('Gloo requires a Canvas to run.\n' + msg)
         return canvas.context.glir
 
 


### PR DESCRIPTION
issues: closes #757

Better error message, and a class to help use gloo without an `app.Canvas`.