### PR TITLE
Fixed out-of-bounds mouse errors on example resize

### DIFF
--- a/examples/demo/gloo/imshow_cuts.py
+++ b/examples/demo/gloo/imshow_cuts.py
@@ -159,6 +159,10 @@ class Canvas(app.Canvas):
 
         yf = 1 - y/(h/2.)
         xf = x/(w/2.) - 1
+
+        x_norm = (x*512)/w
+        y_norm = (y*512)/h
+
         P = np.zeros((4+4+514+514, 2), np.float32)
 
         x_baseline = P[:4]
@@ -170,11 +174,11 @@ class Canvas(app.Canvas):
         y_baseline[...] = (xf, -1), (xf, -1), (xf, 1), (xf, 1)
 
         x_profile[1:-1, 0] = np.linspace(-1, 1, 512)
-        x_profile[1:-1, 1] = yf+0.15*I[y, :]
+        x_profile[1:-1, 1] = yf+0.15*I[y_norm, :]
         x_profile[0] = x_profile[1]
         x_profile[-1] = x_profile[-2]
 
-        y_profile[1:-1, 0] = xf+0.15*I[:, x]
+        y_profile[1:-1, 0] = xf+0.15*I[:, x_norm]
         y_profile[1:-1, 1] = np.linspace(-1, 1, 512)
         y_profile[0] = y_profile[1]
         y_profile[-1] = y_profile[-2]

--- a/examples/demo/gloo/imshow_cuts.py
+++ b/examples/demo/gloo/imshow_cuts.py
@@ -160,8 +160,8 @@ class Canvas(app.Canvas):
         yf = 1 - y/(h/2.)
         xf = x/(w/2.) - 1
 
-        x_norm = (x*512)/w
-        y_norm = (y*512)/h
+        x_norm = (x*512)//w
+        y_norm = (y*512)//h
 
         P = np.zeros((4+4+514+514, 2), np.float32)
 


### PR DESCRIPTION
On window managers where the requested window size is not always respected (I'm on AwesomeWM but I assume other tiling WMs like XMonad etc do the same thing), the tests will fail since they assume the window has not been resized. We should be resilient to this.