### PR TITLE
Volume rendering methods

### DIFF
--- a/examples/basics/scene/volume.py
+++ b/examples/basics/scene/volume.py
@@ -109,7 +109,7 @@ def on_key_press(event):
     elif event.text == '0':
         cam1.set_range()
         cam3.set_range()
-    elif event.text in '[]':
+    elif event.text != '' and event.text in '[]':
         s = -0.025 if event.text == '[' else 0.025
         volume1.threshold += s
         volume2.threshold += s

--- a/examples/basics/scene/volume.py
+++ b/examples/basics/scene/volume.py
@@ -10,11 +10,12 @@ Example volume rendering
 
 Controls:
 
-* 1 - toggle camera between first person (fly) and regular 3D (turntable)
-* 2 - toggle between volume rendering methods
-* 3 - toggle between stent-CT / brain-MRI image
-* 4 - toggle between colormaps
-* 0 - reset cameras
+* 1  - toggle camera between first person (fly) and regular 3D (turntable)
+* 2  - toggle between volume rendering methods
+* 3  - toggle between stent-CT / brain-MRI image
+* 4  - toggle between colormaps
+* 0  - reset cameras
+* [] - decrease/increase isosurface threshold
 
 With fly camera:
 
@@ -50,7 +51,7 @@ view = canvas.central_widget.add_view()
 emulate_texture = True
 
 # Create the volume visuals, only one is visible
-volume1 = scene.visuals.Volume(vol1, parent=view.scene, threshold=0.5,
+volume1 = scene.visuals.Volume(vol1, parent=view.scene, threshold=0.1,
                                emulate_texture=emulate_texture)
 volume1.transform = scene.STTransform(translate=(64, 64, 0))
 volume2 = scene.visuals.Volume(vol2, parent=view.scene, threshold=0.5,
@@ -73,10 +74,13 @@ def on_key_press(event):
         view.camera = cam_toggle.get(view.camera, 'fly')
     elif event.text == '2':
         methods = ['mip', 'translucent', 'iso', 'additive']
+        cmaps = {'mip': 'grays', 'translucent': 'tgrays', 'iso': 'grays', 'additive': 'tgrays'}
         method = methods[(methods.index(volume1.method) + 1) % 4]
         print("Volume render method: %s" % method)
         volume1.method = method
+        volume1.cmap = cmaps[method]
         volume2.method = method
+        volume2.cmap = cmaps[method]
     elif event.text == '3':
         volume1.visible = not volume1.visible
         volume2.visible = not volume1.visible
@@ -88,16 +92,16 @@ def on_key_press(event):
         cam1.set_range()
         cam3.set_range()
     elif event.text == '[':
-        volume1.threshold -= 0.1
+        volume1.threshold -= 0.025
         volume2.threshold = volume1.threshold
     elif event.text == ']':
-        volume1.threshold += 0.1
+        volume1.threshold += 0.025
         volume2.threshold = volume1.threshold
 
 # for testing performance
-#@canvas.connect
-#def on_draw(ev):
-    #canvas.update()
+@canvas.connect
+def on_draw(ev):
+    canvas.update()
 
 if __name__ == '__main__':
     print(__doc__)

--- a/examples/basics/scene/volume.py
+++ b/examples/basics/scene/volume.py
@@ -45,7 +45,7 @@ canvas.measure_fps()
 view = canvas.central_widget.add_view()
 
 # Set whether we are emulating a 3D texture
-emulate_texture = True
+emulate_texture = False
 
 # Create the volume visuals, only one is visible
 volume1 = scene.visuals.Volume(vol1, parent=view.scene, threshold=0.225,

--- a/examples/basics/scene/volume.py
+++ b/examples/basics/scene/volume.py
@@ -11,7 +11,7 @@ Example volume rendering
 Controls:
 
 * 1 - toggle camera between first person (fly) and regular 3D (turntable)
-* 2 - toggle between mip and iso render styles
+* 2 - toggle between volume rendering methods
 * 3 - toggle between stent-CT / brain-MRI image
 * 4 - toggle between colormaps
 * 0 - reset cameras
@@ -72,9 +72,11 @@ def on_key_press(event):
         cam_toggle = {cam1: cam2, cam2: cam3, cam3: cam1}
         view.camera = cam_toggle.get(view.camera, 'fly')
     elif event.text == '2':
-        method_toggle = {'mip': 'iso', 'iso': 'mip'}
-        volume1.method = method_toggle.get(volume1.method, 'mip')
-        volume2.method = volume1.method
+        methods = ['mip', 'translucent', 'iso', 'additive']
+        method = methods[(methods.index(volume1.method) + 1) % 4]
+        print("Volume render method: %s" % method)
+        volume1.method = method
+        volume2.method = method
     elif event.text == '3':
         volume1.visible = not volume1.visible
         volume2.visible = not volume1.visible
@@ -91,6 +93,11 @@ def on_key_press(event):
     elif event.text == ']':
         volume1.threshold += 0.1
         volume2.threshold = volume1.threshold
+
+# for testing performance
+#@canvas.connect
+#def on_draw(ev):
+    #canvas.update()
 
 if __name__ == '__main__':
     print(__doc__)

--- a/vispy/color/__init__.py
+++ b/vispy/color/__init__.py
@@ -9,9 +9,9 @@ This module provides support for manipulating colors.
 
 from ._color_dict import get_color_names, get_color_dict  # noqa
 from .color_array import Color, ColorArray
-from .colormap import (Colormap,  # noqa
+from .colormap import (Colormap, BaseColormap,  # noqa
                        get_colormap, get_colormaps)  # noqa
 
-__all__ = ['Color', 'ColorArray', 'Colormap',
+__all__ = ['Color', 'ColorArray', 'Colormap', 'BaseColormap',
            'get_colormap', 'get_colormaps',
            'get_color_names', 'get_color_dict']

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -462,7 +462,7 @@ class _Grays(BaseColormap):
 class _TGrays(BaseColormap):
     glsl_map = """
     vec4 tgrays(float t) {
-        return vec4(1.0, 1.0, 1.0, t*t);
+        return vec4(pow(t, 0.5), t, t*t, t);
     }
     """
 

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -462,7 +462,7 @@ class _Grays(BaseColormap):
 class _TGrays(BaseColormap):
     glsl_map = """
     vec4 tgrays(float t) {
-        return vec4(pow(t, 0.5), t, t*t, t);
+        return vec4(pow(t, 0.5), t, t*t, max(0, t*1.05 - 0.05));
     }
     """
 

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -462,7 +462,7 @@ class _Grays(BaseColormap):
 class _TGrays(BaseColormap):
     glsl_map = """
     vec4 tgrays(float t) {
-        return vec4(t, t, t, t);
+        return vec4(1.0, 1.0, 1.0, t*t);
     }
     """
 

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -459,6 +459,19 @@ class _Grays(BaseColormap):
         else:
             return np.array([t, t, t, 1.0], dtype=np.float32)
 
+class _TGrays(BaseColormap):
+    glsl_map = """
+    vec4 tgrays(float t) {
+        return vec4(t, t, t, t);
+    }
+    """
+
+    def map(self, t):
+        if isinstance(t, np.ndarray):
+            return np.hstack([t, t, t, t]).astype(np.float32)
+        else:
+            return np.array([t, t, t, t], dtype=np.float32)
+
 
 class _Ice(BaseColormap):
     glsl_map = """
@@ -518,6 +531,7 @@ _colormaps = dict(
     summer=Colormap([(0., .5, .4, 1.), (1., 1., .4, 1.)]),
     fire=_Fire(),
     grays=_Grays(),
+    tgrays=_TGrays(),
     hot=_Hot(),
     ice=_Ice(),
     winter=_Winter(),

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -459,19 +459,6 @@ class _Grays(BaseColormap):
         else:
             return np.array([t, t, t, 1.0], dtype=np.float32)
 
-class _TGrays(BaseColormap):
-    glsl_map = """
-    vec4 tgrays(float t) {
-        return vec4(pow(t, 0.5), t, t*t, max(0, t*1.05 - 0.05));
-    }
-    """
-
-    def map(self, t):
-        if isinstance(t, np.ndarray):
-            return np.hstack([t, t, t, t]).astype(np.float32)
-        else:
-            return np.array([t, t, t, t], dtype=np.float32)
-
 
 class _Ice(BaseColormap):
     glsl_map = """
@@ -531,7 +518,6 @@ _colormaps = dict(
     summer=Colormap([(0., .5, .4, 1.), (1., 1., .4, 1.)]),
     fire=_Fire(),
     grays=_Grays(),
-    tgrays=_TGrays(),
     hot=_Hot(),
     ice=_Ice(),
     winter=_Winter(),

--- a/vispy/gloo/preprocessor.py
+++ b/vispy/gloo/preprocessor.py
@@ -45,7 +45,8 @@ def merge_includes(code):
                 logger.critical('"%s" not found' % filename)
                 raise RuntimeError("File not found", filename)
             text = '\n// --- start of "%s" ---\n' % filename
-            text += open(path).read()
+            with open(path) as fh:
+                text += fh.read()
             text += '// --- end of "%s" ---\n' % filename
             return text
         return ''

--- a/vispy/gloo/preprocessor.py
+++ b/vispy/gloo/preprocessor.py
@@ -45,7 +45,7 @@ def merge_includes(code):
                 logger.critical('"%s" not found' % filename)
                 raise RuntimeError("File not found", filename)
             text = '\n// --- start of "%s" ---\n' % filename
-            text += remove_comments(open(path).read())
+            text += open(path).read()
             text += '// --- end of "%s" ---\n' % filename
             return text
         return ''
@@ -64,6 +64,6 @@ def preprocess(code):
     """Preprocess a code by removing comments, version and merging includes."""
 
     if code:
-        code = remove_comments(code)
+        #code = remove_comments(code)
         code = merge_includes(code)
     return code

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -538,13 +538,19 @@ class TextureEmulated3D(Texture2D):
 
     _glsl_sample = """
         vec4 sample(sampler2D tex, vec3 texcoord) {
-            float index = floor(texcoord.z * $depth);
+            float z = texcoord.z * $depth;
+            float zindex1 = floor(z);
+            float u1 = (mod(zindex1, $r) + texcoord.x) / $r;
+            float v1 = (floor(zindex1 / $r) + texcoord.y) / $c;
 
-            // Do a lookup in the 2D texture
-            float u = (mod(index, $r) + texcoord.x) / $r;
-            float v = (floor(index / $r) + texcoord.y) / $c;
+            float zindex2 = zindex1 + 1.0;
+            float u2 = (mod(zindex2, $r) + texcoord.x) / $r;
+            float v2 = (floor(zindex2 / $r) + texcoord.y) / $c;
 
-            return texture2D(tex, vec2(u,v));
+            vec4 s1 = texture2D(tex, vec2(u1, v1));
+            vec4 s2 = texture2D(tex, vec2(u2, v2));
+            
+            return s1 * (zindex2 - z) + s2 * (z - zindex1);
         }
     """
 

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -539,7 +539,13 @@ class TextureEmulated3D(Texture2D):
     # TODO: does GL's nearest use floor or round?
     _glsl_sample_nearest = """
         vec4 sample(sampler2D tex, vec3 texcoord) {
-            float index = floor(texcoord.z * $depth);
+            // Don't let adjacent frames be interpolated into this one
+            texcoord.x = min(texcoord.x * $shape.x, $shape.x - 0.5);
+            texcoord.x = max(0.5, texcoord.x) / $shape.x;
+            texcoord.y = min(texcoord.y * $shape.y, $shape.y - 0.5);
+            texcoord.y = max(0.5, texcoord.y) / $shape.y;
+            
+            float index = floor(texcoord.z * $shape.z);
 
             // Do a lookup in the 2D texture
             float u = (mod(index, $r) + texcoord.x) / $r;
@@ -551,7 +557,14 @@ class TextureEmulated3D(Texture2D):
 
     _glsl_sample_linear = """
         vec4 sample(sampler2D tex, vec3 texcoord) {
-            float z = texcoord.z * $depth;
+            // Don't let adjacent frames be interpolated into this one
+            texcoord.x = min(texcoord.x * $shape.x, $shape.x - 0.5);
+            texcoord.x = max(0.5, texcoord.x) / $shape.x;
+            texcoord.y = min(texcoord.y * $shape.y, $shape.y - 0.5);
+            texcoord.y = max(0.5, texcoord.y) / $shape.y;
+            
+
+            float z = texcoord.z * $shape.z;
             float zindex1 = floor(z);
             float u1 = (mod(zindex1, $r) + texcoord.x) / $r;
             float v1 = (floor(zindex1 / $r) + texcoord.y) / $c;
@@ -614,7 +627,7 @@ class TextureEmulated3D(Texture2D):
             data_or_shape[3:]
 
     def _update_variables(self):
-        self._glsl_sample['depth'] = self.depth
+        self._glsl_sample['shape'] = self.shape[:3][::-1]
         self._glsl_sample['c'] = self._c
         self._glsl_sample['r'] = self._r
 

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -504,7 +504,6 @@ class BaseGlooFunctions(object):
             cull_face = kwargs.pop('cull_face')
             if isinstance(cull_face, bool):
                 funcname = 'glEnable' if cull_face else 'glDisable'
-                #func(_gl_attr('cull_face'))
                 self.glir.command('FUNC', funcname, 'cull_face')
             else:
                 self.glir.command('FUNC', 'glEnable', 'cull_face')

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -31,15 +31,23 @@ _setters = [s[4:] for s in __all__
 
 # NOTE: If these are updated to have things beyond glEnable/glBlendFunc
 # calls, set_preset_state will need to be updated to deal with it.
-_gl_presets = dict(
-    opaque=dict(depth_test=True, cull_face=False, blend=False),
-    translucent=dict(depth_test=True, cull_face=False, blend=True,
-                        blend_func=('src_alpha', 'one_minus_src_alpha')),
-    additive=dict(depth_test=False, cull_face=False, blend=True,
-                    blend_func=('src_alpha', 'one'),)
-)
+_gl_presets = {
+    'opaque': dict(
+        depth_test=True, 
+        cull_face=False, 
+        blend=False),
+    'translucent': dict(
+        depth_test=True, 
+        cull_face=False, 
+        blend=True,
+        blend_func=('src_alpha', 'one_minus_src_alpha')),
+    'additive': dict(
+        depth_test=False, 
+        cull_face=False, 
+        blend=True,
+        blend_func=('src_alpha', 'one')),
+}
     
-
 
 def get_current_canvas():
     """ Proxy for context.get_current_canvas to avoud circular import.

--- a/vispy/scene/cameras/cameras.py
+++ b/vispy/scene/cameras/cameras.py
@@ -261,7 +261,6 @@ class BaseCamera(Node):
         For e.g. the TurntableCamera the elevation and azimuth are not
         set. One should use reset() for that.
         """
-
         # Flag to indicate that this is an initializing (not user-invoked)
         init = self._xlim is None
 
@@ -288,6 +287,7 @@ class BaseCamera(Node):
             for i in range(3):
                 if bounds[i] is None:
                     bounds[i] = self._viewbox.get_scene_bounds(i)
+        print "setrange", bounds
         # Calculate ranges and margins
         ranges = [b[1] - b[0] for b in bounds]
         margins = [(r*margin or 0.1) for r in ranges]

--- a/vispy/scene/cameras/cameras.py
+++ b/vispy/scene/cameras/cameras.py
@@ -287,7 +287,7 @@ class BaseCamera(Node):
             for i in range(3):
                 if bounds[i] is None:
                     bounds[i] = self._viewbox.get_scene_bounds(i)
-        print "setrange", bounds
+        
         # Calculate ranges and margins
         ranges = [b[1] - b[0] for b in bounds]
         margins = [(r*margin or 0.1) for r in ranges]

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -32,9 +32,13 @@ class Node(object):
     name : str
         The name used to identify the node.
     """
+    
+    # Needed to allow subclasses to repr() themselves before Node.__init__()
+    _name = None
 
     def __init__(self, parent=None, name=None, **kwargs):
         self.name = name
+        self._visible = True
 
         # Add some events to the emitter groups:
         events = ['parents_change', 'children_change', 'transform_change',

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -4,14 +4,12 @@
 
 from __future__ import division
 
-from ..util.event import Event
+from ..util.event import Event, EmitterGroup
 from ..visuals.transforms import (NullTransform, BaseTransform, 
                                   ChainTransform, create_transform)
-from ..visuals import Visual
 
 
-# todo: I though the visuals were mixed, but the base Node was *not* a visual?
-class Node(Visual):
+class Node(object):
     """ Base class representing an object in a scene.
 
     A group of nodes connected through parent-child relationships define a 
@@ -36,16 +34,19 @@ class Node(Visual):
     """
 
     def __init__(self, parent=None, name=None, **kwargs):
-        Visual.__init__(self, **kwargs)
-        
+        self.name = name
+
         # Add some events to the emitter groups:
         events = ['parents_change', 'children_change', 'transform_change',
                   'mouse_press', 'mouse_move', 'mouse_release', 'mouse_wheel', 
                   'key_press', 'key_release']
+        # Create event emitter if needed (in subclasses that inherit from
+        # Visual, we already have an emitter to share)
+        if not hasattr(self, 'events'):
+            self.events = EmitterGroup(source=self, auto_connect=True,
+                                       update=Event)
         self.events.add(**dict([(ev, Event) for ev in events]))
         
-        self.name = name
-
         # Entities are organized in a parent-children hierarchy
         self._children = []
         # TODO: use weakrefs for parents.
@@ -154,15 +155,15 @@ class Node(Visual):
         parent._remove_child(self)
         self.events.parents_change(removed=parent)
 
-    def _add_child(self, ent):
-        self._children.append(ent)
-        self.events.children_change(added=ent)
-        ent.events.update.connect(self.events.update)
+    def _add_child(self, node):
+        self._children.append(node)
+        self.events.children_change(added=node)
+        node.events.update.connect(self.events.update)
 
-    def _remove_child(self, ent):
-        self._children.remove(ent)
-        self.events.children_change(removed=ent)
-        ent.events.update.disconnect(self.events.update)
+    def _remove_child(self, node):
+        self._children.remove(node)
+        self.events.children_change(removed=node)
+        node.events.update.disconnect(self.events.update)
 
     def update(self):
         """

--- a/vispy/scene/systems.py
+++ b/vispy/scene/systems.py
@@ -19,7 +19,7 @@ class DrawingSystem(object):
     def process(self, event, node):
         prof = Profiler(str(node))
         # Draw this node if it is a visual
-        if isinstance(node, Visual) and node.visible:
+        if hasattr(node, 'draw') and node.visible:
             try:
                 node.draw(event)
                 prof('draw')

--- a/vispy/scene/systems.py
+++ b/vispy/scene/systems.py
@@ -6,7 +6,6 @@ from __future__ import division
 
 import sys
 
-from ..visuals.visual import Visual
 from ..util.logs import logger, _handle_exception
 from ..util.profiler import Profiler
 

--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -35,6 +35,7 @@ def create_visual_node(subclass):
     def __init__(self, *args, **kwargs):
         parent = kwargs.pop('parent', None)
         name = kwargs.pop('name', None)
+        self.name = name  # to allow __str__ before Node.__init__
         subclass.__init__(self, *args, **kwargs)
         Node.__init__(self, parent=parent, name=name)
     

--- a/vispy/scene/widgets/viewbox.py
+++ b/vispy/scene/widgets/viewbox.py
@@ -163,7 +163,7 @@ class ViewBox(Widget):
                                         max(bounds[axis][1], b[1]))
         # Set defaults
         for axis in (0, 1, 2):
-            if np.inf in [np.abs(x) for x in bounds[axis]]:
+            if any(np.isinf(bounds[axis])):
                 bounds[axis] = -1, 1
         
         if dim is not None:

--- a/vispy/scene/widgets/viewbox.py
+++ b/vispy/scene/widgets/viewbox.py
@@ -13,6 +13,7 @@ from ...ext.six import string_types
 from ... color import Color
 from ... import gloo
 from ...visuals.components import Clipper
+from ...visuals import Visual
 
 
 class ViewBox(Widget):
@@ -315,11 +316,12 @@ class ViewBox(Widget):
             root = self.scene
             
         for ch in root.children:
-            try:
-                ch.attach(self._clipper)
-            except NotImplementedError:
-                # visual does not support clipping
-                pass
+            if isinstance(ch, Visual):
+                try:
+                    ch.attach(self._clipper)
+                except NotImplementedError:
+                    # visual does not support clipping
+                    pass
             self._prepare_fragment(ch)
 
     def _prepare_viewport(self, event):

--- a/vispy/visuals/gridlines.py
+++ b/vispy/visuals/gridlines.py
@@ -82,7 +82,7 @@ class GridLinesVisual(Visual):
         self._vbo = None
         self._scale = scale
         self._tr_cache = TransformCache()
-        self.set_gl_state('additive', cull_face='front_and_back')
+        self.set_gl_state('additive', cull_face=False)
 
     def _buffer(self):
         if self._vbo is None:

--- a/vispy/visuals/gridlines.py
+++ b/vispy/visuals/gridlines.py
@@ -77,7 +77,7 @@ class GridLinesVisual(Visual):
     any scale.
     """
     def __init__(self, scale=(1, 1), **kwargs):
-        super(Visual, self).__init__(**kwargs)
+        super(GridLinesVisual, self).__init__(**kwargs)
         self._program = ModularProgram(VERT, FRAG)
         self._vbo = None
         self._scale = scale

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -258,7 +258,7 @@ class ImageVisual(Visual):
         if self._data is None:
             return
 
-        set_state(cull_face='front_and_back')
+        set_state(cull_face=False)
 
         # upload texture is needed
         if self._texture is None:

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -76,7 +76,7 @@ class MeshVisual(Visual):
         Visual.__init__(self, **kwargs)
         
         self.set_gl_state('translucent', depth_test=True,
-                          cull_face='front_and_back')
+                          cull_face=False)
         
         # Create a program
         self._program = ModularProgram(vertex_template, fragment_template)

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -110,7 +110,7 @@ class PolygonVisual(Visual):
             return
         if not self._color.is_blank:
             gloo.set_state(polygon_offset_fill=True, 
-                           cull_face='front_and_back')
+                           cull_face=False)
             gloo.set_polygon_offset(1, 1)
             self.mesh.draw(transforms)
         if not self._border_color.is_blank:

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -113,13 +113,13 @@ void main() {{
     
     // Compute the distance to the front surface or near clipping plane
     float distance = dot(nearpos-v_position, view_ray);
-    distance = max(distance, min((0 - v_position.x) / view_ray.x, 
-                                 (u_shape.x - v_position.x) / view_ray.x));
-    distance = max(distance, min((0 - v_position.y) / view_ray.y, 
-                                 (u_shape.y - v_position.y) / view_ray.y));
-    distance = max(distance, min((0 - v_position.z) / view_ray.z, 
-                                 (u_shape.z - v_position.z) / view_ray.z));
-        
+    distance = max(distance, min((-0.5 - v_position.x) / view_ray.x, 
+                            (u_shape.x - 0.5 - v_position.x) / view_ray.x));
+    distance = max(distance, min((-0.5 - v_position.y) / view_ray.y, 
+                            (u_shape.y - 0.5 - v_position.y) / view_ray.y));
+    distance = max(distance, min((-0.5 - v_position.z) / view_ray.z, 
+                            (u_shape.z - 0.5 - v_position.z) / view_ray.z));
+    
     // Now we have the starting position on the front surface
     vec3 front = v_position + view_ray * distance;
     
@@ -399,7 +399,7 @@ class VolumeVisual(Visual):
         # Only show back faces of cuboid. This is required because if we are 
         # inside the volume, then the front faces are outside of the clipping
         # box and will not be drawn.
-        self.set_gl_state('translucent', cull_face='back')
+        self.set_gl_state('translucent', cull_face=False)
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
 
         # Storage of information of volume

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -336,13 +336,12 @@ MIP_SNIPPETS = dict(
     in_loop="""
         color = $cmap(color);
         float a1 = integrated_color.a;
-        float a2 = color.a;
-        float t1 = 1.0 - a1;
-        float t2 = 1.0 - a2;
+        float a2 = color.a * (1 - a1);
+        float alpha = max(a1 + a2, 0.0000001);
         
         // Translucent
         //integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * a1), );
-        integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * a1), a1 + a2 * t1);
+        integrated_color = vec4((color.rgb * a2/alpha) + (integrated_color.rgb * a1/alpha), alpha);
         
         // Additive
         //integrated_color = vec4(integrated_color.rgb + (color.rgb * color.a), (1.0 - t1*t2));

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -335,9 +335,17 @@ MIP_SNIPPETS = dict(
         """,
     in_loop="""
         color = $cmap(color);
-        float t1 = 1.0 - integrated_color.a;
-        float t2 = 1.0 - color.a;
-        integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * integrated_color.a), (1.0 - t1*t2));
+        float a1 = integrated_color.a;
+        float a2 = color.a;
+        float t1 = 1.0 - a1;
+        float t2 = 1.0 - a2;
+        
+        // Translucent
+        //integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * a1), );
+        integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * a1), a1 + a2 * t1);
+        
+        // Additive
+        //integrated_color = vec4(integrated_color.rgb + (color.rgb * color.a), (1.0 - t1*t2));
         """,
     after_loop="""
         gl_FragColor = integrated_color;
@@ -412,6 +420,7 @@ class VolumeVisual(Visual):
                  relative_step_size=0.8, cmap='tgrays',
                  emulate_texture=False):
         Visual.__init__(self)
+        self.set_gl_state('translucent')
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
 
         # Storage of information of volume

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -126,8 +126,8 @@ void main() {{
     
     // Offset the ray with a random amount to make for a smoother
     // appearance when rotating the camera. noise is [0..1].
-    float noise = rand((ray.xy * 10.0 + edgeloc.xy) * 100.0);
-    edgeloc += ray * (0.5 - noise);
+    //float noise = rand((ray.xy * 10.0 + edgeloc.xy) * 100.0);
+    //edgeloc += ray * (0.5 - noise);
     
     // Instead of discarding based on gl_FrontFacing, we can also discard
     // on number of steps.
@@ -328,6 +328,22 @@ MIP_SNIPPETS = dict(
         """,
 )
 
+
+MIP_SNIPPETS = dict(
+    before_loop="""
+        vec4 integrated_color = vec4(0., 0., 0., 0.);
+        """,
+    in_loop="""
+        color = $cmap(color);
+        float t1 = 1.0 - integrated_color.a;
+        float t2 = 1.0 - color.a;
+        integrated_color = vec4((color.rgb * t1) + (integrated_color.rgb * integrated_color.a), (1.0 - t1*t2));
+        """,
+    after_loop="""
+        gl_FragColor = integrated_color;
+        """,
+)
+
 MIP_FRAG_SHADER = FRAG_SHADER.format(**MIP_SNIPPETS)
 
 ISO_SNIPPETS = dict(
@@ -393,7 +409,7 @@ class VolumeVisual(Visual):
     """
 
     def __init__(self, vol, clim=None, method='mip', threshold=None, 
-                 relative_step_size=0.8, cmap='grays',
+                 relative_step_size=0.8, cmap='tgrays',
                  emulate_texture=False):
         Visual.__init__(self)
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -315,7 +315,8 @@ TRANSLUCENT_SNIPPETS = dict(
             float alpha = max(a1 + a2, 0.001);
             
             // Doesn't work.. GLSL optimizer bug?
-            //integrated_color = (integrated_color * a1 / alpha) + (color * a2 / alpha); 
+            //integrated_color = (integrated_color * a1 / alpha) + 
+            //                   (color * a2 / alpha); 
             // This should be identical but does work correctly:
             integrated_color *= a1 / alpha;
             integrated_color += color * a2 / alpha;


### PR DESCRIPTION
The main purpose of this PR is to add a couple of new volume rendering methods, but many ancillary changes are included.

* Add "translucent" rendering method (better quality compositing but requires more effort in selecting colormaps)
* Add "additive" rendering method (nice for visualizing 3D functions like electron orbitals)
* Reorganized a "bit" of the volume fragment shader core--improved performance, simpler code, somewhat easier to understand.
* Tweaked isosurface rendering; no more ray randomization.
* Added Z-interpolation to emulated 3D texture
* Disabled comment removal from shader preprocessing (@rougier, was this necessary?)
* Fixed `VisualNode` double-init bug (see #871) 

@almarklein, please be critical--I imagine I have not tested the volume rendering under all of the cases that you have.

Depends on #870.
