### PR TITLE
Fixed a TubeVisual bug and rearranged doc

### DIFF
--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -21,6 +21,12 @@ class TubeVisual(MeshVisual):
         tube will be extruded.
     radius : float
         The radius of the tube. Defaults to 1.0.
+    closed : bool
+        Whether the tube should be closed, joining the last point to the
+        first. Defaults to False.
+    tube_points : int
+        The number of points in the circle-approximating polygon of the
+        tube's cross section. Defaults to 8.
     color : Color | ColorArray
         The color(s) to use when drawing the tube. The same color is
         applied to each vertex of the mesh surrounding each point of
@@ -28,9 +34,6 @@ class TubeVisual(MeshVisual):
         cycled; for instance if 'red' is passed then the entire tube
         will be red, or if ['green', 'blue'] is passed then the points
         will alternate between these colours. Defaults to 'purple'.
-    tube_points : int
-        The number of points in the circle-approximating polygon of the
-        tube's cross section. Defaults to 8.
     shading : str | None
         Same as for the `MeshVisual` class. Defaults to 'smooth'.
     vertex_colors: ndarray | None
@@ -41,12 +44,13 @@ class TubeVisual(MeshVisual):
         Same as for the `MeshVisual` class. Defaults to 'triangles'.
 
     """
-    def __init__(self, points, radius=1.0, tube_points=8,
+    def __init__(self, points, radius=1.0,
                  closed=False,
+                 tube_points=8,
+                 color='purple',
                  shading='smooth',
                  vertex_colors=None,
                  face_colors=None,
-                 color='purple',
                  mode='triangles'):
 
         points = np.array(points)

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -119,6 +119,9 @@ def _frenet_frames(points, closed):
 
     # Compute tangent vectors for each segment
     tangents = np.roll(points, -1, axis=0) - np.roll(points, 1, axis=0)
+    if not closed:
+        tangents[0] = points[1] - points[0]
+        tangents[-1] = points[-1] = points[-2]
     mags = np.sqrt(np.sum(tangents * tangents, axis=1))
     tangents /= mags[:, np.newaxis]
 

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -24,9 +24,6 @@ class TubeVisual(MeshVisual):
     closed : bool
         Whether the tube should be closed, joining the last point to the
         first. Defaults to False.
-    tube_points : int
-        The number of points in the circle-approximating polygon of the
-        tube's cross section. Defaults to 8.
     color : Color | ColorArray
         The color(s) to use when drawing the tube. The same color is
         applied to each vertex of the mesh surrounding each point of
@@ -34,6 +31,9 @@ class TubeVisual(MeshVisual):
         cycled; for instance if 'red' is passed then the entire tube
         will be red, or if ['green', 'blue'] is passed then the points
         will alternate between these colours. Defaults to 'purple'.
+    tube_points : int
+        The number of points in the circle-approximating polygon of the
+        tube's cross section. Defaults to 8.
     shading : str | None
         Same as for the `MeshVisual` class. Defaults to 'smooth'.
     vertex_colors: ndarray | None
@@ -46,8 +46,8 @@ class TubeVisual(MeshVisual):
     """
     def __init__(self, points, radius=1.0,
                  closed=False,
-                 tube_points=8,
                  color='purple',
+                 tube_points=8,
                  shading='smooth',
                  vertex_colors=None,
                  face_colors=None,

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -121,7 +121,7 @@ def _frenet_frames(points, closed):
     tangents = np.roll(points, -1, axis=0) - np.roll(points, 1, axis=0)
     if not closed:
         tangents[0] = points[1] - points[0]
-        tangents[-1] = points[-1] = points[-2]
+        tangents[-1] = points[-1] - points[-2]
     mags = np.sqrt(np.sum(tangents * tangents, axis=1))
     tangents /= mags[:, np.newaxis]
 


### PR DESCRIPTION
Previously the tube tangents were calculated assuming the tube was closed, which messed up the first and last tangent values unless they happened to match anyway. The problem is shown in the images below. I also rearranged the doc (and added a missing parameter) to emphasise the main arguments.

Example tubes before this PR:
![tubes_problem_orig](https://cloud.githubusercontent.com/assets/1265819/6882107/b1a926c8-d572-11e4-8b2b-b4b1ec9ef02d.png)

And after:
![tubes_problem_fixed](https://cloud.githubusercontent.com/assets/1265819/6882106/b1a2dfac-d572-11e4-830b-cf7fbf9228cd.png)
