### PR TITLE
Scenegraph profiling

### DIFF
--- a/examples/benchmark/scene_test_1.py
+++ b/examples/benchmark/scene_test_1.py
@@ -7,6 +7,10 @@
 """
 Compare an optimal pan/zoom implementation to the same functionality
 provided by scenegraph.
+
+Use --vispy-cprofile to see an overview of time spent in all functions.
+Use util.profiler and --vispy-profile=ClassName.method_name for more directed
+profiling measurements.
 """
 import numpy as np
 import math
@@ -344,6 +348,7 @@ if __name__ == '__main__':
     svisual = Signals(data)
     view = scanvas.central_widget.add_view()
     view.add(svisual)
+    view.camera = 'panzoom'
 
     import sys
     if sys.flags.interactive != 1:

--- a/examples/benchmark/scene_test_1.py
+++ b/examples/benchmark/scene_test_1.py
@@ -15,6 +15,7 @@ from vispy import gloo, app, scene
 from vispy.visuals import Visual
 from vispy.visuals.shaders import ModularProgram, Function, Variable
 from vispy.visuals.transforms import TransformSystem, BaseTransform
+from vispy.util.profiler import Profiler
 
 
 class PanZoomTransform(BaseTransform):
@@ -143,6 +144,7 @@ class PanZoomCanvas(app.Canvas):
             self.update()
 
     def on_mouse_wheel(self, event):
+        prof = Profiler()
         if not event.modifiers:
             dx = np.sign(event.delta[1])*.05
             x0, y0 = self._normalize(event.pos)
@@ -176,9 +178,11 @@ class PanZoomCanvas(app.Canvas):
         return self._visuals
 
     def on_draw(self, event):
+        prof = Profiler()
         gloo.clear()
         for visual in self.visuals:
             visual.draw(self._tr)
+            prof('draw visual')
 
 
 X_TRANSFORM = """

--- a/examples/benchmark/scene_test_1.py
+++ b/examples/benchmark/scene_test_1.py
@@ -144,7 +144,7 @@ class PanZoomCanvas(app.Canvas):
             self.update()
 
     def on_mouse_wheel(self, event):
-        prof = Profiler()
+        prof = Profiler()  # noqa
         if not event.modifiers:
             dx = np.sign(event.delta[1])*.05
             x0, y0 = self._normalize(event.pos)

--- a/examples/benchmark/scene_test_2.py
+++ b/examples/benchmark/scene_test_2.py
@@ -10,20 +10,15 @@ provided by scenegraph.
 """
 from __future__ import division
 import numpy as np
-import math
 
 from vispy import gloo, app, scene, visuals
-from vispy.visuals import Visual
-from vispy.visuals.shaders import ModularProgram, Function, Variable
-from vispy.visuals.transforms import TransformSystem, BaseTransform
 from vispy.util.profiler import Profiler
-
 
 
 class GridCanvas(app.Canvas):
     def __init__(self, cells, **kwargs):
         super(GridCanvas, self).__init__(keys='interactive',
-                                            show=True, **kwargs)
+                                         show=True, **kwargs)
         m, n = (10, 10)
         self.grid_size = (m, n)
         self.cells = cells
@@ -39,7 +34,9 @@ class GridCanvas(app.Canvas):
             m, n = len(self.cells), len(self.cells[0])
             cell = self.cells[int(i*m)][n - 1 - int(j*n)]
             if event.press_event.button == 1:
-                offset = np.array(cell.offset) + (dx / (np.array(self.size) / [m, n])) *  (2 / np.array(cell.scale))
+                offset = (np.array(cell.offset) + 
+                          (dx / (np.array(self.size) / [m, n])) *  
+                          (2 / np.array(cell.scale)))
                 cell.set_transform(offset, cell.scale)
                 
             else:
@@ -47,7 +44,7 @@ class GridCanvas(app.Canvas):
             self.update()
 
     def on_draw(self, event):
-        prof = Profiler()
+        prof = Profiler()  # noqa
         gloo.clear()
         M = len(self.cells)
         N = len(self.cells[0])
@@ -92,11 +89,10 @@ class Line(object):
         self.program.draw('line_strip')
 
 
-
 class VisualCanvas(app.Canvas):
     def __init__(self, vis, **kwargs):
         super(VisualCanvas, self).__init__(keys='interactive',
-                                            show=True, **kwargs)
+                                           show=True, **kwargs)
         m, n = (10, 10)
         self.grid_size = (m, n)
         self.visuals = vis
@@ -126,7 +122,7 @@ class VisualCanvas(app.Canvas):
             self.update()
 
     def on_draw(self, event):
-        prof = Profiler()
+        prof = Profiler()  # noqa
         gloo.clear()
         M, N = self.grid_size
         w, h = self.size
@@ -137,15 +133,12 @@ class VisualCanvas(app.Canvas):
                 v.draw(v.tr_sys)
 
 
-
-
 if __name__ == '__main__':
     M, N = (10, 10)
     
     data = np.empty((10000, 2), dtype=np.float32)
     data[:, 0] = np.linspace(0, 100, data.shape[0])
     data[:, 1] = np.random.normal(size=data.shape[0])
-    
     
     # Optimized version
     cells = []
@@ -158,40 +151,38 @@ if __name__ == '__main__':
     gcanvas = GridCanvas(cells, position=(400, 300), size=(800, 600), 
                          title="GridCanvas")
     
-    
     # Visual version
     vlines = []
     for i in range(M):
         row = []
         vlines.append(row)
         for j in range(N):
-            v = visuals.LineVisual(pos=data, color=(1, 1, 1, 0.5), mode='gl')
-            v.transform = visuals.transforms.STTransform(translate=(0, 200), scale=(7, 50))
+            v = visuals.LineVisual(pos=data, color=(1, 1, 1, 0.5), method='gl')
+            v.transform = visuals.transforms.STTransform(translate=(0, 200), 
+                                                         scale=(7, 50))
             row.append(v)
     
     vcanvas = VisualCanvas(vlines, position=(400, 300), size=(800, 600), 
-                         title="VisualCanvas")
-    
+                           title="VisualCanvas")
     
     # Scenegraph version
-    #scanvas = scene.SceneCanvas(show=True, keys='interactive', 
-                                #title="SceneCanvas")
+    scanvas = scene.SceneCanvas(show=True, keys='interactive', 
+                                title="SceneCanvas")
     
-    
-    #scanvas.size = 800, 600
-    #scanvas.show()
-    #grid = scanvas.central_widget.add_grid()
+    scanvas.size = 800, 600
+    scanvas.show()
+    grid = scanvas.central_widget.add_grid()
 
-    #lines = []
-    #for i in range(10):
-        #lines.append([])
-        #for j in range(10):
-            #vb = grid.add_view(row=i, col=j)
-            #vb.camera.rect = (0, -5), (100, 10)
-            #vb.border = (1, 1, 1, 0.4)
-            #line = scene.visuals.Line(pos=data, color=(1, 1, 1, 0.5), mode='gl')
-            #vb.add(line)
-    
+    lines = []
+    for i in range(10):
+        lines.append([])
+        for j in range(10):
+            vb = grid.add_view(row=i, col=j)
+            vb.camera.rect = (0, -5), (100, 10)
+            vb.border = (1, 1, 1, 0.4)
+            line = scene.visuals.Line(pos=data, color=(1, 1, 1, 0.5), 
+                                      method='gl')
+            vb.add(line)
     
     import sys
     if sys.flags.interactive != 1:

--- a/examples/benchmark/scene_test_2.py
+++ b/examples/benchmark/scene_test_2.py
@@ -7,6 +7,10 @@
 """
 Compare an optimal plot grid implementation to the same functionality
 provided by scenegraph.
+
+Use --vispy-cprofile to see an overview of time spent in all functions.
+Use util.profiler and --vispy-profile=ClassName.method_name for more directed
+profiling measurements.
 """
 from __future__ import division
 import numpy as np
@@ -17,11 +21,11 @@ from vispy.util.profiler import Profiler
 
 class GridCanvas(app.Canvas):
     def __init__(self, cells, **kwargs):
-        super(GridCanvas, self).__init__(keys='interactive',
-                                         show=True, **kwargs)
         m, n = (10, 10)
         self.grid_size = (m, n)
         self.cells = cells
+        super(GridCanvas, self).__init__(keys='interactive',
+                                         show=True, **kwargs)
 
     def on_initialize(self, event):
         gloo.set_state(clear_color='black', blend=True,

--- a/examples/benchmark/scene_test_2.py
+++ b/examples/benchmark/scene_test_2.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# vispy: testskip
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+"""
+Compare an optimal plot grid implementation to the same functionality
+provided by scenegraph.
+"""
+from __future__ import division
+import numpy as np
+import math
+
+from vispy import gloo, app, scene
+from vispy.visuals import Visual
+from vispy.visuals.shaders import ModularProgram, Function, Variable
+from vispy.visuals.transforms import TransformSystem, BaseTransform
+from vispy.util.profiler import Profiler
+
+
+
+class GridCanvas(app.Canvas):
+    def __init__(self, cells, **kwargs):
+        super(GridCanvas, self).__init__(keys='interactive',
+                                            show=True, **kwargs)
+        m, n = (10, 10)
+        self.grid_size = (m, n)
+        self.cells = cells
+
+    def on_initialize(self, event):
+        gloo.set_state(clear_color='black', blend=True,
+                       blend_func=('src_alpha', 'one_minus_src_alpha'))
+
+    def on_mouse_move(self, event):
+        if event.is_dragging and not event.modifiers:
+            dx = (event.pos - event.last_event.pos) * [1, -1]
+            i, j = event.press_event.pos / self.size
+            m, n = len(self.cells), len(self.cells[0])
+            cell = self.cells[int(i*m)][n - 1 - int(j*n)]
+            if event.press_event.button == 1:
+                offset = np.array(cell.offset) + (dx / (np.array(self.size) / [m, n])) *  (2 / np.array(cell.scale))
+                cell.set_transform(offset, cell.scale)
+                
+            else:
+                cell.set_transform(cell.offset, cell.scale * 1.05 ** dx)
+            #x0, y0 = self._normalize(event.press_event.pos)
+            #x1, y1 = self._normalize(event.last_event.pos)
+            #x, y = self._normalize(event.pos)
+            #dx, dy = x - x1, -(y - y1)
+            #button = event.press_event.button
+
+            #pan_x, pan_y = self._pz.pan
+            #zoom_x, zoom_y = self._pz.zoom
+
+            #if button == 1:
+                #self._pz.pan = (pan_x + dx/zoom_x,
+                                #pan_y + dy/zoom_y)
+            #elif button == 2:
+                #zoom_x_new, zoom_y_new = (zoom_x * math.exp(2.5 * dx),
+                                          #zoom_y * math.exp(2.5 * dy))
+                #self._pz.zoom = (zoom_x_new, zoom_y_new)
+                #self._pz.pan = (pan_x - x0 * (1./zoom_x - 1./zoom_x_new),
+                                #pan_y + y0 * (1./zoom_y - 1./zoom_y_new))
+            self.update()
+
+    def on_draw(self, event):
+        prof = Profiler()
+        gloo.clear()
+        M = len(self.cells)
+        N = len(self.cells[0])
+        w, h = self.size
+        for i in range(M):
+            for j in range(N):
+                gloo.set_viewport(w*i/M, h*j/N, w/M, h/N)
+                self.cells[i][j].draw()
+
+
+vert = """
+attribute vec2 pos;
+uniform vec2 offset;
+uniform vec2 scale;
+
+void main() {
+    gl_Position = vec4((pos + offset) * scale, 0, 1);
+}
+"""
+
+frag = """
+void main() {
+    gl_FragColor = vec4(1, 1, 1, 0.5);
+}
+"""
+
+
+class Line(object):
+    def __init__(self, data, offset, scale):
+        self.data = gloo.VertexBuffer(data)
+        self.program = gloo.Program(vert, frag)
+        self.program['pos'] = self.data
+        self.set_transform(offset, scale)
+        
+    def set_transform(self, offset, scale):
+        self.offset = offset
+        self.scale = scale
+        self.program['offset'] = self.offset
+        self.program['scale'] = self.scale
+    
+    def draw(self):
+        self.program.draw('line_strip')
+
+
+if __name__ == '__main__':
+    M, N = (10, 10)
+    
+    data = np.empty((10000, 2), dtype=np.float32)
+    data[:, 0] = np.linspace(0, 100, data.shape[0])
+    data[:, 1] = np.random.normal(size=data.shape[0])
+    
+    
+    # Optimized version
+    cells = []
+    for i in range(M):
+        row = []
+        cells.append(row)
+        for j in range(N):
+            row.append(Line(data, offset=(-50, 0), scale=(1.9/100, 2/10)))
+    
+    gcanvas = GridCanvas(cells, position=(400, 300), size=(800, 600), 
+                         title="GridCanvas")
+    
+    
+    # Scenegraph version
+    scanvas = scene.SceneCanvas(show=True, keys='interactive', 
+                                title="SceneCanvas")
+    
+    
+    scanvas.size = 800, 600
+    scanvas.show()
+    grid = scanvas.central_widget.add_grid()
+
+    lines = []
+    for i in range(10):
+        lines.append([])
+        for j in range(10):
+            vb = grid.add_view(row=i, col=j)
+            vb.camera.rect = (0, -5), (100, 10)
+            vb.border = (1, 1, 1, 0.4)
+            line = scene.visuals.Line(pos=data, color=(1, 1, 1, 0.5), mode='gl')
+            vb.add(line)
+    
+    
+    import sys
+    if sys.flags.interactive != 1:
+        app.run()

--- a/vispy/scene/systems.py
+++ b/vispy/scene/systems.py
@@ -8,6 +8,7 @@ import sys
 
 from ..visuals.visual import Visual
 from ..util.logs import logger, _handle_exception
+from ..util.profiler import Profiler
 
 
 class DrawingSystem(object):
@@ -16,10 +17,12 @@ class DrawingSystem(object):
 
     """
     def process(self, event, node):
+        prof = Profiler(str(node))
         # Draw this node if it is a visual
         if isinstance(node, Visual) and node.visible:
             try:
                 node.draw(event)
+                prof('draw')
             except Exception:
                 # get traceback and store (so we can do postmortem
                 # debugging)
@@ -35,6 +38,7 @@ class DrawingSystem(object):
                 self.process(event, sub_node)
             finally:
                 event.pop_node()
+            prof('process child %s', sub_node)
 
 
 class MouseInputSystem(object):

--- a/vispy/util/config.py
+++ b/vispy/util/config.py
@@ -45,6 +45,7 @@ def _init():
         'logging_level': string_types,
         'qt_lib': string_types,
         'dpi': (int, type(None)),
+        'profile': string_types + (type(None),),
     }
 
     # Default values for all config options
@@ -58,6 +59,7 @@ def _init():
         'logging_level': 'info',
         'qt_lib': 'any',
         'dpi': None,
+        'profile': None,
     }
 
     config = Config(**default_config_options)
@@ -101,8 +103,14 @@ VisPy command line arguments:
   --vispy-glir-file
     Export glir commands to specified file.
 
-  --vispy-profile
-    Enable profiling and print the results when the program exits.
+  --vispy-profile=locations
+    Measure performance at specific code locations and display results. 
+    *locations* may be "all" or a comma-separated list of method names like
+    "SceneCanvas.draw_visual".
+
+  --vispy-cprofile
+    Enable profiling using the built-in cProfile module and display results
+    when the program exits.
 
   --vispy-help
     Display this help message.
@@ -117,7 +125,8 @@ def _parse_command_line_arguments():
     global config
     # Get command line args for vispy
     argnames = ['vispy-backend=', 'vispy-gl-debug', 'vispy-glir-file=',
-                'vispy-log=', 'vispy-help', 'vispy-profile', 'vispy-dpi=']
+                'vispy-log=', 'vispy-help', 'vispy-profile=', 'vispy-cprofile',
+                'vispy-dpi=']
     try:
         opts, args = getopt.getopt(sys.argv[1:], '', argnames)
     except getopt.GetoptError:
@@ -141,6 +150,8 @@ def _parse_command_line_arguments():
                 config['logging_level'] = a
                 set_log_level(verbose, match)
             elif o == '--vispy-profile':
+                config['profile'] = a
+            elif o == '--vispy-cprofile':
                 _enable_profiling()
             elif o == '--vispy-help':
                 print(VISPY_HELP)

--- a/vispy/util/profiler.py
+++ b/vispy/util/profiler.py
@@ -86,7 +86,7 @@ class Profiler(object):
         obj._new_msg("> Entering " + obj._name)
         return obj
 
-    def __call__(self, msg=None):
+    def __call__(self, msg=None, *args):
         """Register or print a new message with timing information.
         """
         if self.disable:
@@ -95,8 +95,8 @@ class Profiler(object):
             msg = str(self._mark_count)
         self._mark_count += 1
         new_time = ptime.time()
-        self._new_msg("  %s: %0.4f ms", 
-                     msg, (new_time - self._last_time) * 1000)
+        elapsed = (new_time - self._last_time) * 1000
+        self._new_msg("  " + msg + ": %0.4f ms", *(args + (elapsed,)))
         self._last_time = new_time
         
     def mark(self, msg=None):

--- a/vispy/util/profiler.py
+++ b/vispy/util/profiler.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014, Vispy Development Team.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # Adapted from PyQtGraph
-import os
 import sys
 from . import ptime
 from .. import config
@@ -44,37 +43,42 @@ class Profiler(object):
     
     _depth = 0
     _msgs = []
-    disable = False  # set this flag to disable all or individual profilers at runtime
+    # set this flag to disable all or individual profilers at runtime
+    disable = False
     
     class DisabledProfiler(object):
         def __init__(self, *args, **kwds):
             pass
+        
         def __call__(self, *args):
             pass
+        
         def finish(self):
             pass
+        
         def mark(self, msg=None):
             pass
+        
     _disabled_profiler = DisabledProfiler()
         
     def __new__(cls, msg=None, disabled='env', delayed=True):
         """Optionally create a new profiler based on caller's qualname.
         """
         if (disabled is True or 
-            (disabled == 'env' and len(cls._profilers) == 0)):
+                (disabled == 'env' and len(cls._profilers) == 0)):
             return cls._disabled_profiler
                         
         # determine the qualified name of the caller function
         caller_frame = sys._getframe(1)
         try:
             caller_object_type = type(caller_frame.f_locals["self"])
-        except KeyError: # we are in a regular function
+        except KeyError:  # we are in a regular function
             qualifier = caller_frame.f_globals["__name__"].split(".", 1)[1]
-        else: # we are in a method
+        else:  # we are in a method
             qualifier = caller_object_type.__name__
         func_qualname = qualifier + "." + caller_frame.f_code.co_name
         if (disabled == 'env' and func_qualname not in cls._profilers and
-            'all' not in cls._profilers): # don't do anything
+                'all' not in cls._profilers):  # don't do anything
             return cls._disabled_profiler
         # create an actual profiling object
         cls._depth += 1
@@ -123,13 +127,12 @@ class Profiler(object):
         if msg is not None:
             self(msg)
         self._new_msg("< Exiting %s, total time: %0.4f ms", 
-                     self._name, (ptime.time() - self._firstTime) * 1000)
+                      self._name, (ptime.time() - self._firstTime) * 1000)
         type(self)._depth -= 1
         if self._depth < 1:
             self.flush()
         
     def flush(self):
         if self._msgs:
-            print("\n".join([m[0]%m[1] for m in self._msgs]))
+            print("\n".join([m[0] % m[1] for m in self._msgs]))
             type(self)._msgs = []
-

--- a/vispy/util/profiler.py
+++ b/vispy/util/profiler.py
@@ -5,6 +5,7 @@
 import os
 import sys
 from . import ptime
+from .. import config
 
 
 class Profiler(object):
@@ -38,8 +39,8 @@ class Profiler(object):
     only the initial "vispy.." prefix from the module.
     """
 
-    _profilers = os.environ.get("VISPYPROFILE", None)
-    _profilers = _profilers.split(",") if _profilers is not None else []
+    _profilers = (config['profile'].split(",") if config['profile'] is not None
+                  else [])
     
     _depth = 0
     _msgs = []

--- a/vispy/util/profiler.py
+++ b/vispy/util/profiler.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# Adapted from PyQtGraph
+import os
+import sys
+from . import ptime
+
+
+class Profiler(object):
+    """Simple profiler allowing directed, hierarchical measurement of time
+    intervals.
+
+    By default, profilers are disabled.  To enable profiling, set the
+    environment variable `VISPYPROFILE` to a comma-separated list of
+    fully-qualified names of profiled functions.
+
+    Calling a profiler registers a message (defaulting to an increasing
+    counter) that contains the time elapsed since the last call.  When the
+    profiler is about to be garbage-collected, the messages are passed to the
+    outer profiler if one is running, or printed to stdout otherwise.
+
+    If `delayed` is set to False, messages are immediately printed instead.
+
+    Example:
+        def function(...):
+            profiler = Profiler()
+            ... do stuff ...
+            profiler('did stuff')
+            ... do other stuff ...
+            profiler('did other stuff')
+            # profiler is garbage-collected and flushed at function end
+
+    If this function is a method of class C, setting `VISPYPROFILE` to
+    "C.function" (without the module name) will enable this profiler.
+
+    For regular functions, use the qualified name of the function, stripping
+    only the initial "vispy.." prefix from the module.
+    """
+
+    _profilers = os.environ.get("VISPYPROFILE", None)
+    _profilers = _profilers.split(",") if _profilers is not None else []
+    
+    _depth = 0
+    _msgs = []
+    disable = False  # set this flag to disable all or individual profilers at runtime
+    
+    class DisabledProfiler(object):
+        def __init__(self, *args, **kwds):
+            pass
+        def __call__(self, *args):
+            pass
+        def finish(self):
+            pass
+        def mark(self, msg=None):
+            pass
+    _disabled_profiler = DisabledProfiler()
+        
+    def __new__(cls, msg=None, disabled='env', delayed=True):
+        """Optionally create a new profiler based on caller's qualname.
+        """
+        if (disabled is True or 
+            (disabled == 'env' and len(cls._profilers) == 0)):
+            return cls._disabled_profiler
+                        
+        # determine the qualified name of the caller function
+        caller_frame = sys._getframe(1)
+        try:
+            caller_object_type = type(caller_frame.f_locals["self"])
+        except KeyError: # we are in a regular function
+            qualifier = caller_frame.f_globals["__name__"].split(".", 1)[1]
+        else: # we are in a method
+            qualifier = caller_object_type.__name__
+        func_qualname = qualifier + "." + caller_frame.f_code.co_name
+        if (disabled == 'env' and func_qualname not in cls._profilers and
+            'all' not in cls._profilers): # don't do anything
+            return cls._disabled_profiler
+        # create an actual profiling object
+        cls._depth += 1
+        obj = super(Profiler, cls).__new__(cls)
+        obj._name = msg or func_qualname
+        obj._delayed = delayed
+        obj._mark_count = 0
+        obj._finished = False
+        obj._firstTime = obj._last_time = ptime.time()
+        obj._new_msg("> Entering " + obj._name)
+        return obj
+
+    def __call__(self, msg=None):
+        """Register or print a new message with timing information.
+        """
+        if self.disable:
+            return
+        if msg is None:
+            msg = str(self._mark_count)
+        self._mark_count += 1
+        new_time = ptime.time()
+        self._new_msg("  %s: %0.4f ms", 
+                     msg, (new_time - self._last_time) * 1000)
+        self._last_time = new_time
+        
+    def mark(self, msg=None):
+        self(msg)
+
+    def _new_msg(self, msg, *args):
+        msg = "  " * (self._depth - 1) + msg
+        if self._delayed:
+            self._msgs.append((msg, args))
+        else:
+            self.flush()
+            print(msg % args)
+
+    def __del__(self):
+        self.finish()
+    
+    def finish(self, msg=None):
+        """Add a final message; flush the message list if no parent profiler.
+        """
+        if self._finished or self.disable:
+            return        
+        self._finished = True
+        if msg is not None:
+            self(msg)
+        self._new_msg("< Exiting %s, total time: %0.4f ms", 
+                     self._name, (ptime.time() - self._firstTime) * 1000)
+        type(self)._depth -= 1
+        if self._depth < 1:
+            self.flush()
+        
+    def flush(self):
+        if self._msgs:
+            print("\n".join([m[0]%m[1] for m in self._msgs]))
+            type(self)._msgs = []
+

--- a/vispy/visuals/line/line.py
+++ b/vispy/visuals/line/line.py
@@ -14,6 +14,7 @@ from ...color import Color, ColorArray, get_colormap
 from ...ext.six import string_types
 from ..shaders import ModularProgram, Function
 from ..visual import Visual
+from ...util.profiler import Profiler
 
 from .dash_atlas import DashAtlas
 from . import vertex
@@ -296,6 +297,7 @@ class _GLLineVisual(Visual):
         self.set_gl_state('translucent')
 
     def draw(self, transforms):
+        prof = Profiler()
         Visual.draw(self, transforms)
         
         # first see whether we can bail out early
@@ -361,6 +363,8 @@ class _GLLineVisual(Visual):
                 self._connect_ibo.set_data(self._connect)
         if self._connect is None:
             return
+        
+        prof('prepare')
 
         # Draw
         if self._connect == 'strip':
@@ -371,6 +375,8 @@ class _GLLineVisual(Visual):
             self._program.draw('lines', self._connect_ibo)
         else:
             raise ValueError("Invalid line connect mode: %r" % self._connect)
+        
+        prof('draw')
 
 
 class _AggLineVisual(Visual):


### PR DESCRIPTION
Adds a Profiler class and instruments some visual/scenegraph code. Should add negligible overhead when profiling is not in use. Works like this:

```
# profile a specific code location (comma-separated list)
python example.py --vispy-profile=SceneCanvas.draw_visual

# enable all profilers
python example.py --vispy-profile=all
```
