### PR TITLE
PR: Support for parametric plane and box geometries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ doc/_build
 /_gh-pages
 /_images
 /_demo-data
+.idea
 build
 dist
 MANIFEST

--- a/examples/basics/visuals/box.py
+++ b/examples/basics/visuals/box.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014, Vispy Development Team.
+# Copyright (c) 2015, Vispy Development Team.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 """
@@ -15,9 +15,6 @@ canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 
 view = canvas.central_widget.add_view()
 
-camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
-view.camera = camera
-
 vertices, faces, outline = geometry.create_box(width=2, height=4, depth=8,
                                                width_segments=4,
                                                height_segments=8,
@@ -28,6 +25,9 @@ box = scene.visuals.Box(width=4, height=4, depth=8, width_segments=4,
                         vertex_colors=vertices['color'],
                         edge_color='k',
                         parent=view.scene)
+
+camera = scene.cameras.TurntableCamera(fov=45, azimuth=60, parent=view.scene)
+view.camera = camera
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     canvas.app.run()

--- a/examples/basics/visuals/box.py
+++ b/examples/basics/visuals/box.py
@@ -9,8 +9,7 @@ Simple demonstration of the box geometry.
 import sys
 
 from vispy import scene
-from vispy import visuals
-from vispy.geometry import create_box
+from vispy import geometry
 
 canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 
@@ -19,45 +18,16 @@ view = canvas.central_widget.add_view()
 camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
 view.camera = camera
 
-vertices, faces, outline = create_box(width=1,
-                                      height=2,
-                                      depth=3,
-                                      width_segments=4,
-                                      height_segments=8,
-                                      depth_segments=12)
+vertices, faces, outline = geometry.create_box(width=2, height=4, depth=8,
+                                               width_segments=4,
+                                               height_segments=8,
+                                               depth_segments=16)
 
-box_f = scene.Mesh(vertices=vertices['position'],
-                   faces=faces,
-                   vertex_colors=vertices['color'],
-                   parent=view.scene)
-
-box_w1 = scene.Mesh(vertices=vertices['position'],
-                    faces=outline,
-                    vertex_colors=vertices['color'],
-                    mode='lines',
-                    parent=view.scene)
-
-transform = visuals.transforms.AffineTransform()
-transform.translate((0, 0, 2.5))
-box_w1.transform = transform
-
-vertices, faces, outline = create_box(width=1,
-                                      height=2,
-                                      depth=3,
-                                      width_segments=4,
-                                      height_segments=8,
-                                      depth_segments=12,
-                                      planes=('-x', '-y', '-z'))
-
-box_w2 = scene.Mesh(vertices=vertices['position'],
-                    faces=outline,
-                    vertex_colors=vertices['color'],
-                    mode='lines',
-                    parent=view.scene)
-
-transform = visuals.transforms.AffineTransform()
-transform.translate((0, 3.5, 0))
-box_w2.transform = transform
+box = scene.visuals.Box(width=4, height=4, depth=8, width_segments=4,
+                        height_segments=8, depth_segments=16,
+                        vertex_colors=vertices['color'],
+                        edge_color='k',
+                        parent=view.scene)
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     canvas.app.run()

--- a/examples/basics/visuals/box.py
+++ b/examples/basics/visuals/box.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+"""
+Simple demonstration of the box geometry.
+"""
+
+import sys
+
+from vispy import scene
+from vispy import visuals
+from vispy.geometry import create_box
+
+canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
+
+view = canvas.central_widget.add_view()
+
+camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
+view.camera = camera
+
+vertices, faces, outline = create_box(width=1,
+                                      height=2,
+                                      depth=3,
+                                      width_segments=4,
+                                      height_segments=8,
+                                      depth_segments=12)
+
+box_f = scene.Mesh(vertices=vertices['position'],
+                   faces=faces,
+                   vertex_colors=vertices['color'],
+                   parent=view.scene)
+
+box_w1 = scene.Mesh(vertices=vertices['position'],
+                    faces=outline,
+                    vertex_colors=vertices['color'],
+                    mode='lines',
+                    parent=view.scene)
+
+transform = visuals.transforms.AffineTransform()
+transform.translate((0, 0, 2.5))
+box_w1.transform = transform
+
+vertices, faces, outline = create_box(width=1,
+                                      height=2,
+                                      depth=3,
+                                      width_segments=4,
+                                      height_segments=8,
+                                      depth_segments=12,
+                                      planes=('-x', '-y', '-z'))
+
+box_w2 = scene.Mesh(vertices=vertices['position'],
+                    faces=outline,
+                    vertex_colors=vertices['color'],
+                    mode='lines',
+                    parent=view.scene)
+
+transform = visuals.transforms.AffineTransform()
+transform.translate((0, 3.5, 0))
+box_w2.transform = transform
+
+if __name__ == '__main__' and sys.flags.interactive == 0:
+    canvas.app.run()

--- a/examples/basics/visuals/plane.py
+++ b/examples/basics/visuals/plane.py
@@ -9,8 +9,7 @@ Simple demonstration of the plane geometry.
 import sys
 
 from vispy import scene
-from vispy import visuals
-from vispy.geometry import create_plane
+from vispy import geometry
 
 canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 
@@ -19,42 +18,16 @@ view = canvas.central_widget.add_view()
 camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
 view.camera = camera
 
-vertices, faces, outline = create_plane(width=2,
-                                        height=4,
-                                        width_segments=4,
-                                        height_segments=8,
-                                        direction='+y')
+vertices, faces, outline = geometry.create_plane(width=2, height=4,
+                                                 width_segments=4,
+                                                 height_segments=8,
+                                                 direction='+y')
 
-plane_f = scene.Mesh(vertices=vertices['position'],
-                     faces=faces,
-                     vertex_colors=vertices['color'],
-                     parent=view.scene)
-
-plane_w1 = scene.Mesh(vertices=vertices['position'],
-                      faces=outline,
-                      vertex_colors=vertices['color'],
-                      mode='lines',
-                      parent=view.scene)
-
-transform = visuals.transforms.AffineTransform()
-transform.translate((0, 0, 2.5))
-plane_w1.transform = transform
-
-vertices, faces, outline = create_plane(width=2,
-                                        height=4,
-                                        width_segments=4,
-                                        height_segments=8,
-                                        direction='+z')
-
-plane_w2 = scene.Mesh(vertices=vertices['position'],
-                      faces=outline,
-                      vertex_colors=vertices['color'],
-                      mode='lines',
-                      parent=view.scene)
-
-transform = visuals.transforms.AffineTransform()
-transform.translate((4.5, 0, 0))
-plane_w2.transform = transform
+plane = scene.visuals.Plane(width=2, height=4, width_segments=4,
+                            height_segments=8, direction='+y',
+                            vertex_colors=vertices['color'],
+                            edge_color='k',
+                            parent=view.scene)
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     canvas.app.run()

--- a/examples/basics/visuals/plane.py
+++ b/examples/basics/visuals/plane.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+"""
+Simple demonstration of the plane geometry.
+"""
+
+import sys
+
+from vispy import scene
+from vispy import visuals
+from vispy.geometry import create_plane
+
+canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
+
+view = canvas.central_widget.add_view()
+
+camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
+view.camera = camera
+
+vertices, faces, outline = create_plane(width=2,
+                                        height=4,
+                                        width_segments=4,
+                                        height_segments=8,
+                                        direction='+y')
+
+plane_f = scene.Mesh(vertices=vertices['position'],
+                     faces=faces,
+                     vertex_colors=vertices['color'],
+                     parent=view.scene)
+
+plane_w1 = scene.Mesh(vertices=vertices['position'],
+                      faces=outline,
+                      vertex_colors=vertices['color'],
+                      mode='lines',
+                      parent=view.scene)
+
+transform = visuals.transforms.AffineTransform()
+transform.translate((0, 0, 2.5))
+plane_w1.transform = transform
+
+vertices, faces, outline = create_plane(width=2,
+                                        height=4,
+                                        width_segments=4,
+                                        height_segments=8,
+                                        direction='+z')
+
+plane_w2 = scene.Mesh(vertices=vertices['position'],
+                      faces=outline,
+                      vertex_colors=vertices['color'],
+                      mode='lines',
+                      parent=view.scene)
+
+transform = visuals.transforms.AffineTransform()
+transform.translate((4.5, 0, 0))
+plane_w2.transform = transform
+
+if __name__ == '__main__' and sys.flags.interactive == 0:
+    canvas.app.run()

--- a/examples/basics/visuals/plane.py
+++ b/examples/basics/visuals/plane.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014, Vispy Development Team.
+# Copyright (c) 2015, Vispy Development Team.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 """
@@ -15,9 +15,6 @@ canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 
 view = canvas.central_widget.add_view()
 
-camera = scene.cameras.TurntableCamera(fov=45, parent=view.scene)
-view.camera = camera
-
 vertices, faces, outline = geometry.create_plane(width=2, height=4,
                                                  width_segments=4,
                                                  height_segments=8,
@@ -28,6 +25,9 @@ plane = scene.visuals.Plane(width=2, height=4, width_segments=4,
                             vertex_colors=vertices['color'],
                             edge_color='k',
                             parent=view.scene)
+
+camera = scene.cameras.TurntableCamera(fov=45, azimuth=-45, parent=view.scene)
+view.camera = camera
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     canvas.app.run()

--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -9,8 +9,8 @@ This module implements classes and methods for handling geometric data.
 from __future__ import division
 
 __all__ = ['MeshData', 'PolygonData', 'Rect', 'Triangulation', 'triangulate',
-           'create_arrow', 'create_cone', 'create_cube', 'create_cylinder',
-           'create_sphere', 'resize']
+           'create_arrow', 'create_box', 'create_cone', 'create_cube',
+           'create_cylinder', 'create_plane', 'create_sphere', 'resize']
 
 from .polygon import PolygonData  # noqa
 from .meshdata import MeshData  # noqa

--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -19,5 +19,6 @@ from .triangulation import Triangulation, triangulate  # noqa
 from .torusknot import TorusKnot  # noqa
 from .calculations import (_calculate_normals, _fast_cross_3d,  # noqa
                            resize)  # noqa
-from .generation import create_arrow, create_box, create_cone, create_cube, \
-           create_cylinder, create_plane, create_sphere  # noqa
+from .generation import (create_arrow, create_box, create_cone,  # noqa
+                         create_cube, create_cylinder, create_plane,  # noqa
+                         create_sphere)  # noqa

--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -19,5 +19,5 @@ from .triangulation import Triangulation, triangulate  # noqa
 from .torusknot import TorusKnot  # noqa
 from .calculations import (_calculate_normals, _fast_cross_3d,  # noqa
                            resize)  # noqa
-from .generation import create_arrow, create_cone, create_cube, \
-           create_cylinder, create_sphere  # noqa
+from .generation import create_arrow, create_box, create_cone, create_cube, \
+           create_cylinder, create_plane, create_sphere  # noqa

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -89,6 +89,250 @@ def create_cube():
     return vertices, filled, outline
 
 
+def create_plane(width=1,
+                 height=1,
+                 width_segments=1,
+                 height_segments=1,
+                 direction='+z'):
+    """ Generate vertices & indices for a filled and outlined plane.
+
+    Parameters
+    ----------
+    width : numeric
+        Plane width.
+    height : numeric
+        Plane height.
+    width_segments : int
+        Plane segments count along the width.
+    height_segments : numeric
+        Plane segments count along the height.
+    direction: unicode
+        ``{'-x', '+x', '-y', '+y', '-z', '+z'}``
+        Direction the plane will be facing.
+
+    Returns
+    -------
+    vertices : array
+        Array of vertices suitable for use as a VertexBuffer.
+    faces : array
+        Indices to use to produce a filled plane.
+    outline : array
+        Indices to use to produce an outline of the plane.
+
+    References
+    ----------
+    [1] Cabello, R. (n.d.). PlaneBufferGeometry.js. Retrieved May 12, 2015,
+        from https://github.com/mrdoob/three.js/blob/master/src/extras/geometries/PlaneBufferGeometry.js  #noqa
+    """
+
+    x_grid = width_segments
+    y_grid = height_segments
+
+    x_grid1 = x_grid + 1
+    y_grid1 = y_grid + 1
+
+    # Positions, normals and texcoords.
+    positions = np.zeros(x_grid1 * y_grid1 * 3)
+    normals = np.zeros(x_grid1 * y_grid1 * 3)
+    texcoords = np.zeros(x_grid1 * y_grid1 * 2)
+
+    offset = offset1 = 0
+    for i_y in range(y_grid1):
+        y = i_y * height / y_grid - height / 2
+        for i_x in range(x_grid1):
+            x = i_x * width / x_grid - width / 2
+
+            positions[offset] = x
+            positions[offset + 1] = - y
+
+            normals[offset + 2] = 1
+
+            texcoords[offset1] = i_x / x_grid
+            texcoords[offset1 + 1] = 1 - (i_y / y_grid)
+
+            offset += 3
+            offset1 += 2
+
+    # Faces and outline.
+    faces = np.zeros(x_grid * y_grid * 6, dtype=np.uint32)
+    outline = np.zeros(x_grid * y_grid * 8, dtype=np.uint32)
+
+    offset = offset1 = 0
+    for i_y in range(y_grid):
+        for i_x in range(x_grid):
+            a = i_x + x_grid1 * i_y
+            b = i_x + x_grid1 * (i_y + 1)
+            c = (i_x + 1) + x_grid1 * (i_y + 1)
+            d = (i_x + 1) + x_grid1 * i_y
+
+            faces[offset] = a
+            faces[offset + 1] = b
+            faces[offset + 2] = d
+
+            faces[offset + 3] = b
+            faces[offset + 4] = c
+            faces[offset + 5] = d
+
+            outline[offset1] = a
+            outline[offset1 + 1] = b
+
+            outline[offset1 + 2] = b
+            outline[offset1 + 3] = c
+
+            outline[offset1 + 4] = c
+            outline[offset1 + 5] = d
+
+            outline[offset1 + 6] = d
+            outline[offset1 + 7] = a
+
+            offset += 6
+            offset1 += 8
+
+    positions = np.reshape(positions, (-1, 3))
+    normals = np.reshape(normals, (-1, 3))
+    faces = np.reshape(faces, (-1, 3))
+    outline = np.reshape(outline, (-1, 2))
+
+    direction = direction.lower()
+    if direction in ('-x', '+x'):
+        shift, neutral_axis = 1, 0
+    elif direction in ('-y', '+y'):
+        shift, neutral_axis = -1, 1
+    elif direction in ('-z', '+z'):
+        shift, neutral_axis = 0, 2
+
+    sign = -1 if '-' in direction else 1
+
+    positions = np.roll(positions, shift, -1)
+    texcoords = np.reshape(texcoords, (-1, 2))
+    normals = np.roll(normals, shift, -1) * sign
+    colours = np.ravel(positions)
+    colours = np.hstack((np.reshape(np.interp(colours,
+                                              (np.min(colours),
+                                               np.max(colours)),
+                                              (0, 1)),
+                                    positions.shape),
+                         np.ones((positions.shape[0], 1))))
+    colours[..., neutral_axis] = 0
+
+    vertices = np.zeros(positions.shape[0],
+                        [('position', np.float32, 3),
+                         ('texcoord', np.float32, 2),
+                         ('normal', np.float32, 3),
+                         ('color', np.float32, 4)])
+
+    vertices['position'] = positions
+    vertices['texcoord'] = texcoords
+    vertices['normal'] = normals
+    vertices['color'] = colours
+
+    return vertices, faces, outline
+
+
+def create_box(width=1,
+               height=1,
+               depth=1,
+               width_segments=1,
+               height_segments=1,
+               depth_segments=1,
+               planes=None):
+    """ Generate vertices & indices for a filled and outlined box.
+
+    Parameters
+    ----------
+    width : numeric
+        Box width.
+    height : numeric
+        Box height.
+    depth : numeric
+        Box depth.
+    width_segments : int
+        Box segments count along the width.
+    height_segments : numeric
+        Box segments count along the height.
+    depth_segments : numeric
+        Box segments count along the depth.
+    planes: array_like
+        Any combination of ``{'-x', '+x', '-y', '+y', '-z', '+z'}``
+        Included planes in the box construction.
+
+    Returns
+    -------
+    vertices : array
+        Array of vertices suitable for use as a VertexBuffer.
+    faces : array
+        Indices to use to produce a filled box.
+    outline : array
+        Indices to use to produce an outline of the box.
+    """
+
+    planes = (('+x', '-x', '+y', '-y', '+z', '-z')
+              if planes is None else
+              [d.lower() for d in planes])
+
+    w_s, h_s, d_s = width_segments, height_segments, depth_segments
+
+    planes_m = []
+    if '-z' in planes:
+        planes_m.append(create_plane(width, depth, w_s, d_s, '-z'))
+        planes_m[-1][0]['position'][..., 2] -= height / 2
+    if '+z' in planes:
+        planes_m.append(create_plane(width, depth, w_s, d_s, '+z'))
+        planes_m[-1][0]['position'][..., 2] += height / 2
+
+    if '-y' in planes:
+        planes_m.append(create_plane(height, width, h_s, w_s, '-y'))
+        planes_m[-1][0]['position'][..., 1] -= depth / 2
+    if '+y' in planes:
+        planes_m.append(create_plane(height, width, h_s, w_s, '+y'))
+        planes_m[-1][0]['position'][..., 1] += depth / 2
+
+    if '-x' in planes:
+        planes_m.append(create_plane(depth, height, d_s, h_s, '-x'))
+        planes_m[-1][0]['position'][..., 0] -= width / 2
+    if '+x' in planes:
+        planes_m.append(create_plane(depth, height, d_s, h_s, '+x'))
+        planes_m[-1][0]['position'][..., 0] += width / 2
+
+    positions = np.zeros((0, 3))
+    texcoords = np.zeros((0, 2))
+    normals = np.zeros((0, 3))
+
+    faces = np.zeros((0, 3), dtype=np.uint32)
+    outline = np.zeros((0, 2), dtype=np.uint32)
+
+    offset = 0
+    for vertices_p, faces_p, outline_p in planes_m:
+        positions = np.vstack((positions, vertices_p['position']))
+        texcoords = np.vstack((texcoords, vertices_p['texcoord']))
+        normals = np.vstack((normals, vertices_p['normal']))
+
+        faces = np.vstack((faces, faces_p + offset))
+        outline = np.vstack((outline, outline_p + offset))
+        offset += vertices_p['position'].shape[0]
+
+    vertices = np.zeros(positions.shape[0],
+                        [('position', np.float32, 3),
+                         ('texcoord', np.float32, 2),
+                         ('normal', np.float32, 3),
+                         ('color', np.float32, 4)])
+
+    colors = np.ravel(positions)
+    colors = np.hstack((np.reshape(np.interp(colors,
+                                             (np.min(colors),
+                                              np.max(colors)),
+                                             (0, 1)),
+                                   positions.shape),
+                        np.ones((positions.shape[0], 1))))
+
+    vertices['position'] = positions
+    vertices['texcoord'] = texcoords
+    vertices['normal'] = normals
+    vertices['color'] = colors
+
+    return vertices, faces, outline
+
+
 def create_sphere(rows, cols, radius=1.0, offset=True):
     """Create a sphere
 

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -118,7 +118,7 @@ def create_plane(width=1, height=1, width_segments=1, height_segments=1,
 
     References
     ----------
-    [1] Cabello, R. (n.d.). PlaneBufferGeometry.js. Retrieved May 12, 2015,
+    .. [1] Cabello, R. (n.d.). PlaneBufferGeometry.js. Retrieved May 12, 2015,
         from http://git.io/vU1Fh
     """
 

--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -119,7 +119,7 @@ def create_plane(width=1, height=1, width_segments=1, height_segments=1,
     References
     ----------
     [1] Cabello, R. (n.d.). PlaneBufferGeometry.js. Retrieved May 12, 2015,
-        from https://github.com/mrdoob/three.js/blob/master/src/extras/geometries/PlaneBufferGeometry.js  #noqa
+        from http://git.io/vU1Fh
     """
 
     x_grid = width_segments

--- a/vispy/geometry/tests/test_generation.py
+++ b/vispy/geometry/tests/test_generation.py
@@ -5,7 +5,14 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 from vispy.testing import run_tests_if_main
-from vispy.geometry import create_cube, create_cylinder, create_sphere
+from vispy.geometry import (create_box, create_cube, create_cylinder,
+                            create_sphere, create_plane)
+
+def test_box():
+    """Test box function"""
+    vertices, filled, outline = create_box()
+    assert_array_equal(np.arange(len(vertices)), np.unique(filled))
+    assert_array_equal(np.arange(len(vertices)), np.unique(outline))
 
 
 def test_cube():
@@ -27,6 +34,13 @@ def test_cylinder():
     md = create_cylinder(10, 20, radius=[10, 10])
     radii = np.sqrt((md.get_vertices()[:, :2] ** 2).sum(axis=1))
     assert_allclose(radii, np.ones_like(radii) * 10)
+
+
+def test_plane():
+    """Test plane function"""
+    vertices, filled, outline = create_plane()
+    assert_array_equal(np.arange(len(vertices)), np.unique(filled))
+    assert_array_equal(np.arange(len(vertices)), np.unique(outline))
 
 
 run_tests_if_main()

--- a/vispy/geometry/tests/test_generation.py
+++ b/vispy/geometry/tests/test_generation.py
@@ -8,6 +8,7 @@ from vispy.testing import run_tests_if_main
 from vispy.geometry import (create_box, create_cube, create_cylinder,
                             create_sphere, create_plane)
 
+
 def test_box():
     """Test box function"""
     vertices, filled, outline = create_box()

--- a/vispy/visuals/__init__.py
+++ b/vispy/visuals/__init__.py
@@ -11,6 +11,7 @@ a scenegraph. For scenegraph use, see the complementary Visual+Node classes
 defined in vispy.scene.
 """
 
+from .box import BoxVisual  # noqa
 from .cube import CubeVisual  # noqa
 from .ellipse import EllipseVisual  # noqa
 from .gridlines import GridLinesVisual  # noqa
@@ -23,6 +24,7 @@ from .line import LineVisual  # noqa
 from .line_plot import LinePlotVisual  # noqa
 from .markers import MarkersVisual, marker_types  # noqa
 from .mesh import MeshVisual  # noqa
+from .plane import PlaneVisual  # noqa
 from .polygon import PolygonVisual  # noqa
 from .rectangle import RectangleVisual  # noqa
 from .regular_polygon import RegularPolygonVisual  # noqa

--- a/vispy/visuals/box.py
+++ b/vispy/visuals/box.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014, Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+
+from ..geometry import create_box
+from ..gloo import set_state
+from .mesh import MeshVisual
+
+
+class BoxVisual(MeshVisual):
+    """Visual that displays a box.
+
+    Parameters
+    ----------
+    width : float
+        Box width.
+    height : float
+        Box height.
+    depth : float
+        Box depth.
+    width_segments : int
+        Box segments count along the width.
+    height_segments : float
+        Box segments count along the height.
+    depth_segments : float
+        Box segments count along the depth.
+    planes: array_like
+        Any combination of ``{'-x', '+x', '-y', '+y', '-z', '+z'}``
+        Included planes in the box construction.
+    vertex_colors : ndarray
+        Same as for `MeshVisual` class. See `create_plane` for vertex ordering.
+    face_colors : ndarray
+        Same as for `MeshVisual` class. See `create_plane` for vertex ordering.
+    color : Color
+        The `Color` to use when drawing the cube faces.
+    edge_color : tuple or Color
+        The `Color` to use when drawing the cube edges. If `None`, then no
+        cube edges are drawn.
+    """
+
+    def __init__(self, width=1, height=1, depth=1, width_segments=1,
+                 height_segments=1, depth_segments=1, planes=None,
+                 vertex_colors=None, face_colors=None,
+                 color=(0.5, 0.5, 1, 1), edge_color=None):
+        vertices, filled_indices, outline_indices = create_box(
+            width, height, depth, width_segments, height_segments,
+            depth_segments, planes)
+
+        MeshVisual.__init__(self, vertices['position'], filled_indices,
+                            vertex_colors, face_colors, color)
+        if edge_color:
+            self._outline = MeshVisual(vertices['position'], outline_indices,
+                                       color=edge_color, mode='lines')
+        else:
+            self._outline = None
+
+    def draw(self, transforms):
+        MeshVisual.draw(self, transforms)
+        if self._outline:
+            set_state(polygon_offset=(1, 1), polygon_offset_fill=True)
+            self._outline.draw(transforms)

--- a/vispy/visuals/box.py
+++ b/vispy/visuals/box.py
@@ -57,6 +57,13 @@ class BoxVisual(MeshVisual):
             self._outline = None
 
     def draw(self, transforms):
+        """Draw the visual
+
+        Parameters
+        ----------
+        transforms : instance of TransformSystem
+            The transforms to use.
+        """
         MeshVisual.draw(self, transforms)
         if self._outline:
             set_state(polygon_offset=(1, 1), polygon_offset_fill=True)

--- a/vispy/visuals/plane.py
+++ b/vispy/visuals/plane.py
@@ -51,6 +51,13 @@ class PlaneVisual(MeshVisual):
             self._outline = None
 
     def draw(self, transforms):
+        """Draw the visual
+
+        Parameters
+        ----------
+        transforms : instance of TransformSystem
+            The transforms to use.
+        """
         MeshVisual.draw(self, transforms)
         if self._outline:
             set_state(polygon_offset=(1, 1), polygon_offset_fill=True)

--- a/vispy/visuals/plane.py
+++ b/vispy/visuals/plane.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014, Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+
+from ..geometry import create_plane
+from ..gloo import set_state
+from .mesh import MeshVisual
+
+
+class PlaneVisual(MeshVisual):
+    """Visual that displays a plane.
+
+    Parameters
+    ----------
+    width : float
+        Plane width.
+    height : float
+        Plane height.
+    width_segments : int
+        Plane segments count along the width.
+    height_segments : float
+        Plane segments count along the height.
+    direction: unicode
+        ``{'-x', '+x', '-y', '+y', '-z', '+z'}``
+        Direction the plane will be facing.
+    vertex_colors : ndarray
+        Same as for `MeshVisual` class. See `create_plane` for vertex ordering.
+    face_colors : ndarray
+        Same as for `MeshVisual` class. See `create_plane` for vertex ordering.
+    color : Color
+        The `Color` to use when drawing the cube faces.
+    edge_color : tuple or Color
+        The `Color` to use when drawing the cube edges. If `None`, then no
+        cube edges are drawn.
+    """
+
+    def __init__(self, width=1, height=1, width_segments=1, height_segments=1,
+                 direction='+z', vertex_colors=None, face_colors=None,
+                 color=(0.5, 0.5, 1, 1), edge_color=None):
+        vertices, filled_indices, outline_indices = create_plane(
+            width, height, width_segments, height_segments, direction)
+
+        MeshVisual.__init__(self, vertices['position'], filled_indices,
+                            vertex_colors, face_colors, color)
+        if edge_color:
+            self._outline = MeshVisual(vertices['position'], outline_indices,
+                                       color=edge_color, mode='lines')
+        else:
+            self._outline = None
+
+    def draw(self, transforms):
+        MeshVisual.draw(self, transforms)
+        if self._outline:
+            set_state(polygon_offset=(1, 1), polygon_offset_fill=True)
+            self._outline.draw(transforms)


### PR DESCRIPTION
This PR implements support for a parametric plane and a parametric box that builds on it through the following objects:

- `vispy.geometry.generation.create_plane`

![image](https://cloud.githubusercontent.com/assets/99779/7622624/4d4b4f16-f9d1-11e4-935d-8163c860f053.png)

- `vispy.geometry.generation.create_box`

![image](https://cloud.githubusercontent.com/assets/99779/7622628/5678e5b2-f9d1-11e4-8cc1-bcf6eed282f0.png)

Some things to consider:

- It would be neat to actually return a `MeshData` instance instead of the current tuple for `create_cube`, `create_plane` and `create_box` definitions, however the class may not have all the needed fields, especially one for the outline. Upon really quick inspection it doesn't seem to support arbitrary data.
- As I didn't wanted to break anything, I did not replaced `make_cube`, it is maybe worth for it to be an alias to `make_box` or whatever you feel the best.
- I haven't created matching visuals for the new geometries, but I have some that fit my usage accordingly to #900 there: https://github.com/colour-science/colour-vispy/blob/master/colour_vispy/visuals.py