### PR TITLE
Fixes for Retina/HiDPI displays

### DIFF
--- a/examples/basics/gloo/animate_images.py
+++ b/examples/basics/gloo/animate_images.py
@@ -60,8 +60,7 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = W * 5, H * 5
+        app.Canvas.__init__(self, keys='interactive', size=((W * 5), (H * 5)))
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         self.texture = gloo.Texture2D(I, interpolation='linear')
@@ -82,8 +81,10 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
         self.projection = ortho(0, width, 0, height, -100, 100)
         self.program['u_projection'] = self.projection
@@ -110,5 +111,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/animate_images_slice.py
+++ b/examples/basics/gloo/animate_images_slice.py
@@ -73,8 +73,7 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = W * 5, H * 5
+        app.Canvas.__init__(self, keys='interactive', size=((W*5), (H*5)))
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         self.texture = gloo.Texture3D(I, interpolation='nearest',
@@ -98,8 +97,10 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
         self.projection = ortho(0, width, 0, height, -100, 100)
         self.program['u_projection'] = self.projection
@@ -130,5 +131,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/animate_shape.py
+++ b/examples/basics/gloo/animate_shape.py
@@ -84,8 +84,10 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -105,5 +107,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/display_lines.py
+++ b/examples/basics/gloo/display_lines.py
@@ -16,7 +16,9 @@ from vispy import gloo
 from vispy import app
 from vispy.util.transforms import perspective, translate, rotate
 
-# Create vetices
+W, H = 400, 400
+
+# Create vertices
 n = 100
 a_position = np.random.uniform(-1, 1, (n, 3)).astype(np.float32)
 a_id = np.random.randint(0, 30, (n, 1))
@@ -54,7 +56,7 @@ class Canvas(app.Canvas):
 
     # ---------------------------------
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
+        app.Canvas.__init__(self, keys='interactive', size=(W, H))
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
 
@@ -64,7 +66,10 @@ class Canvas(app.Canvas):
 
         self.view = np.eye(4, dtype=np.float32)
         self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
+
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] / float(self.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
 
         self.translate = 5
         translate(self.view, 0, 0, -self.translate)
@@ -78,6 +83,8 @@ class Canvas(app.Canvas):
         self.context.set_state('translucent')
 
         self.timer = app.Timer('auto', connect=self.on_timer)
+
+        self.show()
 
     # ---------------------------------
     def on_key_press(self, event):
@@ -99,9 +106,8 @@ class Canvas(app.Canvas):
 
     # ---------------------------------
     def on_resize(self, event):
-        width, height = event.size
-        self.context.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 1.0, 1000.0)
+        gloo.set_viewport(0, 0, event.physical_size[0], event.physical_size[1])
+        self.projection = perspective(45.0, event.size[0] / float(event.size[1]), 1.0, 1000.0)
         self.program['u_projection'] = self.projection
 
     # ---------------------------------
@@ -121,5 +127,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/display_lines.py
+++ b/examples/basics/gloo/display_lines.py
@@ -68,7 +68,8 @@ class Canvas(app.Canvas):
         self.model = np.eye(4, dtype=np.float32)
 
         gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
-        self.projection = perspective(45.0, self.size[0] / float(self.size[1]), 1.0, 1000.0)
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 1000.0)
         self.program['u_projection'] = self.projection
 
         self.translate = 5
@@ -107,7 +108,8 @@ class Canvas(app.Canvas):
     # ---------------------------------
     def on_resize(self, event):
         gloo.set_viewport(0, 0, event.physical_size[0], event.physical_size[1])
-        self.projection = perspective(45.0, event.size[0] / float(event.size[1]), 1.0, 1000.0)
+        self.projection = perspective(45.0, event.size[0] /
+                                      float(event.size[1]), 1.0, 1000.0)
         self.program['u_projection'] = self.projection
 
     # ---------------------------------

--- a/examples/basics/gloo/display_points.py
+++ b/examples/basics/gloo/display_points.py
@@ -8,12 +8,6 @@ from vispy import gloo
 from vispy import app
 import numpy as np
 
-# Create vetices
-n = 10000
-v_position = 0.25 * np.random.randn(n, 2).astype(np.float32)
-v_color = np.random.uniform(0, 1, (n, 3)).astype(np.float32)
-v_size = np.random.uniform(2, 12, (n, 1)).astype(np.float32)
-
 VERT_SHADER = """
 attribute vec2  a_position;
 attribute vec3  a_color;
@@ -70,6 +64,13 @@ class Canvas(app.Canvas):
 
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive')
+        ps = self.pixel_scale
+
+        # Create vertices
+        n = 10000
+        v_position = 0.25 * np.random.randn(n, 2).astype(np.float32)
+        v_color = np.random.uniform(0, 1, (n, 3)).astype(np.float32)
+        v_size = np.random.uniform(2*ps, 12*ps, (n, 1)).astype(np.float32)
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         # Set uniform and attribute
@@ -79,8 +80,10 @@ class Canvas(app.Canvas):
         gloo.set_state(clear_color='white', blend=True,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
 
+        self.show()
+
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
@@ -89,5 +92,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/display_shape.py
+++ b/examples/basics/gloo/display_shape.py
@@ -46,8 +46,10 @@ class Canvas(app.Canvas):
 
         gloo.set_clear_color('white')
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -57,5 +59,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/gpuimage.py
+++ b/examples/basics/gloo/gpuimage.py
@@ -96,12 +96,14 @@ class Canvas(app.Canvas):
         self.program['u_time'] = 0.0
         self.timer = app.Timer('auto', connect=self.on_timer, start=True)
 
+        self.show()
+
     def on_timer(self, event):
         self.program['u_time'] = event.elapsed
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -109,5 +111,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     canvas = Canvas()
-    canvas.show()
     app.run()

--- a/examples/basics/gloo/hello_fbo.py
+++ b/examples/basics/gloo/hello_fbo.py
@@ -75,7 +75,7 @@ SIZE = 50
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive', size=(560,420))
+        app.Canvas.__init__(self, keys='interactive', size=(560, 420))
 
         # Create texture to render to
         shape = self.physical_size[1], self.physical_size[0]

--- a/examples/basics/gloo/hello_fbo.py
+++ b/examples/basics/gloo/hello_fbo.py
@@ -75,11 +75,10 @@ SIZE = 50
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 560, 420
+        app.Canvas.__init__(self, keys='interactive', size=(560,420))
 
         # Create texture to render to
-        shape = self.size[1], self.size[0]
+        shape = self.physical_size[1], self.physical_size[0]
         self._rendertex = gloo.Texture2D((shape + (3,)))
 
         # Create FBO, attach the color buffer and depth buffer
@@ -96,8 +95,10 @@ class Canvas(app.Canvas):
         self._program2['a_texcoord'] = gloo.VertexBuffer(vTexcoord)
         self._program2['u_texture1'] = self._rendertex
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -105,7 +106,7 @@ class Canvas(app.Canvas):
         with self._fbo:
             gloo.set_clear_color((0.0, 0.0, 0.5, 1))
             gloo.clear(color=True, depth=True)
-            gloo.set_viewport(0, 0, *self.size)
+            gloo.set_viewport(0, 0, *self.physical_size)
             self._program1.draw('triangle_strip')
 
         # Now draw result to a full-screen quad
@@ -117,5 +118,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/multi_texture.py
+++ b/examples/basics/gloo/multi_texture.py
@@ -72,8 +72,10 @@ class Canvas(app.Canvas):
 
         gloo.set_clear_color('white')
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -83,5 +85,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/post_processing.py
+++ b/examples/basics/gloo/post_processing.py
@@ -120,7 +120,9 @@ class Canvas(app.Canvas):
         # --------------------------------------
         set_state(clear_color=(.3, .3, .35, 1), depth_test=True)
         self.timer = app.Timer('auto', connect=self.on_timer, start=True)
-        self._set_projection(self.size)
+        self._set_projection(self.physical_size)
+
+        self.show()
 
     def on_draw(self, event):
         with self.framebuffer:
@@ -128,13 +130,13 @@ class Canvas(app.Canvas):
             clear(color=True, depth=True)
             set_state(depth_test=True)
             self.cube.draw('triangles', self.indices)
-        set_viewport(0, 0, *self.size)
+        set_viewport(0, 0, *self.physical_size)
         clear(color=True)
         set_state(depth_test=False)
         self.quad.draw('triangle_strip')
 
     def on_resize(self, event):
-        self._set_projection(event.size)
+        self._set_projection(event.physical_size)
 
     def _set_projection(self, size):
         width, height = size
@@ -153,5 +155,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     c.app.run()

--- a/examples/basics/gloo/rotate_cube.py
+++ b/examples/basics/gloo/rotate_cube.py
@@ -99,7 +99,6 @@ class Canvas(app.Canvas):
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive', size=(800, 600))
 
-
         self.vertices, self.filled, self.outline = cube()
         self.filled_buf = gloo.IndexBuffer(self.filled)
         self.outline_buf = gloo.IndexBuffer(self.outline)
@@ -111,7 +110,9 @@ class Canvas(app.Canvas):
         self.model = np.eye(4, dtype=np.float32)
         
         gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
-        self.projection = perspective(45.0, self.size[0] / float(self.size[1]), 2.0, 10.0)
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 2.0, 10.0)
+
         self.program['u_projection'] = self.projection
 
         translate(self.view, 0, 0, -5)
@@ -142,7 +143,8 @@ class Canvas(app.Canvas):
     # ---------------------------------
     def on_resize(self, event):
         gloo.set_viewport(0, 0, event.physical_size[0], event.physical_size[1])
-        self.projection = perspective(45.0, event.size[0] / float(event.size[1]), 2.0, 10.0)
+        self.projection = perspective(45.0, event.size[0] /
+                                      float(event.size[1]), 2.0, 10.0)
         self.program['u_projection'] = self.projection
 
     # ---------------------------------

--- a/examples/basics/gloo/rotate_cube.py
+++ b/examples/basics/gloo/rotate_cube.py
@@ -10,7 +10,6 @@ import numpy as np
 from vispy import app, gloo
 from vispy.util.transforms import perspective, translate, rotate
 
-
 vert = """
 // Uniforms
 // ------------------------------------
@@ -98,8 +97,8 @@ def cube():
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 800, 600
+        app.Canvas.__init__(self, keys='interactive', size=(800, 600))
+
 
         self.vertices, self.filled, self.outline = cube()
         self.filled_buf = gloo.IndexBuffer(self.filled)
@@ -110,7 +109,10 @@ class Canvas(app.Canvas):
 
         self.view = np.eye(4, dtype=np.float32)
         self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
+        
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] / float(self.size[1]), 2.0, 10.0)
+        self.program['u_projection'] = self.projection
 
         translate(self.view, 0, 0, -5)
         self.program['u_model'] = self.model
@@ -125,6 +127,8 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
+        self.show()
+
     # ---------------------------------
     def on_timer(self, event):
         self.theta += .5
@@ -137,9 +141,8 @@ class Canvas(app.Canvas):
 
     # ---------------------------------
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 2.0, 10.0)
+        gloo.set_viewport(0, 0, event.physical_size[0], event.physical_size[1])
+        self.projection = perspective(45.0, event.size[0] / float(event.size[1]), 2.0, 10.0)
         self.program['u_projection'] = self.projection
 
     # ---------------------------------
@@ -163,5 +166,4 @@ class Canvas(app.Canvas):
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/basics/gloo/start.py
+++ b/examples/basics/gloo/start.py
@@ -6,13 +6,14 @@ import sys
 
 from vispy import app, gloo
 
-canvas = app.Canvas(show=True, keys='interactive')
-
+canvas = app.Canvas(keys='interactive')
 
 @canvas.connect
 def on_draw(event):
     gloo.set_clear_color((0.2, 0.4, 0.6, 1.0))
     gloo.clear()
+
+canvas.show()
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     app.run()

--- a/examples/basics/gloo/start.py
+++ b/examples/basics/gloo/start.py
@@ -8,6 +8,7 @@ from vispy import app, gloo
 
 canvas = app.Canvas(keys='interactive')
 
+
 @canvas.connect
 def on_draw(event):
     gloo.set_clear_color((0.2, 0.4, 0.6, 1.0))

--- a/examples/basics/gloo/start_shaders.py
+++ b/examples/basics/gloo/start_shaders.py
@@ -8,11 +8,11 @@ import numpy as np
 
 VERT_SHADER = """
 attribute vec2 a_position;
-uniform float a_size;
+uniform float u_size;
 
 void main() {
     gl_Position = vec4(a_position, 0.0, 1.0);
-    gl_PointSize = a_size;
+    gl_PointSize = u_size;
 }
 """
 
@@ -32,7 +32,7 @@ class Canvas(app.Canvas):
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         data = np.random.uniform(-0.5, 0.5, size=(20, 2))
         self.program['a_position'] = data.astype(np.float32)
-        self.program['a_size'] = 20.*ps
+        self.program['u_size'] = 20.*ps
 
         self.show()
 

--- a/examples/basics/gloo/start_shaders.py
+++ b/examples/basics/gloo/start_shaders.py
@@ -8,9 +8,11 @@ import numpy as np
 
 VERT_SHADER = """
 attribute vec2 a_position;
+uniform float a_size;
+
 void main() {
     gl_Position = vec4(a_position, 0.0, 1.0);
-    gl_PointSize = 10.0;
+    gl_PointSize = a_size;
 }
 """
 
@@ -24,9 +26,15 @@ void main() {
 class Canvas(app.Canvas):
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive')
+
+        ps = self.pixel_scale
+
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         data = np.random.uniform(-0.5, 0.5, size=(20, 2))
         self.program['a_position'] = data.astype(np.float32)
+        self.program['a_size'] = 20.*ps
+
+        self.show()
 
     def on_resize(self, event):
         width, height = event.size
@@ -38,6 +46,5 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     if sys.flags.interactive != 1:
         app.run()

--- a/examples/basics/scene/shared_context.py
+++ b/examples/basics/scene/shared_context.py
@@ -38,7 +38,7 @@ view2.add(p1)
 # Add a 3D axis to keep us oriented
 axis = scene.visuals.XYZAxis(parent=view1.scene)
 
-canvas = canvas1  # allow running this example in out test suite
+canvas = canvas1  # allow running this example in our test suite
 
 if __name__ == '__main__':
     if sys.flags.interactive == 0:

--- a/examples/basics/scene/text.py
+++ b/examples/basics/scene/text.py
@@ -18,6 +18,8 @@ from vispy.scene.visuals import Text
 canvas = scene.SceneCanvas(keys='interactive')
 vb = scene.widgets.ViewBox(parent=canvas.scene, border_color='b')
 
+vb.pos = 1, canvas.size[1] // 2 - 1
+vb.size = canvas.size[0] - 2, canvas.size[1] // 2 - 2
 
 @canvas.events.resize.connect
 def resize(event=None):

--- a/examples/basics/scene/text.py
+++ b/examples/basics/scene/text.py
@@ -21,6 +21,7 @@ vb = scene.widgets.ViewBox(parent=canvas.scene, border_color='b')
 vb.pos = 1, canvas.size[1] // 2 - 1
 vb.size = canvas.size[0] - 2, canvas.size[1] // 2 - 2
 
+
 @canvas.events.resize.connect
 def resize(event=None):
     vb.pos = 1, canvas.size[1] // 2 - 1

--- a/examples/basics/visuals/cube.py
+++ b/examples/basics/visuals/cube.py
@@ -14,25 +14,25 @@ from vispy.visuals import CubeVisual, transforms
 
 class Canvas(app.Canvas):
     def __init__(self):
+        app.Canvas.__init__(self, 'Cube', keys='interactive',
+                            size=(400, 400))
+
         self.cube = CubeVisual((1.0, 0.5, 0.25), color='red',
                                edge_color='black')
         self.theta = 0
         self.phi = 0
 
-        app.Canvas.__init__(self, 'Cube', keys='interactive',
-                            size=(400, 400))
-        
         # Create a TransformSystem that will tell the visual how to draw
         self.cube_transform = transforms.AffineTransform()
         self.tr_sys = transforms.TransformSystem(self)
         self.tr_sys.visual_to_document = self.cube_transform
-        
+
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, event):
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         gloo.clear('white')
         self.tr_sys.auto_configure()
         self.cube.draw(self.tr_sys)

--- a/examples/basics/visuals/custom_visual.py
+++ b/examples/basics/visuals/custom_visual.py
@@ -104,11 +104,12 @@ class Canvas(app.Canvas):
 
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive')
+        ps = self.pixel_scale
 
         n = 10000
         pos = 0.25 * np.random.randn(n, 2).astype(np.float32)
         color = np.random.uniform(0, 1, (n, 3)).astype(np.float32)
-        size = np.random.uniform(2, 12, (n, 1)).astype(np.float32)
+        size = np.random.uniform(2*ps, 12*ps, (n, 1)).astype(np.float32)
 
         self.points = MarkerVisual(pos=pos, color=color, size=size)
 

--- a/examples/basics/visuals/dynamic_polygon.py
+++ b/examples/basics/visuals/dynamic_polygon.py
@@ -44,8 +44,7 @@ pos[-1] = pos[0]
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
         global pos
         self.visuals = []
         polygon = visuals.PolygonVisual(pos=pos, color=(0.8, .2, 0, 1),
@@ -82,12 +81,14 @@ class Canvas(app.Canvas):
             v.tr_sys = transforms.TransformSystem(self)
             v.tr_sys.visual_to_document = v.transform
 
-        self.show()
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show()
+
 
     def on_draw(self, ev):
         gloo.set_clear_color((0, 0, 0, 1))
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         gloo.clear()
         for vis in self.visuals:
             vis.draw(vis.tr_sys)

--- a/examples/basics/visuals/dynamic_polygon.py
+++ b/examples/basics/visuals/dynamic_polygon.py
@@ -85,7 +85,6 @@ class Canvas(app.Canvas):
 
         self.show()
 
-
     def on_draw(self, ev):
         gloo.set_clear_color((0, 0, 0, 1))
         gloo.set_viewport(0, 0, *self.physical_size)

--- a/examples/basics/visuals/image_transforms.py
+++ b/examples/basics/visuals/image_transforms.py
@@ -11,9 +11,9 @@ import numpy as np
 import vispy.app
 from vispy import gloo
 from vispy import visuals
-from vispy.visuals.transforms import (AffineTransform, STTransform, 
+from vispy.visuals.transforms import (AffineTransform, STTransform,
                                       arg_to_array, TransformSystem,
-                                      LogTransform, PolarTransform, 
+                                      LogTransform, PolarTransform,
                                       BaseTransform)
 
 image = np.random.normal(size=(100, 100, 3))
@@ -27,10 +27,12 @@ image = ((image-image.min()) *
 
 class Canvas(vispy.app.Canvas):
     def __init__(self):
+        vispy.app.Canvas.__init__(self, keys='interactive', size=(800, 800))
+
         self.images = [visuals.ImageVisual(image, method='impostor')
                        for i in range(4)]
         self.images[0].transform = (STTransform(scale=(30, 30),
-                                                translate=(600, 600)) * 
+                                                translate=(600, 600)) *
                                     SineTransform() *
                                     STTransform(scale=(0.1, 0.1),
                                                 translate=(-5, -5)))
@@ -54,18 +56,15 @@ class Canvas(vispy.app.Canvas):
                                     STTransform(scale=(np.pi/200, 0.005),
                                                 translate=(-3*np.pi/4., 0.1)))
 
-        vispy.app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
-
         for img in self.images:
             img.tr_sys = TransformSystem(self)
             img.tr_sys.visual_to_document = img.transform
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, ev):
         gloo.clear(color='black', depth=True)
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         # Create a TransformSystem that will tell the visual how to draw
         for img in self.images:
             img.draw(img.tr_sys)

--- a/examples/basics/visuals/image_visual.py
+++ b/examples/basics/visuals/image_visual.py
@@ -18,20 +18,20 @@ image = np.random.normal(size=(100, 100, 3), loc=128,
 
 class Canvas(vispy.app.Canvas):
     def __init__(self):
+        vispy.app.Canvas.__init__(self, keys='interactive', size=(800, 800))
+
         self.image = visuals.ImageVisual(image, method='subdivide')
         self.image_transform = STTransform(scale=(7, 7), translate=(50, 50))
-        vispy.app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
-        
+
         # Create a TransformSystem that will tell the visual how to draw
         self.tr_sys = TransformSystem(self)
         self.tr_sys.visual_to_document = self.image_transform
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, ev):
         gloo.clear(color='black', depth=True)
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.image.draw(self.tr_sys)
 
 

--- a/examples/basics/visuals/line.py
+++ b/examples/basics/visuals/line.py
@@ -87,7 +87,7 @@ class Canvas(app.Canvas):
 
     def on_draw(self, event):
         gloo.clear('black')
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         for visual in self.visuals:
             visual.draw(visual.tr_sys)
 

--- a/examples/basics/visuals/line.py
+++ b/examples/basics/visuals/line.py
@@ -44,18 +44,18 @@ class Canvas(app.Canvas):
             visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1), mode='agg'),
             # wide
             visuals.LineVisual(pos=pos, color=color, width=5, mode='agg'),
-            
+
             # GL-mode lines:
             visuals.LineVisual(pos=pos, color=color, mode='gl'),
             visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1), mode='gl'),
             visuals.LineVisual(pos=pos, color=color, width=5, mode='gl'),
             # GL-mode: "connect" not available in AGG mode yet
-            
+
             # only connect alternate vert pairs
-            visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1), 
+            visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1),
                                connect='segments', mode='gl'),
             # connect specific pairs
-            visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1), 
+            visuals.LineVisual(pos=pos, color=(0, 0.5, 0.3, 1),
                                connect=connect, mode='gl'),
         ]
         counts = [0, 0]
@@ -68,22 +68,22 @@ class Canvas(app.Canvas):
             line.transform = STTransform(translate=[x, y])
             # redraw the canvas if any visuals request an update
             line.events.update.connect(lambda evt: self.update())
-        
-        self.texts = [visuals.TextVisual('GL', bold=True, font_size=24, 
+
+        self.texts = [visuals.TextVisual('GL', bold=True, font_size=24,
                                          color='w', pos=(200, 40)),
                       visuals.TextVisual('Agg', bold=True, font_size=24,
                                          color='w', pos=(600, 40))]
         for text in self.texts:
             text.transform = NullTransform()
         self.visuals = self.lines + self.texts
-        
+
         # create a TransformSystem for each visual.
         # (these are stored as attributes of each visual for convenience)
         for visual in self.visuals:
             visual.tr_sys = visuals.transforms.TransformSystem(self)
             visual.tr_sys.visual_to_document = visual.transform
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, event):
         gloo.clear('black')

--- a/examples/basics/visuals/line_plot.py
+++ b/examples/basics/visuals/line_plot.py
@@ -21,17 +21,19 @@ pos[:, 1] = np.random.normal(size=N, scale=100, loc=400)
 
 class Canvas(app.Canvas):
     def __init__(self):
-        self.line = visuals.LinePlotVisual(pos, color='w', edge_color='w',
-                                           face_color=(0.2, 0.2, 1))
         app.Canvas.__init__(self, keys='interactive',
                             size=(800, 800))
+
+        self.line = visuals.LinePlotVisual(pos, color='w', edge_color='w',
+                                           face_color=(0.2, 0.2, 1))
+
         self.tr_sys = visuals.transforms.TransformSystem(self)
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, event):
         gloo.clear('black')
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.line.draw(self.tr_sys)
 
 

--- a/examples/basics/visuals/line_transform.py
+++ b/examples/basics/visuals/line_transform.py
@@ -32,6 +32,7 @@ color[:, 1] = color[::-1, 0]
 
 class Canvas(app.Canvas):
     def __init__(self):
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
 
         # Define several Line visuals that use the same position data
         # but have different colors and transformations
@@ -45,14 +46,14 @@ class Canvas(app.Canvas):
 
         self.lines[0].transform = center
 
-        self.lines[1].transform = (center * 
+        self.lines[1].transform = (center *
                                    STTransform(scale=(1, 0.1, 1)))
 
-        self.lines[2].transform = (center * 
+        self.lines[2].transform = (center *
                                    STTransform(translate=(200, 200, 0)) *
                                    STTransform(scale=(0.3, 0.5, 1)))
 
-        self.lines[3].transform = (center * 
+        self.lines[3].transform = (center *
                                    STTransform(translate=(-200, -200, 0),
                                                scale=(200, 1)) *
                                    LogTransform(base=(10, 0, 0)) *
@@ -70,19 +71,16 @@ class Canvas(app.Canvas):
                                    STTransform(scale=(0.01, 0.1),
                                                translate=(4, 20)))
 
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
-        
         for line in self.lines:
             tr_sys = visuals.transforms.TransformSystem(self)
             tr_sys.visual_to_document = line.transform
             line.tr_sys = tr_sys
 
-        self.show(True)
+        self.show()
 
     def on_draw(self, ev):
         gloo.clear('black', depth=True)
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         for line in self.lines:
             line.draw(line.tr_sys)
 

--- a/examples/basics/visuals/line_transform.py
+++ b/examples/basics/visuals/line_transform.py
@@ -84,7 +84,6 @@ class Canvas(app.Canvas):
         for line in self.lines:
             line.draw(line.tr_sys)
 
-
 if __name__ == '__main__':
     win = Canvas()
     import sys

--- a/examples/basics/visuals/markers.py
+++ b/examples/basics/visuals/markers.py
@@ -39,6 +39,8 @@ class Canvas(app.Canvas):
         self.markers.set_data(pos, face_color=colors)
         self.markers.set_style(visuals.marker_types[self.index])
 
+        self.show()
+
     def on_draw(self, event):
         gloo.clear(color='white')
         self.markers.draw(self.tr_sys)
@@ -53,7 +55,7 @@ class Canvas(app.Canvas):
         self.apply_zoom()
 
     def apply_zoom(self):
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.tr_sys.visual_to_document.scale = (self.scale, self.scale)
         self.update()
 
@@ -65,5 +67,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     canvas = Canvas()
-    canvas.show()
     app.run()

--- a/examples/basics/visuals/mesh.py
+++ b/examples/basics/visuals/mesh.py
@@ -15,8 +15,7 @@ from vispy.visuals.transforms import (STTransform, AffineTransform,
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
+        app.Canvas.__init__(self, keys='interactive', size=(800, 550))
         
         self.meshes = []
         self.rotation = AffineTransform()
@@ -81,7 +80,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_draw(self, ev):
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         gloo.clear(color='black', depth=True)
         for mesh in self.meshes:
             mesh.draw(mesh.tr_sys)

--- a/examples/basics/visuals/modular_line.py
+++ b/examples/basics/visuals/modular_line.py
@@ -24,16 +24,16 @@ color[:, 1] = color[::-1, 0]
 
 class Canvas(app.Canvas):
     def __init__(self):
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
+
         self.line = ModularLine(pos=pos, color=color)
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
         self.tr_sys = visuals.transforms.TransformSystem(self)
         self.show()
 
     def on_draw(self, ev):
         gloo.set_clear_color('black')
         gloo.clear(color=True, depth=True)
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.line.draw(self.tr_sys)
 
 

--- a/examples/basics/visuals/modular_mesh.py
+++ b/examples/basics/visuals/modular_mesh.py
@@ -20,7 +20,7 @@ from vispy.visuals.transforms import (STTransform, AffineTransform,
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
+        app.Canvas.__init__(self, keys='interactive', size=(800, 550))
         
         self.meshes = []
         self.rotation = AffineTransform()
@@ -101,7 +101,6 @@ class Canvas(app.Canvas):
             mesh.tr_sys = visuals.transforms.TransformSystem(self)
             mesh.tr_sys.visual_to_document = mesh.transform
 
-        self.size = (800, 800)
         self.show()
 
         self.timer = app.Timer(connect=self.rotate)

--- a/examples/basics/visuals/modular_point.py
+++ b/examples/basics/visuals/modular_point.py
@@ -19,16 +19,15 @@ pos[:, 1] = np.random.normal(size=N, scale=100, loc=400).astype(np.float32)
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
         self.points = ModularPoint(pos, color=(0, 1, 0, 1))
         self.tr_sys = visuals.transforms.TransformSystem(self)
-        self.size = (800, 800)
         self.show()
 
     def on_draw(self, ev):
         gloo.set_clear_color('black')
         gloo.clear(color=True, depth=True)
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.points.draw(self.tr_sys)
 
 

--- a/examples/basics/visuals/polygon_visual.py
+++ b/examples/basics/visuals/polygon_visual.py
@@ -44,8 +44,7 @@ pos[-1] = pos[0]
 
 class Canvas(app.Canvas):
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = (800, 800)
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
         global pos
         self.visuals = []
         polygon = visuals.PolygonVisual(pos=pos, color=(0.8, .2, 0, 1),
@@ -86,7 +85,7 @@ class Canvas(app.Canvas):
 
     def on_draw(self, ev):
         gloo.set_clear_color((0, 0, 0, 1))
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         gloo.clear()
         for vis in self.visuals:
             vis.draw(vis.tr_sys)

--- a/examples/basics/visuals/text_visual.py
+++ b/examples/basics/visuals/text_visual.py
@@ -18,7 +18,7 @@ class Canvas(app.Canvas):
 
     def on_draw(self, event):
         gloo.clear(color='white')
-        gloo.set_viewport(0, 0, *self.size)
+        gloo.set_viewport(0, 0, *self.physical_size)
         self.text.draw(self.tr_sys)
 
     def on_mouse_wheel(self, event):

--- a/examples/benchmark/scene_test_1.py
+++ b/examples/benchmark/scene_test_1.py
@@ -87,15 +87,19 @@ class PanZoomTransform(BaseTransform):
 
 class PanZoomCanvas(app.Canvas):
     def __init__(self, **kwargs):
-        super(PanZoomCanvas, self).__init__(keys='interactive',
-                                            show=True, **kwargs)
+        super(PanZoomCanvas, self).__init__(keys='interactive', **kwargs)
         self._visuals = []
 
         self._pz = PanZoomTransform()
         self._pz.pan = Variable('uniform vec2 u_pan', (0, 0))
         self._pz.zoom = Variable('uniform vec2 u_zoom', (1, 1))
 
+        self.width, self.height = self.size
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+
         self._tr = TransformSystem(self)
+
+        self.show()
 
     def on_initialize(self, event):
         gloo.set_state(clear_color='black', blend=True,
@@ -103,7 +107,7 @@ class PanZoomCanvas(app.Canvas):
 
     def on_resize(self, event):
         self.width, self.height = event.size
-        gloo.set_viewport(0, 0, self.width, self.height)
+        gloo.set_viewport(0, 0, event.physical_size[0], event.physical_size[1])
 
     def _normalize(self, x_y):
         x, y = x_y

--- a/examples/demo/gloo/atom.py
+++ b/examples/demo/gloo/atom.py
@@ -102,14 +102,13 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 800, 800
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
         self.title = "Atom [zoom with mouse scroll"
 
         self.program = gloo.Program(vert, frag)
         self.view = np.eye(4, dtype=np.float32)
         self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
+        self.apply_zoom()
         self.translate = 6.5
         translate(self.view, 0, 0, -self.translate)
 
@@ -128,6 +127,8 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
+        self.show()
+
     def on_key_press(self, event):
         if event.text == ' ':
             self.stop_rotation = not self.stop_rotation
@@ -145,10 +146,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection
+        self.apply_zoom()
 
     def on_mouse_wheel(self, event):
         self.translate += event.delta[1]
@@ -164,8 +162,13 @@ class Canvas(app.Canvas):
         gloo.clear('black')
         self.program.draw('points')
 
+    def apply_zoom(self):
+        width, height = self.physical_size
+        gloo.set_viewport(0, 0, width, height)
+        self.projection = perspective(45.0, width / float(height), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
+
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/boids.py
+++ b/examples/demo/gloo/boids.py
@@ -78,6 +78,9 @@ class Canvas(app.Canvas):
         self._pos = 0.0, 0.0
         self._button = None
 
+        width, height = self.physical_size
+        gloo.set_viewport(0, 0, width, height)
+
         # Create program
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
 
@@ -96,8 +99,10 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_mouse_press(self, event):
@@ -180,5 +185,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/boids.py
+++ b/examples/demo/gloo/boids.py
@@ -55,11 +55,11 @@ class Canvas(app.Canvas):
         # Create boids
         n = 1000
         self.particles = np.zeros(2 + n, [('position', 'f4', 3),
-                                     ('position_1', 'f4', 3),
-                                     ('position_2', 'f4', 3),
-                                     ('velocity', 'f4', 3),
-                                     ('color', 'f4', 4),
-                                     ('size', 'f4', 1*ps)])
+                                          ('position_1', 'f4', 3),
+                                          ('position_2', 'f4', 3),
+                                          ('velocity', 'f4', 3),
+                                          ('color', 'f4', 4),
+                                          ('size', 'f4', 1*ps)])
         self.boids = self.particles[2:]
         self.target = self.particles[0]
         self.predator = self.particles[1]
@@ -176,7 +176,8 @@ class Canvas(app.Canvas):
         D = np.repeat(D, 3, axis=0).reshape(n, 3)
         dP *= D
 
-        #self.boids['velocity'] += 0.0005*C + 0.01*A + 0.01*R + 0.0005*T + 0.0025*dP
+        #self.boids['velocity'] += 0.0005*C + 0.01*A + 0.01*R +
+        #                           0.0005*T + 0.0025*dP
         self.boids['velocity'] += 0.0005 * C + 0.01 * \
             A + 0.01 * R + 0.0005 * T + 0.025 * dP
         self.boids['position'] += self.boids['velocity']

--- a/examples/demo/gloo/boids.py
+++ b/examples/demo/gloo/boids.py
@@ -17,29 +17,6 @@ from scipy.spatial import cKDTree
 from vispy import gloo
 from vispy import app
 
-# Create boids
-n = 1000
-particles = np.zeros(2 + n, [('position', 'f4', 3),
-                             ('position_1', 'f4', 3),
-                             ('position_2', 'f4', 3),
-                             ('velocity', 'f4', 3),
-                             ('color', 'f4', 4),
-                             ('size', 'f4', 1)])
-boids = particles[2:]
-target = particles[0]
-predator = particles[1]
-
-boids['position'] = np.random.uniform(-0.25, +0.25, (n, 3))
-boids['velocity'] = np.random.uniform(-0.00, +0.00, (n, 3))
-boids['size'] = 4
-boids['color'] = 1, 1, 1, 1
-
-target['size'] = 16
-target['color'][:] = 1, 1, 0, 1
-predator['size'] = 16
-predator['color'][:] = 1, 0, 0, 1
-target['position'][:] = 0.25, 0.0, 0
-
 VERT_SHADER = """
 #version 120
 attribute vec3 position;
@@ -73,6 +50,31 @@ class Canvas(app.Canvas):
     def __init__(self):
         app.Canvas.__init__(self, keys='interactive')
 
+        ps = self.pixel_scale
+
+        # Create boids
+        n = 1000
+        self.particles = np.zeros(2 + n, [('position', 'f4', 3),
+                                     ('position_1', 'f4', 3),
+                                     ('position_2', 'f4', 3),
+                                     ('velocity', 'f4', 3),
+                                     ('color', 'f4', 4),
+                                     ('size', 'f4', 1*ps)])
+        self.boids = self.particles[2:]
+        self.target = self.particles[0]
+        self.predator = self.particles[1]
+
+        self.boids['position'] = np.random.uniform(-0.25, +0.25, (n, 3))
+        self.boids['velocity'] = np.random.uniform(-0.00, +0.00, (n, 3))
+        self.boids['size'] = 4*ps
+        self.boids['color'] = 1, 1, 1, 1
+
+        self.target['size'] = 16*ps
+        self.target['color'][:] = 1, 1, 0, 1
+        self.predator['size'] = 16*ps
+        self.predator['color'][:] = 1, 0, 0, 1
+        self.target['position'][:] = 0.25, 0.0, 0
+
         # Time
         self._t = time.time()
         self._pos = 0.0, 0.0
@@ -85,9 +87,10 @@ class Canvas(app.Canvas):
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
 
         # Create vertex buffers
-        self.vbo_position = gloo.VertexBuffer(particles['position'].copy())
-        self.vbo_color = gloo.VertexBuffer(particles['color'].copy())
-        self.vbo_size = gloo.VertexBuffer(particles['size'].copy())
+        self.vbo_position = gloo.VertexBuffer(self.particles['position']
+                                              .copy())
+        self.vbo_color = gloo.VertexBuffer(self.particles['color'].copy())
+        self.vbo_size = gloo.VertexBuffer(self.particles['size'].copy())
 
         # Bind vertex buffers
         self.program['color'] = self.vbo_color
@@ -122,9 +125,9 @@ class Canvas(app.Canvas):
         sy = - (2 * y / float(h) - 1.0)
 
         if self._button == 1:
-            target['position'][:] = sx, sy, 0
+            self.target['position'][:] = sx, sy, 0
         elif self._button == 2:
-            predator['position'][:] = sx, sy, 0
+            self.predator['position'][:] = sx, sy, 0
 
     def on_draw(self, event):
         gloo.clear()
@@ -137,16 +140,16 @@ class Canvas(app.Canvas):
         t = self._t
 
         t += 0.5 * dt
-        #target[...] = np.array([np.sin(t),np.sin(2*t),np.cos(3*t)])*.1
+        #self.target[...] = np.array([np.sin(t),np.sin(2*t),np.cos(3*t)])*.1
 
         t += 0.5 * dt
-        #predator[...] = np.array([np.sin(t),np.sin(2*t),np.cos(3*t)])*.2
+        #self.predator[...] = np.array([np.sin(t),np.sin(2*t),np.cos(3*t)])*.2
 
-        boids['position_2'] = boids['position_1']
-        boids['position_1'] = boids['position']
-        n = len(boids)
-        P = boids['position']
-        V = boids['velocity']
+        self.boids['position_2'] = self.boids['position_1']
+        self.boids['position_1'] = self.boids['position']
+        n = len(self.boids)
+        P = self.boids['position']
+        V = self.boids['velocity']
 
         # Cohesion: steer to move toward the average position of local
         # flockmates
@@ -162,10 +165,10 @@ class Canvas(app.Canvas):
         R = -((P[I] - Z) * M).sum(axis=1)
 
         # Target : Follow target
-        T = target['position'] - P
+        T = self.target['position'] - P
 
         # Predator : Move away from predator
-        dP = P - predator['position']
+        dP = P - self.predator['position']
         D = np.maximum(0, 0.3 -
                        np.sqrt(dP[:, 0] ** 2 +
                                dP[:, 1] ** 2 +
@@ -173,12 +176,12 @@ class Canvas(app.Canvas):
         D = np.repeat(D, 3, axis=0).reshape(n, 3)
         dP *= D
 
-        #boids['velocity'] += 0.0005*C + 0.01*A + 0.01*R + 0.0005*T + 0.0025*dP
-        boids['velocity'] += 0.0005 * C + 0.01 * \
+        #self.boids['velocity'] += 0.0005*C + 0.01*A + 0.01*R + 0.0005*T + 0.0025*dP
+        self.boids['velocity'] += 0.0005 * C + 0.01 * \
             A + 0.01 * R + 0.0005 * T + 0.025 * dP
-        boids['position'] += boids['velocity']
+        self.boids['position'] += self.boids['velocity']
 
-        self.vbo_position.set_data(particles['position'].copy())
+        self.vbo_position.set_data(self.particles['position'].copy())
 
         return t
 

--- a/examples/demo/gloo/brain.py
+++ b/examples/demo/gloo/brain.py
@@ -105,6 +105,8 @@ class Canvas(app.Canvas):
         self.program['u_light_position'] = (1., 1., 1.)
         self.program['u_light_intensity'] = (1., 1., 1.)
 
+        self.apply_zoom()
+
         gloo.set_state(blend=False, depth_test=True, polygon_offset_fill=True)
 
         self._t0 = default_timer()
@@ -134,10 +136,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 1.0, 20.0)
-        self.program['u_projection'] = self.projection
+        self.apply_zoom()
 
     def on_mouse_wheel(self, event):
         self.translate += -event.delta[1]/5.
@@ -148,6 +147,12 @@ class Canvas(app.Canvas):
     def on_draw(self, event):
         gloo.clear()
         self.program.draw('triangles', indices=self.faces)
+
+    def apply_zoom(self):
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 20.0)
+        self.program['u_projection'] = self.projection
 
 if __name__ == '__main__':
     c = Canvas()

--- a/examples/demo/gloo/camera.py
+++ b/examples/demo/gloo/camera.py
@@ -49,13 +49,19 @@ class Canvas(app.Canvas):
         self.program['position'] = [(-1, -1), (-1, +1), (+1, -1), (+1, +1)]
         self.program['texcoord'] = [(1, 1), (1, 0), (0, 1), (0, 0)]
         self.program['texture'] = np.zeros((480, 640, 3)).astype(np.uint8)
+
+        width, height = self.physical_size
+        gloo.set_viewport(0, 0, width, height)
+
         self.cap = cv2.VideoCapture(0)
         if not self.cap.isOpened():
             raise Exception("There's no available camera.")
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -68,6 +74,5 @@ class Canvas(app.Canvas):
         self.update()
         
 c = Canvas()
-c.show()
 app.run()
 c.cap.release()

--- a/examples/demo/gloo/cloud.py
+++ b/examples/demo/gloo/cloud.py
@@ -230,7 +230,6 @@ class Canvas(app.Canvas):
         data['a_size'] = np.random.uniform(5*ps, 10*ps, n)
         u_linewidth = 1.0
         u_antialias = 1.0
-        u_size = 1
 
         self.program = gloo.Program(vert, frag)
         self.view = np.eye(4, dtype=np.float32)
@@ -294,7 +293,6 @@ class Canvas(app.Canvas):
         self.projection = perspective(45.0, self.size[0] /
                                       float(self.size[1]), 1.0, 1000.0)
         self.program['u_projection'] = self.projection
-
 
 
 if __name__ == '__main__':

--- a/examples/demo/gloo/cloud.py
+++ b/examples/demo/gloo/cloud.py
@@ -12,22 +12,6 @@ from vispy import gloo
 from vispy import app
 from vispy.util.transforms import perspective, translate, rotate
 
-
-# Create vertices
-n = 1000000
-data = np.zeros(n, [('a_position', np.float32, 3),
-                    ('a_bg_color', np.float32, 4),
-                    ('a_fg_color', np.float32, 4),
-                    ('a_size', np.float32, 1)])
-data['a_position'] = 0.45 * np.random.randn(n, 3)
-data['a_bg_color'] = np.random.uniform(0.85, 1.00, (n, 4))
-data['a_fg_color'] = 0, 0, 0, 1
-data['a_size'] = np.random.uniform(5, 10, n)
-u_linewidth = 1.0
-u_antialias = 1.0
-u_size = 1
-
-
 vert = """
 #version 120
 
@@ -231,15 +215,30 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 800, 600
+        app.Canvas.__init__(self, keys='interactive', size=(800, 600))
+        ps = self.pixel_scale
+
+        # Create vertices
+        n = 1000000
+        data = np.zeros(n, [('a_position', np.float32, 3),
+                            ('a_bg_color', np.float32, 4),
+                            ('a_fg_color', np.float32, 4),
+                            ('a_size', np.float32, 1)])
+        data['a_position'] = 0.45 * np.random.randn(n, 3)
+        data['a_bg_color'] = np.random.uniform(0.85, 1.00, (n, 4))
+        data['a_fg_color'] = 0, 0, 0, 1
+        data['a_size'] = np.random.uniform(5*ps, 10*ps, n)
+        u_linewidth = 1.0
+        u_antialias = 1.0
+        u_size = 1
 
         self.program = gloo.Program(vert, frag)
         self.view = np.eye(4, dtype=np.float32)
         self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
         self.translate = 5
         translate(self.view, 0, 0, -self.translate)
+
+        self.apply_zoom()
 
         self.program.bind(gloo.VertexBuffer(data))
         self.program['u_linewidth'] = u_linewidth
@@ -254,6 +253,8 @@ class Canvas(app.Canvas):
         gloo.set_state('translucent', clear_color='white')
 
         self.timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show()
 
     def on_key_press(self, event):
         if event.text == ' ':
@@ -272,10 +273,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection
+        self.apply_zoom()
 
     def on_mouse_wheel(self, event):
         self.translate += event.delta[1]
@@ -291,8 +289,14 @@ class Canvas(app.Canvas):
         gloo.clear()
         self.program.draw('points')
 
+    def apply_zoom(self):
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
+
+
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/donut.py
+++ b/examples/demo/gloo/donut.py
@@ -123,7 +123,6 @@ class Canvas(app.Canvas):
         data['a_size'] = 8.0*ps
         u_linewidth = 1.0*ps
         u_antialias = 1.0
-        u_size = 1
 
         self.program = gloo.Program(vert, frag)
         self.view = np.eye(4, dtype=np.float32)

--- a/examples/demo/gloo/donut.py
+++ b/examples/demo/gloo/donut.py
@@ -16,23 +16,6 @@ from vispy import gloo
 from vispy import app
 from vispy.util.transforms import perspective, translate, rotate
 
-# Create vertices
-n, p = 50, 40
-data = np.zeros(p * n, [('a_position', np.float32, 2),
-                        ('a_bg_color', np.float32, 4),
-                        ('a_fg_color', np.float32, 4),
-                        ('a_size',     np.float32, 1)])
-data['a_position'][:, 0] = np.resize(np.linspace(0, 2 * np.pi, n), p * n)
-data['a_position'][:, 1] = np.repeat(np.linspace(0, 2 * np.pi, p), n)
-data['a_bg_color'] = np.random.uniform(0.75, 1.00, (n * p, 4))
-data['a_bg_color'][:, 3] = 1
-data['a_fg_color'] = 0, 0, 0, 1
-data['a_size'] = np.random.uniform(8, 8, n * p)
-u_linewidth = 1.0
-u_antialias = 1.0
-u_size = 1
-
-
 vert = """
 #version 120
 
@@ -119,9 +102,28 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 800, 800
-        self.title = "D'oh ! A big donut"
+        app.Canvas.__init__(self, keys='interactive', size=(800, 800))
+        ps = self.pixel_scale
+
+        self.title = "D'oh! A big donut"
+
+        # Create vertices
+        n, p = 50, 40
+        data = np.zeros(p * n, [('a_position', np.float32, 2),
+                                ('a_bg_color', np.float32, 4),
+                                ('a_fg_color', np.float32, 4),
+                                ('a_size',     np.float32, 1)])
+        data['a_position'][:, 0] = np.resize(np.linspace(
+                                             0, 2 * np.pi, n), p * n)
+        data['a_position'][:, 1] = np.repeat(np.linspace(0, 2 * np.pi, p), n)
+        data['a_bg_color'] = np.random.uniform(0.75, 1.00, (n * p, 4))
+        data['a_bg_color'][:, 3] = 1
+        data['a_fg_color'] = 0, 0, 0, 1
+        # data['a_size'] = np.random.uniform(8*ps, 8*ps, n * p)
+        data['a_size'] = 8.0*ps
+        u_linewidth = 1.0*ps
+        u_antialias = 1.0
+        u_size = 1
 
         self.program = gloo.Program(vert, frag)
         self.view = np.eye(4, dtype=np.float32)
@@ -137,6 +139,8 @@ class Canvas(app.Canvas):
         self.program['u_view'] = self.view
         self.program['u_size'] = 5 / self.translate
 
+        self.apply_zoom()
+
         self.theta = 0
         self.phi = 0
         self.clock = 0
@@ -146,6 +150,8 @@ class Canvas(app.Canvas):
         self.program['u_clock'] = 0.0
 
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show()
 
     def on_key_press(self, event):
         if event.text == ' ':
@@ -164,10 +170,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection
+        self.apply_zoom()
 
     def on_mouse_wheel(self, event):
         self.translate += event.delta[1]
@@ -183,8 +186,13 @@ class Canvas(app.Canvas):
         gloo.clear()
         self.program.draw('points')
 
+    def apply_zoom(self):
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
+
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/fireworks.py
+++ b/examples/demo/gloo/fireworks.py
@@ -85,8 +85,7 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = 800, 600
+        app.Canvas.__init__(self, keys='interactive', size=(800, 600))
 
         # Create program
         self._program = gloo.Program(VERT_SHADER, FRAG_SHADER)
@@ -100,10 +99,14 @@ class Canvas(app.Canvas):
         gloo.set_state(blend=True, clear_color='black',
                        blend_func=('src_alpha', 'one'))
 
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
+        width, height = event.physical_size
         gloo.set_viewport(0, 0, width, height)
 
     def on_draw(self, event):
@@ -142,5 +145,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/galaxy.py
+++ b/examples/demo/gloo/galaxy.py
@@ -120,15 +120,14 @@ class Canvas(app.Canvas):
         self.title = "A very fake galaxy [mouse scroll to zoom]"
 
         data = np.zeros(n, [('a_position', np.float32, 3),
-                    ('a_size', np.float32, 1),
-                    ('a_dist', np.float32, 1)])
-        
+                        ('a_size', np.float32, 1),
+                        ('a_dist', np.float32, 1)])
+
         for i in range(3):
             P, S, D = make_arm(p, i * 2 * np.pi / 3)
             data['a_dist'][(i + 0) * p:(i + 1) * p] = D
             data['a_position'][(i + 0) * p:(i + 1) * p] = P
             data['a_size'][(i + 0) * p:(i + 1) * p] = S*ps
-
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         self.view = np.eye(4, dtype=np.float32)

--- a/examples/demo/gloo/galaxy/galaxy.py
+++ b/examples/demo/gloo/galaxy/galaxy.py
@@ -112,36 +112,13 @@ def load_galaxy_star_image():
 class Canvas(app.Canvas):
 
     def __init__(self):
-        # setup initial width, height
-        self.width = 800
-        self.height = 600
-        app.Canvas.__init__(self, keys='interactive')
-        self.size = self.width, self.height
+        self.width, self.height  = 800, 600
+
+        app.Canvas.__init__(self, keys='interactive', size=(self.width,
+                            self.height))
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
-    # create the numpy array corresponding to the shader data
-    def __create_galaxy_vertex_data(self):
-        data = np.zeros(len(galaxy),
-                        dtype=[('a_size', np.float32, 1),
-                               ('a_position', np.float32, 2),
-                               ('a_color_index', np.float32, 1),
-                               ('a_brightness', np.float32, 1),
-                               ('a_type', np.float32, 1)])
-
-        # see shader for parameter explanations
-        data['a_size'] = galaxy['size'] * max(self.width / 800.0,
-                                              self.height / 800.0)
-        data['a_position'] = galaxy['position'] / 13000.0
-
-        data['a_color_index'] = (galaxy['temperature'] - t0) / (t1 - t0)
-        data['a_brightness'] = galaxy['brightness']
-        data['a_type'] = galaxy['type']
-
-        return data
-
-    def on_initialize(self, event):
-        # create a new shader program
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER,
                                     count=len(galaxy))
 
@@ -176,6 +153,30 @@ class Canvas(app.Canvas):
         # setup blending
         self.__setup_blending_mode()
 
+        self.activate_zoom()
+
+        self.show()
+
+    # create the numpy array corresponding to the shader data
+    def __create_galaxy_vertex_data(self):
+        data = np.zeros(len(galaxy),
+                        dtype=[('a_size', np.float32, 1),
+                               ('a_position', np.float32, 2),
+                               ('a_color_index', np.float32, 1),
+                               ('a_brightness', np.float32, 1),
+                               ('a_type', np.float32, 1)])
+
+        # see shader for parameter explanations
+        data['a_size'] = galaxy['size'] * max(self.width / 800.0,
+                                              self.height / 800.0)
+        data['a_position'] = galaxy['position'] / 13000.0
+
+        data['a_color_index'] = (galaxy['temperature'] - t0) / (t1 - t0)
+        data['a_brightness'] = galaxy['brightness']
+        data['a_type'] = galaxy['type']
+
+        return data
+
     def __setup_blending_mode(self):
         # set the clear color to almost black
         gloo.gl.glClearColor(0.0, 0.0, 0.03, 1.0)
@@ -186,9 +187,12 @@ class Canvas(app.Canvas):
         gloo.gl.glBlendFunc(gloo.gl.GL_SRC_ALPHA, gloo.gl.GL_ONE)
 
     def on_resize(self, event):
-        self.width, self.height = event.size
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        self.width, self.height = self.size
         # setup the new viewport
-        gloo.set_viewport(0, 0, self.width, self.height)
+        gloo.set_viewport(0, 0, *self.physical_size)
         # recompute the projection matrix
         self.projection = perspective(45.0, self.width / float(self.height),
                                       1.0, 1000.0)
@@ -212,7 +216,6 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
 
     if sys.flags.interactive == 0:
         app.run()

--- a/examples/demo/gloo/game_of_life.py
+++ b/examples/demo/gloo/game_of_life.py
@@ -114,7 +114,7 @@ class Canvas(app.Canvas):
 
         # Build programs
         # --------------
-        self.comp_size = (512, 512)
+        self.comp_size = self.size
         size = self.comp_size + (4,)
         Z = np.zeros(size, dtype=np.float32)
         Z[...] = np.random.randint(0, 2, size)
@@ -159,24 +159,22 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_draw(self, event):
         with self.fbo:
             set_viewport(0, 0, *self.comp_size)
             self.compute["texture"].interpolation = 'nearest'
             self.compute.draw('triangle_strip')
         clear()
-        set_viewport(0, 0, *self.size)
+        set_viewport(0, 0, *self.physical_size)
         self.render["texture"].interpolation = 'linear'
         self.render.draw('triangle_strip')
         self.pingpong = 1 - self.pingpong
         self.compute["pingpong"] = self.pingpong
         self.render["pingpong"] = self.pingpong
 
-    def on_reshape(self, event):
-        set_viewport(0, 0, *event.size)
-
 
 if __name__ == '__main__':
     canvas = Canvas()
-    canvas.show()
     app.run()

--- a/examples/demo/gloo/glsl_sandbox_cube.py
+++ b/examples/demo/gloo/glsl_sandbox_cube.py
@@ -62,8 +62,7 @@ faces_buffer = gloo.IndexBuffer(faces.astype(np.uint16))
 class Canvas(app.Canvas):
 
     def __init__(self, **kwargs):
-        app.Canvas.__init__(self, **kwargs)
-        self.geometry = 0, 0, 400, 400
+        app.Canvas.__init__(self, size=(400,400), **kwargs)
 
         self.program = gloo.Program(VERT_CODE, FRAG_CODE)
 
@@ -76,17 +75,18 @@ class Canvas(app.Canvas):
         # Handle transformations
         self.init_transforms()
 
+        self.apply_zoom()
+
         gloo.set_clear_color((1, 1, 1, 1))
         gloo.set_state(depth_test=True)
 
         self._timer = app.Timer('auto', connect=self.update_transforms)
         self._timer.start()
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(45.0, width / float(height), 2.0, 10.0)
-        self.program['u_projection'] = self.projection
+        self.apply_zoom()
 
     def on_draw(self, event):
         gloo.clear()
@@ -112,6 +112,12 @@ class Canvas(app.Canvas):
         rotate(self.model, self.phi, 0, 1, 0)
         self.program['u_model'] = self.model
         self.update()
+
+    def apply_zoom(self):
+        gloo.set_viewport(0, 0, self.physical_size[0], self.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 2.0, 10.0)
+        self.program['u_projection'] = self.projection
 
 
 class TextField(QtGui.QPlainTextEdit):
@@ -161,6 +167,8 @@ class MainWindow(QtGui.QWidget):
         vlayout.addWidget(self.fragEdit, 1)
         vlayout.addWidget(self.theButton, 0)
 
+        self.show()
+
     def on_compile(self):
         vert_code = str(self.vertEdit.toPlainText())
         frag_code = str(self.fragEdit.toPlainText())
@@ -172,5 +180,4 @@ class MainWindow(QtGui.QWidget):
 if __name__ == '__main__':
     app.create()
     m = MainWindow()
-    m.show()
     app.run()

--- a/examples/demo/gloo/glsl_sandbox_cube.py
+++ b/examples/demo/gloo/glsl_sandbox_cube.py
@@ -62,7 +62,7 @@ faces_buffer = gloo.IndexBuffer(faces.astype(np.uint16))
 class Canvas(app.Canvas):
 
     def __init__(self, **kwargs):
-        app.Canvas.__init__(self, size=(400,400), **kwargs)
+        app.Canvas.__init__(self, size=(400, 400), **kwargs)
 
         self.program = gloo.Program(VERT_CODE, FRAG_CODE)
 

--- a/examples/demo/gloo/graph.py
+++ b/examples/demo/gloo/graph.py
@@ -124,31 +124,34 @@ void main(){
 }
 """
 
-n = 100
-ne = 100
-data = np.zeros(n, dtype=[('a_position', np.float32, 3),
-                          ('a_fg_color', np.float32, 4),
-                          ('a_bg_color', np.float32, 4),
-                          ('a_size', np.float32, 1),
-                          ('a_linewidth', np.float32, 1),
-                          ])
-edges = np.random.randint(size=(ne, 2), low=0, high=n).astype(np.uint32)
-data['a_position'] = np.hstack((.25 * np.random.randn(n, 2), np.zeros((n, 1))))
-data['a_fg_color'] = 0, 0, 0, 1
-color = np.random.uniform(0.5, 1., (n, 3))
-data['a_bg_color'] = np.hstack((color, np.ones((n, 1))))
-data['a_size'] = np.random.randint(size=n, low=10, high=30)
-data['a_linewidth'] = 2
-u_antialias = 1
-
 
 class Canvas(app.Canvas):
 
     def __init__(self, **kwargs):
         # Initialize the canvas for real
-        app.Canvas.__init__(self, keys='interactive', **kwargs)
-        self.size = 512, 512
+        app.Canvas.__init__(self, keys='interactive', size=(512, 512),
+                            **kwargs)
+        ps = self.pixel_scale
         self.position = 50, 50
+
+        n = 100
+        ne = 100
+        data = np.zeros(n, dtype=[('a_position', np.float32, 3),
+                                  ('a_fg_color', np.float32, 4),
+                                  ('a_bg_color', np.float32, 4),
+                                  ('a_size', np.float32, 1),
+                                  ('a_linewidth', np.float32, 1),
+                                  ])
+        edges = np.random.randint(size=(ne, 2), low=0,
+                                  high=n).astype(np.uint32)
+        data['a_position'] = np.hstack((.25 * np.random.randn(n, 2),
+                                       np.zeros((n, 1))))
+        data['a_fg_color'] = 0, 0, 0, 1
+        color = np.random.uniform(0.5, 1., (n, 3))
+        data['a_bg_color'] = np.hstack((color, np.ones((n, 1))))
+        data['a_size'] = np.random.randint(size=n, low=8*ps, high=20*ps)
+        data['a_linewidth'] = 1.*ps
+        u_antialias = 1
 
         self.vbo = gloo.VertexBuffer(data)
         self.index = gloo.IndexBuffer(edges)
@@ -164,15 +167,18 @@ class Canvas(app.Canvas):
         self.program['u_view'] = self.view
         self.program['u_projection'] = self.projection
 
+        set_viewport(0, 0, *self.physical_size)
+
         self.program_e = gloo.Program(vs, fs)
         self.program_e.bind(self.vbo)
 
         set_state(clear_color='white', depth_test=False, blend=True,
                   blend_func=('src_alpha', 'one_minus_src_alpha'))
 
+        self.show()
+
     def on_resize(self, event):
-        width, height = event.size
-        set_viewport(0, 0, width, height)
+        set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         clear(color=True, depth=True)
@@ -181,5 +187,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas(title="Graph")
-    c.show()
     app.run()

--- a/examples/demo/gloo/grayscott.py
+++ b/examples/demo/gloo/grayscott.py
@@ -128,7 +128,7 @@ class Canvas(app.Canvas):
                             size=(512, 512), keys='interactive')
 
         self.scale = 4
-        self.comp_size = (256, 256)
+        self.comp_size = self.size
         comp_w, comp_h = self.comp_size
         dt = 1.0
         dd = 1.5
@@ -184,13 +184,15 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_draw(self, event):
         with self.fbo:
             set_viewport(0, 0, *self.comp_size)
             self.compute["texture"].interpolation = 'nearest'
             self.compute.draw('triangle_strip')
         clear(color=True)
-        set_viewport(0, 0, *self.size)
+        set_viewport(0, 0, *self.physical_size)
         self.render["texture"].interpolation = 'linear'
         self.render.draw('triangle_strip')
         self.pingpong = 1 - self.pingpong
@@ -198,10 +200,9 @@ class Canvas(app.Canvas):
         self.render["pingpong"] = self.pingpong
 
     def on_resize(self, event):
-        set_viewport(0, 0, *self.size)
+        set_viewport(0, 0, *self.physical_size)
 
 
 if __name__ == '__main__':
     canvas = Canvas()
-    canvas.show()
     app.run()

--- a/examples/demo/gloo/high_frequency.py
+++ b/examples/demo/gloo/high_frequency.py
@@ -80,15 +80,18 @@ class Canvas(app.Canvas):
         self.program['a_position'] = [(-1, -1), (-1, +1),
                                       (+1, -1), (+1, +1)]
 
+        self.apply_zoom()
+
         gloo.set_state(blend=True,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
 
         self._timer = app.Timer('auto', connect=self.on_timer_event,
                                 start=True)
 
+        self.show()
+
     def on_resize(self, event):
-        self.program["u_resolution"] = event.size
-        gloo.set_viewport(0, 0, *event.size)
+        self.apply_zoom()
 
     def on_draw(self, event):
         gloo.clear('white')
@@ -106,8 +109,11 @@ class Canvas(app.Canvas):
             else:
                 self._timer.start()
 
+    def apply_zoom(self):
+        self.program["u_resolution"] = self.physical_size
+        gloo.set_viewport(0, 0, *self.physical_size)
+
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/imshow.py
+++ b/examples/demo/gloo/imshow.py
@@ -113,11 +113,11 @@ class Canvas(app.Canvas):
 
         set_clear_color('black')
 
-        self.show(True)
+        self.show()
 
     def on_resize(self, event):
-        width, height = event.size
-        set_viewport(0, 0, *event.size)
+        width, height = event.physical_size
+        set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         clear(color=True, depth=True)

--- a/examples/demo/gloo/imshow_cuts.py
+++ b/examples/demo/gloo/imshow_cuts.py
@@ -125,6 +125,8 @@ class Canvas(app.Canvas):
         self.image['image'] = I.astype('float32')
         self.image['image'].interpolation = 'linear'
 
+        set_viewport(0, 0, *self.physical_size)
+
         self.lines = Program(lines_vertex, lines_fragment)
         self.lines["position"] = np.zeros((4+4+514+514, 2), np.float32)
         color = np.zeros((4+4+514+514, 4), np.float32)
@@ -137,10 +139,10 @@ class Canvas(app.Canvas):
         set_state(clear_color='white', blend=True,
                   blend_func=('src_alpha', 'one_minus_src_alpha'))
 
-        self.show(True)
+        self.show()
 
     def on_resize(self, event):
-        set_viewport(0, 0, *event.size)
+        set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         clear(color=True, depth=True)
@@ -150,6 +152,11 @@ class Canvas(app.Canvas):
     def on_mouse_move(self, event):
         x, y = event.pos
         w, h = self.size
+
+        # Make sure the mouse isn't outside of the viewport.
+        x = max(0, min(x, w - 1))
+        y = max(0, min(y, h - 1))
+
         yf = 1 - y/(h/2.)
         xf = x/(w/2.) - 1
         P = np.zeros((4+4+514+514, 2), np.float32)
@@ -163,7 +170,7 @@ class Canvas(app.Canvas):
         y_baseline[...] = (xf, -1), (xf, -1), (xf, 1), (xf, 1)
 
         x_profile[1:-1, 0] = np.linspace(-1, 1, 512)
-        x_profile[1:-1, 1] = yf+0.15*I[y]
+        x_profile[1:-1, 1] = yf+0.15*I[y, :]
         x_profile[0] = x_profile[1]
         x_profile[-1] = x_profile[-2]
 

--- a/examples/demo/gloo/jfa/jfa_vispy.py
+++ b/examples/demo/gloo/jfa/jfa_vispy.py
@@ -53,6 +53,8 @@ class Canvas(app.Canvas):
             program.bind(vertices)
         self._timer = app.Timer('auto', self.update, start=True)
 
+        self.show()
+
     def _setup_textures(self, fname):
         data = imread(load_data_file('jfa/' + fname))[::-1].copy()
         if data.ndim == 3:
@@ -92,7 +94,7 @@ class Canvas(app.Canvas):
             self.programs[2]['texture'] = self.comp_texs[last_rend]
         else:
             self.programs[2]['texture'] = self.orig_tex
-        set_viewport(0, 0, *self.size)
+        set_viewport(0, 0, *self.physical_size)
         self.programs[2].draw('triangle_strip')
 
     def on_key_press(self, event):
@@ -110,7 +112,6 @@ def fun(x):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     c.measure_fps(callback=fun)
     if sys.flags.interactive != 1:
         c.app.run()

--- a/examples/demo/gloo/mandelbrot.py
+++ b/examples/demo/gloo/mandelbrot.py
@@ -94,7 +94,7 @@ class Canvas(app.Canvas):
         self.scale = self.program["scale"] = 3
         self.center = self.program["center"] = [-0.5, 0]
         self.iterations = self.program["iter"] = 300
-        self.program['resolution'] = self.size
+        self.apply_zoom()
 
         self.bounds = [-2, 2]
         self.min_scale = 0.00005
@@ -104,11 +104,16 @@ class Canvas(app.Canvas):
 
         self._timer = app.Timer('auto', connect=self.update, start=True)
 
+        self.show()
+
     def on_draw(self, event):
         self.program.draw()
 
     def on_resize(self, event):
-        width, height = event.size
+        self.apply_zoom()
+
+    def apply_zoom(self):
+        width, height = self.physical_size
         gloo.set_viewport(0, 0, width, height)
         self.program['resolution'] = [width, height]
 
@@ -154,7 +159,8 @@ class Canvas(app.Canvas):
         wheels :)
 
         """
-        if event.text == '+':
+
+        if event.text == '+' or event.text == '=':
             self.zoom(0.9)
         elif event.text == '-':
             self.zoom(1/0.9)
@@ -182,5 +188,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     canvas = Canvas(size=(800, 800), keys='interactive')
-    canvas.show()
     app.run()

--- a/examples/demo/gloo/mandelbrot_double.py
+++ b/examples/demo/gloo/mandelbrot_double.py
@@ -194,20 +194,23 @@ class Canvas(app.Canvas):
         self.translate_center(0, 0)
         self.iterations = self.program["iter"] = 300
 
-        width, height = self.size
-        self.program['inv_resolution_x'] = set_emulated_double(1 / width)
-        self.program['inv_resolution_y'] = set_emulated_double(1 / height)
+        self.apply_zoom()
 
         self.min_scale = 1e-12
         self.max_scale = 4
 
         gloo.set_clear_color(color='black')
 
+        self.show()
+
     def on_draw(self, event):
         self.program.draw()
 
     def on_resize(self, event):
-        width, height = event.size
+        self.apply_zoom()
+
+    def apply_zoom(self):
+        width, height = self.physical_size
         gloo.set_viewport(0, 0, width, height)
         self.program['inv_resolution_x'] = set_emulated_double(1 / width)
         self.program['inv_resolution_y'] = set_emulated_double(1 / height)
@@ -261,7 +264,7 @@ class Canvas(app.Canvas):
         wheels :)
 
         """
-        if event.text == '+':
+        if event.text == '+' or event.text == '=':
             self.zoom(0.9)
         elif event.text == '-':
             self.zoom(1/0.9)
@@ -296,5 +299,4 @@ def set_emulated_double(number):
 
 if __name__ == '__main__':
     canvas = Canvas(size=(800, 800), keys='interactive')
-    canvas.show()
     app.run()

--- a/examples/demo/gloo/molecular_viewer.py
+++ b/examples/demo/gloo/molecular_viewer.py
@@ -97,15 +97,16 @@ class Canvas(app.Canvas):
 
     def __init__(self):
         app.Canvas.__init__(self, title='Molecular viewer',
-                            keys='interactive')
-        self.size = 1200, 800
+                            keys='interactive', size=(1200, 800))
+        self.ps = self.pixel_scale
 
         self.program = gloo.Program(vertex, fragment)
         self.view = np.eye(4, dtype=np.float32)
         self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
         self.translate = 40
         translate(self.view, 0, 0, -self.translate)
+
+        self.apply_zoom()
 
         fname = load_data_file('molecular_viewer/micelle.npz')
         self.load_molecule(fname)
@@ -116,6 +117,8 @@ class Canvas(app.Canvas):
 
         gloo.set_state(depth_test=True, clear_color='black')
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show()
 
     def load_molecule(self, fname):
         molecule = np.load(fname)['molecule']
@@ -139,7 +142,7 @@ class Canvas(app.Canvas):
 
         data['a_position'] = self.coords
         data['a_color'] = self.atomsColours
-        data['a_radius'] = self.atomsScales
+        data['a_radius'] = self.atomsScales*self.ps
 
         self.program.bind(gloo.VertexBuffer(data))
 
@@ -170,6 +173,9 @@ class Canvas(app.Canvas):
 
     def on_resize(self, event):
         width, height = event.size
+
+    def apply_zoom(self):
+        width, height = self.physical_size
         gloo.set_viewport(0, 0, width, height)
         self.projection = perspective(25.0, width / float(height), 2.0, 100.0)
         self.program['u_projection'] = self.projection
@@ -191,5 +197,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     mvc = Canvas()
-    mvc.show()
     app.run()

--- a/examples/demo/gloo/rain.py
+++ b/examples/demo/gloo/rain.py
@@ -104,18 +104,27 @@ class Canvas(app.Canvas):
         self.program['u_linewidth'] = 1.00
         self.program['u_model'] = np.eye(4, dtype=np.float32)
         self.program['u_view'] = np.eye(4, dtype=np.float32)
+
+        self.activate_zoom()
+
         gloo.set_clear_color('white')
         gloo.set_state(blend=True,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
         self.timer = app.Timer('auto', self.on_timer, start=True)
+
+        self.show()
 
     def on_draw(self, event):
         gloo.clear()
         self.program.draw('points')
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
-        projection = ortho(0, event.size[0], 0, event.size[1], -1, +1)
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        projection = ortho(0, self.size[0], 0,
+                           self.size[1], -1, +1)
         self.program['u_projection'] = projection
 
     def on_timer(self, event):
@@ -135,5 +144,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     canvas = Canvas()
-    canvas.show()
     app.run()

--- a/examples/demo/gloo/realtime_signals.py
+++ b/examples/demo/gloo/realtime_signals.py
@@ -127,14 +127,17 @@ class Canvas(app.Canvas):
         self.program['u_size'] = (nrows, ncols)
         self.program['u_n'] = n
 
+        gloo.set_viewport(0, 0, *self.physical_size)
+
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
 
         gloo.set_state(clear_color='black', blend=True,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
 
+        self.show()
+
     def on_resize(self, event):
-        self.width, self.height = event.size
-        gloo.set_viewport(0, 0, self.width, self.height)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
     def on_mouse_wheel(self, event):
         dx = np.sign(event.delta[1]) * .05
@@ -159,5 +162,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/shadertoy.py
+++ b/examples/demo/gloo/shadertoy.py
@@ -122,7 +122,8 @@ class Canvas(app.Canvas):
 
     def activate_zoom(self):
         gloo.set_viewport(0, 0, *self.physical_size)
-        self.program['iResolution'] = (self.physical_size[0], self.physical_size[1], 0.)
+        self.program['iResolution'] = (self.physical_size[0],
+                                       self.physical_size[1], 0.)
 
 # -------------------------------------------------------------------------
 # COPY-PASTE SHADERTOY CODE BELOW

--- a/examples/demo/gloo/shadertoy.py
+++ b/examples/demo/gloo/shadertoy.py
@@ -59,7 +59,7 @@ def get_idate():
 
 def noise(resolution=64, nchannels=1):
     # Random texture.
-    return np.random.randint(low=0, high=256, 
+    return np.random.randint(low=0, high=256,
                              size=(resolution, resolution, nchannels)
                              ).astype(np.uint8)
 
@@ -83,7 +83,12 @@ class Canvas(app.Canvas):
         self.program['iSampleRate'] = 44100.
         for i in range(4):
             self.program['iChannelTime[%d]' % i] = 0.
+
+        self.activate_zoom()
+
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
+
+        self.show()
 
     def set_channel_input(self, img, i=0):
         tex = gloo.Texture2D(img)
@@ -91,7 +96,7 @@ class Canvas(app.Canvas):
         tex.wrapping = 'repeat'
         self.program['iChannel%d' % i] = tex
         self.program['iChannelResolution[%d]' % i] = img.shape
-        
+
     def on_draw(self, event):
         self.program.draw()
 
@@ -106,17 +111,19 @@ class Canvas(app.Canvas):
             px, py = event.press_event.pos
             imouse = (x, self.size[1] - y, px, self.size[1] - py)
             self.program['iMouse'] = imouse
-        
+
     def on_timer(self, event):
         self.program['iGlobalTime'] = event.elapsed
         self.program['iDate'] = get_idate()  # used in some shadertoy examples
         self.update()
-        
+
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.program['iResolution'] = (width, height, 0.)
-        
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        self.program['iResolution'] = (self.physical_size[0], self.physical_size[1], 0.)
+
 # -------------------------------------------------------------------------
 # COPY-PASTE SHADERTOY CODE BELOW
 # -------------------------------------------------------------------------
@@ -124,7 +131,7 @@ SHADERTOY = """
 // From: https://www.shadertoy.com/view/MdX3Rr
 
 // Created by inigo quilez - iq/2013
-// License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 
+// License Creative Commons Attribution-NonCommercial-ShareAlike 3.0
 // Unported License.
 
 //stereo thanks to Croqueteer
@@ -142,7 +149,7 @@ vec3 noised( in vec2 x )
     float b = texture2D(iChannel0,(p+vec2(1.5,0.5))/256.0,-100.0).x;
     float c = texture2D(iChannel0,(p+vec2(0.5,1.5))/256.0,-100.0).x;
     float d = texture2D(iChannel0,(p+vec2(1.5,1.5))/256.0,-100.0).x;
-    
+
     return vec3(a+(b-a)*u.x+(c-a)*u.y+(a-b-c+d)*u.x*u.y,
                 6.0*f*(1.0-f)*(vec2(b-a,c-a)+(a-b-c+d)*u.yx));
 }
@@ -233,10 +240,10 @@ float interesct( in vec3 ro, in vec3 rd )
 float sinteresct(in vec3 ro, in vec3 rd )
 {
 #if 0
-    // no shadows	
+    // no shadows
     return 1.0;
 #endif
-    
+
 #if 0
     // fake shadows
     vec3 nor;
@@ -247,9 +254,9 @@ float sinteresct(in vec3 ro, in vec3 rd )
     nor = normalize(nor);
     return clamp( 4.0*dot(nor,rd), 0.0, 1.0 );
 #endif
-    
+
 #if 1
-    // real shadows	
+    // real shadows
     float res = 1.0;
     float t = 0.0;
     for( int j=0; j<48; j++ )
@@ -279,7 +286,7 @@ vec3 calcNormal( in vec3 pos, float t )
     nor.x = terrain2(pos.xz-eps.xy) - terrain2(pos.xz+eps.xy);
     nor.y = 2.0*e;
     nor.z = terrain2(pos.xz-eps.yx) - terrain2(pos.xz+eps.yx);
-#endif	
+#endif
     return normalize(nor);
 }
 
@@ -290,7 +297,7 @@ vec3 camPath( float time )
     return vec3( p.x, 0.0, p.y );
 }
 
-    
+
 float fbm( vec2 p )
 {
     float f = 0.0;
@@ -313,11 +320,11 @@ void main(void)
     #ifdef STEREO
     float isCyan = mod(gl_FragCoord.x + mod(gl_FragCoord.y,2.0),2.0);
     #endif
-    
+
     float time = iGlobalTime*0.15 + 0.3 + 4.0*iMouse.x/iResolution.x;
-    
+
     vec3 light1 = normalize( vec3(-0.8,0.4,-0.3) );
-    
+
 
 
     vec3 ro = camPath( time );
@@ -341,25 +348,25 @@ void main(void)
     float t = interesct( ro, rd );
     if( t<0.0 )
     {
-        // sky		
+        // sky
         col = vec3(0.3,.55,0.8)*(1.0-0.8*rd.y);
         col += 0.25*vec3(1.0,0.7,0.4)*pow( sundot,5.0 );
         col += 0.25*vec3(1.0,0.8,0.6)*pow( sundot,64.0 );
         col += 0.2*vec3(1.0,0.8,0.6)*pow( sundot,512.0 );
         vec2 sc = ro.xz + rd.xz*(1000.0-ro.y)/rd.y;
-        col = mix( col, vec3(1.0,0.95,1.0), 
+        col = mix( col, vec3(1.0,0.95,1.0),
             0.5*smoothstep(0.5,0.8,fbm(0.0005*sc)) );
     }
     else
     {
-        // mountains		
+        // mountains
         vec3 pos = ro + t*rd;
 
         vec3 nor = calcNormal( pos, t );
 
         float r = texture2D( iChannel0, 7.0*pos.xz/256.0 ).x;
 
-        col = (r*0.25+0.75)*0.9*mix( vec3(0.08,0.05,0.03), 
+        col = (r*0.25+0.75)*0.9*mix( vec3(0.08,0.05,0.03),
             vec3(0.10,0.09,0.08), texture2D(iChannel0,0.00007*vec2(
                 pos.x,pos.y*48.0)).x );
         col = mix( col, 0.20*vec3(0.45,.30,0.15)*(0.50+0.50*r),
@@ -372,44 +379,44 @@ void main(void)
         float e = smoothstep(1.0-0.5*h,1.0-0.1*h,nor.y);
         float o = 0.3 + 0.7*smoothstep(0.0,0.1,nor.x+h*h);
         float s = h*e*o;
-        col = mix( col, 0.29*vec3(0.62,0.65,0.7), smoothstep( 
+        col = mix( col, 0.29*vec3(0.62,0.65,0.7), smoothstep(
             0.1, 0.9, s ) );
-        
-         // lighting		
+
+         // lighting
         float amb = clamp(0.5+0.5*nor.y,0.0,1.0);
         float dif = clamp( dot( light1, nor ), 0.0, 1.0 );
-        float bac = clamp( 0.2 + 0.8*dot( normalize( 
+        float bac = clamp( 0.2 + 0.8*dot( normalize(
             vec3(-light1.x, 0.0, light1.z ) ), nor ), 0.0, 1.0 );
         float sh = 1.0; if( dif>=0.0001 ) sh = sinteresct(
             pos+light1*20.0,light1);
-        
+
         vec3 lin  = vec3(0.0);
-        lin += dif*vec3(7.00,5.00,3.00)*vec3( sh, sh*sh*0.5+0.5*sh, 
+        lin += dif*vec3(7.00,5.00,3.00)*vec3( sh, sh*sh*0.5+0.5*sh,
             sh*sh*0.8+0.2*sh );
         lin += amb*vec3(0.40,0.60,0.80)*1.5;
         lin += bac*vec3(0.40,0.50,0.60);
         col *= lin;
 
-        
+
         float fo = 1.0-exp(-0.0005*t);
-        vec3 fco = 0.55*vec3(0.55,0.65,0.75) + 0.1*vec3(1.0,0.8,0.5)*pow( 
+        vec3 fco = 0.55*vec3(0.55,0.65,0.75) + 0.1*vec3(1.0,0.8,0.5)*pow(
             sundot, 4.0 );
         col = mix( col, fco, fo );
 
-        col += 0.3*vec3(1.0,0.8,0.4)*pow( sundot, 
+        col += 0.3*vec3(1.0,0.8,0.4)*pow( sundot,
                     8.0 )*(1.0-exp(-0.002*t));
     }
 
     col = pow(col,vec3(0.4545));
 
-    // vignetting	
-    col *= 0.5 + 0.5*pow( (xy.x+1.0)*(xy.y+1.0)*(xy.x-1.0)*(xy.y-1.0), 
+    // vignetting
+    col *= 0.5 + 0.5*pow( (xy.x+1.0)*(xy.y+1.0)*(xy.x-1.0)*(xy.y-1.0),
                          0.1 );
-    
-    #ifdef STEREO	
-    col *= vec3( isCyan, 1.0-isCyan, 1.0-isCyan );	
+
+    #ifdef STEREO
+    col *= vec3( isCyan, 1.0-isCyan, 1.0-isCyan );
     #endif
-    
+
 //	col *= smoothstep( 0.0, 2.0, iGlobalTime );
 
     gl_FragColor=vec4(col,1.0);
@@ -420,9 +427,9 @@ void main(void)
 canvas = Canvas(SHADERTOY)
 # Input data.
 canvas.set_channel_input(noise(resolution=256, nchannels=1), i=0)
-    
+
 if __name__ == '__main__':
-    
+
     canvas.show()
     if sys.flags.interactive == 0:
         canvas.app.run()

--- a/examples/demo/gloo/signals.py
+++ b/examples/demo/gloo/signals.py
@@ -76,12 +76,15 @@ class Canvas(app.Canvas):
         self.program['u_pan'] = (0., 0.)
         self.program['u_scale'] = (1., 1.)
 
+        gloo.set_viewport(0, 0, *self.physical_size)
+
         gloo.set_state(clear_color=(1, 1, 1, 1), blend=True,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
 
+        self.show()
+
     def on_resize(self, event):
-        self.width, self.height = event.size
-        gloo.set_viewport(0, 0, self.width, self.height)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         gloo.clear(color=(0.0, 0.0, 0.0, 1.0))
@@ -89,7 +92,7 @@ class Canvas(app.Canvas):
 
     def _normalize(self, x_y):
         x, y = x_y
-        w, h = float(self.width), float(self.height)
+        w, h = float(self.size[0]), float(self.size[1])
         return x/(w/2.)-1., y/(h/2.)-1.
 
     def on_mouse_move(self, event):
@@ -125,5 +128,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/terrain.py
+++ b/examples/demo/gloo/terrain.py
@@ -131,7 +131,11 @@ class Canvas(app.Canvas):
 
         self.program['a_position'] = gloo.VertexBuffer(triangles)
 
+        self.activate_zoom()
+
         gloo.set_state(clear_color='black', depth_test=True)
+
+        self.show()
 
     def on_key_press(self, event):
         """Controls -
@@ -189,9 +193,12 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        width, height = event.size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = perspective(60.0, width / float(height), 1.0, 100.0)
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        self.projection = perspective(60.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 100.0)
         self.program['u_projection'] = self.projection
 
     def on_draw(self, event):
@@ -205,5 +212,4 @@ generate_points(8)
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/demo/gloo/unstructured_2d.py
+++ b/examples/demo/gloo/unstructured_2d.py
@@ -42,6 +42,10 @@ class Canvas(app.Canvas):
         self._dir_x_right = dir_x_right
         self._dir_y_top = dir_y_top
 
+        self.activate_zoom()
+
+        self.show()
+
     def create_shader(self, colormap):
         if len(colormap.shape) == 2:
             args = dict(
@@ -114,10 +118,11 @@ class Canvas(app.Canvas):
         self.program.draw('triangles', self.index)
 
     def on_resize(self, event):
-        self.resize(*event.size)
+        self.activate_zoom()
 
-    def resize(self, width, height):
-        gloo.set_viewport(0, 0, width, height)
+    def activate_zoom(self):
+        width, heigh = self.size
+        gloo.set_viewport(0, 0, *self.physical_size)
         data_width = self._data_lim[0][1] - self._data_lim[0][0]
         data_height = self._data_lim[1][1] - self._data_lim[1][0]
         data_aspect = data_width / float(data_height)
@@ -207,7 +212,5 @@ if __name__ == '__main__':
                 x=loc[:, 0], y=loc[:, 1], u=vec[:, 0],
                 colormap=create_colormap1d_hot(size=128),
                 keys='interactive')
-    c1.show()
-    c2.show()
     if sys.flags.interactive == 0:
         app.run()

--- a/examples/tutorial/app/fps.py
+++ b/examples/tutorial/app/fps.py
@@ -20,6 +20,7 @@ class Canvas(app.Canvas):
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
         self.tick = 0
 
+        self.show()
     def on_draw(self, event):
         gloo.clear(color=True)
 
@@ -34,6 +35,5 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     canvas = Canvas(keys='interactive')
-    canvas.show()
     canvas.measure_fps(1, canvas.show_fps)
     app.run()

--- a/examples/tutorial/app/fps.py
+++ b/examples/tutorial/app/fps.py
@@ -19,8 +19,8 @@ class Canvas(app.Canvas):
         app.Canvas.__init__(self, *args, **kwargs)
         self._timer = app.Timer('auto', connect=self.on_timer, start=True)
         self.tick = 0
-
         self.show()
+
     def on_draw(self, event):
         gloo.clear(color=True)
 

--- a/examples/tutorial/gl/fireworks.py
+++ b/examples/tutorial/gl/fireworks.py
@@ -121,7 +121,7 @@ class Canvas(app.Canvas):
         gl.glDrawArrays(gl.GL_POINTS, 0, len(self.data))
 
     def on_resize(self, event):
-        gl.glViewport(0, 0, *event.size)
+        gl.glViewport(0, 0, *event.physical_size)
 
     def on_timer(self, event):
         self.elapsed_time += 1. / 60.

--- a/examples/tutorial/gloo/colored_cube.py
+++ b/examples/tutorial/gloo/colored_cube.py
@@ -65,15 +65,22 @@ class Canvas(app.Canvas):
         self.phi, self.theta = 0, 0
         gloo.set_state(clear_color=(0.30, 0.30, 0.35, 1.00), depth_test=True)
 
+        self.activate_zoom()
+
         self.timer = app.Timer('auto', self.on_timer, start=True)
+
+        self.show()
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
         self.program.draw('triangles', self.indices)
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
-        projection = perspective(45.0, event.size[0] / float(event.size[1]),
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        projection = perspective(45.0, self.size[0] / float(self.size[1]),
                                  2.0, 10.0)
         self.program['projection'] = projection
 
@@ -88,5 +95,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/colored_quad.py
+++ b/examples/tutorial/gloo/colored_quad.py
@@ -32,7 +32,7 @@ class Canvas(app.Canvas):
     def __init__(self):
         app.Canvas.__init__(self, size=(512, 512), title='Colored quad',
                             keys='interactive')
-        
+
         # Build program & data
         self.program = Program(vertex, fragment, count=4)
         self.program['color'] = [(1, 0, 0, 1), (0, 1, 0, 1),
@@ -40,14 +40,17 @@ class Canvas(app.Canvas):
         self.program['position'] = [(-1, -1), (-1, +1),
                                     (+1, -1), (+1, +1)]
 
+        gloo.set_viewport(0, 0, *self.physical_size)
+
+        self.show()
+
     def on_draw(self, event):
         gloo.clear(color='white')
         self.program.draw('triangle_strip')
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/lighted_cube.py
+++ b/examples/tutorial/gloo/lighted_cube.py
@@ -107,13 +107,17 @@ class Canvas(app.Canvas):
         self.program["u_normal"] = normal
         self.phi, self.theta = 0, 0
 
-        # OpenGL initalization
+        self.activate_zoom()
+
+        # OpenGL initialization
         # --------------------------------------
         gloo.set_state(clear_color=(0.30, 0.30, 0.35, 1.00), depth_test=True,
                        polygon_offset=(1, 1),
                        blend_func=('src_alpha', 'one_minus_src_alpha'),
                        line_width=0.75)
         self.timer.start()
+
+        self.show()
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
@@ -131,8 +135,11 @@ class Canvas(app.Canvas):
         gloo.set_state(depth_mask=True)
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
-        projection = perspective(45.0, event.size[0] / float(event.size[1]),
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        projection = perspective(45.0, self.size[0] / float(self.size[1]),
                                  2.0, 10.0)
         self.program['u_projection'] = projection
 
@@ -149,5 +156,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/outlined_cube.py
+++ b/examples/tutorial/gloo/outlined_cube.py
@@ -68,12 +68,16 @@ class Canvas(app.Canvas):
         self.program['u_view'] = view
         self.phi, self.theta = 0, 0
 
-        # OpenGL initalization
+        self.activate_zoom()
+
+        # OpenGL initialization
         # --------------------------------------
         gloo.set_state(clear_color=(0.30, 0.30, 0.35, 1.00), depth_test=True,
                        polygon_offset=(1, 1), line_width=0.75,
                        blend_func=('src_alpha', 'one_minus_src_alpha'))
         self.timer.start()
+
+        self.show()
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
@@ -90,8 +94,11 @@ class Canvas(app.Canvas):
         gloo.set_state(depth_mask=True)
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
-        projection = perspective(45.0, event.size[0] / float(event.size[1]),
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        projection = perspective(45.0, self.size[0] / float(self.size[1]),
                                  2.0, 10.0)
         self.program['u_projection'] = projection
 
@@ -106,5 +113,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/rotating_quad.py
+++ b/examples/tutorial/gloo/rotating_quad.py
@@ -46,8 +46,13 @@ class Canvas(app.Canvas):
         self.program['position'] = [(-1, -1), (-1, +1),
                                     (+1, -1), (+1, +1)]
         self.program['theta'] = 0.0
+
+        gloo.set_viewport(0, 0, *self.physical_size)
+
         self.clock = 0
         self.timer.start()
+
+        self.show()
 
     def on_draw(self, event):
         gloo.set_clear_color('white')
@@ -55,7 +60,7 @@ class Canvas(app.Canvas):
         self.program.draw('triangle_strip')
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
     def on_timer(self, event):
         self.clock += 0.001 * 1000.0 / 60.
@@ -64,5 +69,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/texture_precision.py
+++ b/examples/tutorial/gloo/texture_precision.py
@@ -65,7 +65,7 @@ void main()
 {
    float ndiff;
    // an adjacent texel is 1/W further over in normalized texture coordinates
-   vec2 v_texcoord2 = vec2(clamp(v_texcoord.x + 1.0/%(W)d, 0.0, 1.0), 
+   vec2 v_texcoord2 = vec2(clamp(v_texcoord.x + 1.0/%(W)d, 0.0, 1.0),
                            v_texcoord.y);
    vec4 texel1 = texture2D(u_texture, v_texcoord);
    vec4 texel2 = texture2D(u_texture, v_texcoord2);
@@ -104,7 +104,12 @@ class Canvas(app.Canvas):
             shape=(H, W, 3),
             interpolation='nearest'
         )
+
+        gloo.set_viewport(0, 0, *self.physical_size)
+
         self.toggle_internalformat()
+
+        self.show()
 
     def on_key_press(self, event):
         if event.key == 'F':
@@ -127,8 +132,7 @@ class Canvas(app.Canvas):
         self.update()
 
     def on_resize(self, event):
-        w, h = event.size
-        gloo.set_viewport(0, 0, w, h)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
@@ -136,5 +140,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/textured_cube.py
+++ b/examples/tutorial/gloo/textured_cube.py
@@ -73,19 +73,26 @@ class Canvas(app.Canvas):
         self.program['view'] = view
         self.program['texture'] = checkerboard()
 
+        self.activate_zoom()
+
         self.phi, self.theta = 0, 0
 
         # OpenGL initalization
         gloo.set_state(clear_color=(0.30, 0.30, 0.35, 1.00), depth_test=True)
         self.timer.start()
 
+        self.show()
+
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)
         self.program.draw('triangles', self.indices)
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
-        projection = perspective(45.0, event.size[0] / float(event.size[1]),
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        projection = perspective(45.0, self.size[0] / float(self.size[1]),
                                  2.0, 10.0)
         self.program['projection'] = projection
 
@@ -100,5 +107,4 @@ class Canvas(app.Canvas):
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/examples/tutorial/gloo/textured_quad.py
+++ b/examples/tutorial/gloo/textured_quad.py
@@ -47,15 +47,18 @@ class Canvas(app.Canvas):
         self.program['texcoord'] = [(0, 0), (1, 0), (0, 1), (1, 1)]
         self.program['texture'] = checkerboard()
 
+        gloo.set_viewport(0, 0, *self.physical_size)
+
+        self.show()
+
     def on_draw(self, event):
         gloo.set_clear_color('white')
         gloo.clear(color=True)
         self.program.draw('triangle_strip')
 
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, *event.size)
+        gloo.set_viewport(0, 0, *event.physical_size)
 
 if __name__ == '__main__':
     c = Canvas()
-    c.show()
     app.run()

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -345,8 +345,8 @@ class CanvasBackend(BaseCanvasBackend):
             # this ensures that the show takes effect
             self._vispy_update()
         else:
-            glfw.glfwHideWindow(self._id)
 
+            glfw.glfwHideWindow(self._id)
     def _vispy_set_fullscreen(self, fullscreen):
         logger.warn('Cannot change fullscreen mode for GLFW backend')
 
@@ -394,7 +394,7 @@ class CanvasBackend(BaseCanvasBackend):
     def _on_resize(self, _id, w, h):
         if self._vispy_canvas is None:
             return
-        self._vispy_canvas.events.resize(size=(w, h))
+        self._vispy_canvas.events.resize(size=(w, h), physical_size=self._vispy_get_physical_size())
 
     def _on_close(self, _id):
         if self._vispy_canvas is None:

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -76,7 +76,6 @@ try:
         glfw.GLFW_KEY_F11: keys.F11,
         glfw.GLFW_KEY_F12: keys.F12,
 
-        glfw.GLFW_KEY_SPACE: keys.SPACE,
         glfw.GLFW_KEY_ENTER: keys.ENTER,
         '\r': keys.ENTER,
         glfw.GLFW_KEY_TAB: keys.TAB,

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -374,6 +374,12 @@ class CanvasBackend(BaseCanvasBackend):
         w, h = glfw.glfwGetWindowSize(self._id)
         return w, h
 
+    def _vispy_get_physical_size(self):
+        if self._id is None:
+            return
+        w, h = glfw.glfwGetFramebufferSize(self._id)
+        return w, h
+
     def _vispy_get_position(self):
         if self._id is None:
             return

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -345,8 +345,8 @@ class CanvasBackend(BaseCanvasBackend):
             # this ensures that the show takes effect
             self._vispy_update()
         else:
-
             glfw.glfwHideWindow(self._id)
+
     def _vispy_set_fullscreen(self, fullscreen):
         logger.warn('Cannot change fullscreen mode for GLFW backend')
 
@@ -394,7 +394,8 @@ class CanvasBackend(BaseCanvasBackend):
     def _on_resize(self, _id, w, h):
         if self._vispy_canvas is None:
             return
-        self._vispy_canvas.events.resize(size=(w, h), physical_size=self._vispy_get_physical_size())
+        self._vispy_canvas.events.resize(size=(w, h), physical_size=
+                                         self._vispy_get_physical_size())
 
     def _on_close(self, _id):
         if self._vispy_canvas is None:

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -76,6 +76,7 @@ try:
         glfw.GLFW_KEY_F11: keys.F11,
         glfw.GLFW_KEY_F12: keys.F12,
 
+        glfw.GLFW_KEY_SPACE: keys.SPACE,
         glfw.GLFW_KEY_ENTER: keys.ENTER,
         '\r': keys.ENTER,
         glfw.GLFW_KEY_TAB: keys.TAB,
@@ -451,10 +452,10 @@ class CanvasBackend(BaseCanvasBackend):
         fun(key=key, text=text, modifiers=self._mod)
 
     def _process_key(self, key):
-        if key in KEYMAP:
-            return KEYMAP[key], ''
-        elif 32 <= key <= 127:
+        if 32 <= key <= 127:
             return keys.Key(chr(key)), chr(key)
+        elif key in KEYMAP:
+            return KEYMAP[key], ''
         else:
             return None, ''
 

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -134,6 +134,12 @@ class BaseCanvasBackend(object):
         # Should return widget size
         raise NotImplementedError()
 
+    def _vispy_get_physical_size(self):
+        # Should return physical widget size (actual number of screen pixels).
+        # This may differ from _vispy_get_size on backends that expose HiDPI
+        # screens. If not overriden, return the logical sizeself.
+        return _vispy_get_size()
+
     def _vispy_get_position(self):
         # Should return widget position
         raise NotImplementedError()

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -138,7 +138,7 @@ class BaseCanvasBackend(object):
         # Should return physical widget size (actual number of screen pixels).
         # This may differ from _vispy_get_size on backends that expose HiDPI
         # screens. If not overriden, return the logical sizeself.
-        return _vispy_get_size()
+        return self._vispy_get_size()
 
     def _vispy_get_position(self):
         # Should return widget position

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -304,6 +304,12 @@ class Canvas(object):
         return self._backend._vispy_set_size(size[0], size[1])
 
     @property
+    def physical_size(self):
+        """ The physical size of the canvas/window, which may differ from the
+        size property on backends that expose HiDPI """
+        return self._backend._vispy_get_physical_size()
+
+    @property
     def fullscreen(self):
         return self._backend._vispy_get_fullscreen()
 

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -310,6 +310,19 @@ class Canvas(object):
         return self._backend._vispy_get_physical_size()
 
     @property
+    def pixel_scale(self):
+        """ The ratio between the number of logical pixels, or 'points', and
+        the physical pixels on the device. In most cases this will be 1.0,
+        but on certain backends this will be greater than 1. This should be 
+        used as a scaling factor when writing your own visualisations
+        with Gloo (make a copy and multiply all your logical pixel values
+        by it) but you should rarely, if ever, need to use this in your own
+        Visuals or SceneGraph visualisations; instead you should apply the
+        canvas_fb_transform in the SceneGraph canvas. """
+
+        return self.physical_size[0]/self.size[0]
+
+    @property
     def fullscreen(self):
         return self._backend._vispy_get_fullscreen()
 
@@ -673,20 +686,30 @@ class ResizeEvent(Event):
     type : str
        String indicating the event type (e.g. mouse_press, key_release)
     size : (int, int)
-        The new size of the Canvas.
+        The new size of the Canvas, in points (logical pixels).
+    physical_size : (int, int)
+        The new physical size of the Canvas, in pixels.
     native : object (optional)
        The native GUI event object
     **kwargs : extra keyword arguments
         All extra keyword arguments become attributes of the event object.
     """
 
-    def __init__(self, type, size=None, **kwargs):
+    def __init__(self, type, size=None, physical_size=None, **kwargs):
         Event.__init__(self, type, **kwargs)
         self._size = tuple(size)
+        if physical_size is None:
+            self._physical_size = self._size
+        else:
+            self._physical_size = tuple(physical_size)
 
     @property
     def size(self):
         return self._size
+
+    @property
+    def physical_size(self):
+        return self._physical_size
 
 
 class DrawEvent(Event):

--- a/vispy/app/tests/test_backends.py
+++ b/vispy/app/tests/test_backends.py
@@ -55,6 +55,7 @@ def _test_module_properties(_module=None):
         '_vispy_mouse_press',
         '_vispy_mouse_release',
         '_vispy_get_geometry',
+        '_vispy_get_physical_size',
         '_process_backend_kwargs')  # defined in base class
 
     class KlassRef(vispy.app.base.BaseCanvasBackend):

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -353,8 +353,7 @@ class SceneCanvas(app.Canvas):
         """
         fbo, offset, csize = self._current_framebuffer()
         if fbo is None:
-            # todo: account for high-res displays here.
-            fbsize = csize
+            fbsize = self.physical_size
         else:
             fbsize = fbo.color_buffer.shape
             # image shape is (rows, cols), unlike canvas shape.

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -216,7 +216,7 @@ class SceneCanvas(app.Canvas):
         
         scene_event = SceneDrawEvent(canvas=self, event=event, 
                                      transform_cache=tr_cache)
-        scene_event.push_viewport((0, 0) + self.size)
+        scene_event.push_viewport((0, 0) + self.physical_size)
         try:
             # Force update of transforms on base entities
             # TODO: this should happen as a reaction to resize, push_viewport,


### PR DESCRIPTION
A bunch of fixes for HiDPI displays. 

- `physical_size` (i.e. framebuffer size) vs logical `size` concept (currently implemented for GLFW with a fallback in the base backend
- Fixing examples so they don't rely on a resize() event before first draw
- Changing examples to show() only once all variables are initialised (the call to create the canvas is blocking on GLFW / OSX!)

Fixes #779 and #639 