### PR TITLE
Fixed Cube mesh generation

### DIFF
--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -80,6 +80,7 @@ def create_cube():
     filled = np.resize(
         np.array([0, 1, 2, 0, 2, 3], dtype=itype), 6 * (2 * 3))
     filled += np.repeat(4 * np.arange(6, dtype=itype), 6)
+    filled = filled.reshape((len(filled) // 3, 3))
 
     outline = np.resize(
         np.array([0, 1, 1, 2, 2, 3, 3, 0], dtype=itype), 6 * (2 * 4))


### PR DESCRIPTION
Currently the cube mesh generation function returns a 1D array of face indices, but the MeshData expects it to be 2D. This doesn't seem to affect anything right now as functions like `cube._meshdata.get_vertex_normals()` are not accessed, but exceptions are raised if that code is actually called. This PR just fixes that, everything seems to work fine afterwards.