### PR TITLE
Optional install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,17 @@ setup(
     platforms='any',
     provides=['vispy'],
     install_requires=['numpy'],
+    extras_requires={
+        'ipython-static': ['ipython'],
+        'ipython-vnc': ['ipython>=2'],
+        'ipython-webgl': ['ipython>=2', 'tornado'],
+        'pyglet': ['pyglet>=1.2'],
+        # 'pyqt4': [],  # Why is this on PyPI, but without downloads?
+        # 'pyqt5': [],  # Ditto.
+        'pyside': ['PySide'],
+        'sdl2': ['PySDL2'],
+        'wx': ['wxPython'],
+    },
     packages=package_tree('vispy'),
     package_dir={
         'vispy': 'vispy'},

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
 )


### PR DESCRIPTION
This adds some Extra requirements, so that one can do something like `pip install vispy[ipython-vnc]` (or some other backend) and the additional dependencies would be installed.

Unfortunately, it seems like PyQt4/5 don't install eggs and don't have proper information on PyPI, so I wasn't able to add the correct dependencies there. I also added some minimum requirements when I could find checks for them, but couldn't see anything describing requirements for all backends.