### PR TITLE
Switch to SVG version of badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,11 +136,11 @@ External links
 -  `Gallery <http://vispy.org/gallery.html>`__
 -  `Documentation <http://vispy.readthedocs.org>`__
 
-.. |Build Status| image:: https://travis-ci.org/vispy/vispy.png?branch=master
+.. |Build Status| image:: https://travis-ci.org/vispy/vispy.svg?branch=master
    :target: https://travis-ci.org/vispy/vispy
-.. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/dsxgkrbfj29xf9ef/branch/master
+.. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/dsxgkrbfj29xf9ef/branch/master?svg=true
    :target: https://ci.appveyor.com/project/Eric89GXL/vispy/branch/master
-.. |Coverage Status| image:: https://coveralls.io/repos/vispy/vispy/badge.png?branch=master
+.. |Coverage Status| image:: https://img.shields.io/coveralls/vispy/vispy/master.svg
    :target: https://coveralls.io/r/vispy/vispy?branch=master
 .. |Zenodo Link| image:: https://zenodo.org/badge/5822/vispy/vispy.svg
    :target: http://dx.doi.org/10.5281/zenodo.17869


### PR DESCRIPTION
Current badges are a bit inconsistent. Switching to the SVG versions makes them all the same height and shading.