### PR TITLE
FIX: Add some information about GLIR consumer

### DIFF
--- a/vispy/app/backends/_ipynb_webgl.py
+++ b/vispy/app/backends/_ipynb_webgl.py
@@ -94,6 +94,7 @@ class ApplicationBackend(BaseApplicationBackend):
 # ------------------------------------------------------------------ canvas ---
 class WebGLGlirParser(BaseGlirParser):
     def __init__(self, widget=None):
+        super(WebGLGlirParser, self).__init__()
         self._widget = widget
 
     def set_widget(self, widget):

--- a/vispy/gloo/context.py
+++ b/vispy/gloo/context.py
@@ -102,7 +102,7 @@ class GLContext(BaseGlooFunctions):
         assert isinstance(self._shared, GLShared)
         self._glir = GlirQueue()
         self._do_CURRENT_command = False  # flag that CURRENT cmd must be given
-    
+
     def __repr__(self):
         return "<GLContext at 0x%x>" % id(self)
     
@@ -149,7 +149,13 @@ class GLContext(BaseGlooFunctions):
         potentially be shared between multiple contexts.
         """
         return self._shared
-    
+
+    @property
+    def capabilities(self):
+        """ The OpenGL capabilities
+        """
+        return deepcopy(self.shared.parser.capabilities)
+
     def flush_commands(self, event=None):
         """ Flush
 

--- a/vispy/gloo/gl/gl2.py
+++ b/vispy/gloo/gl/gl2.py
@@ -76,7 +76,7 @@ def _get_gl_func(name, restype, argtypes):
             ftype = ctypes.WINFUNCTYPE(*fargs)
             if not _have_get_proc_address:
                 raise RuntimeError('Function %s not available '
-                                   '(OpenGL version %s).'
+                                   '(OpenGL version is %s).'
                                    % (name, _get_gl_version(_lib)))
             if not _have_context():
                 raise RuntimeError('Using %s with no OpenGL context.' % name)
@@ -85,7 +85,7 @@ def _get_gl_func(name, restype, argtypes):
                 return ctypes.cast(address, ftype)
         # If not Windows or if we did not return function object on Windows:
         raise RuntimeError('Function %s not present in context '
-                           '(OpenGL version %s).'
+                           '(OpenGL version is %s).'
                            % (name, _get_gl_version(_lib)))
 
 

--- a/vispy/gloo/gl/gl2.py
+++ b/vispy/gloo/gl/gl2.py
@@ -61,20 +61,26 @@ def _get_gl_func(name, restype, argtypes):
         func.argtypes = argtypes
         return func
     except AttributeError:
+        if hasattr(_lib, 'glGetString'):
+            gl_version = _lib.glGetString(7938).decode('utf-8')
+        else:
+            gl_version = 'unknown'
         if sys.platform.startswith('win'):
             # Ask for a pointer to the function, this is the approach
             # for OpenGL extensions on Windows
             fargs = (restype,) + argtypes
             ftype = ctypes.WINFUNCTYPE(*fargs)
             if not _have_get_proc_address:
-                raise RuntimeError('Function %s not available.' % name)
+                raise RuntimeError('Function %s not available (version %s).'
+                                   % (name, gl_version))
             if not _have_context():
                 raise RuntimeError('Using %s with no OpenGL context.' % name)
             address = wglGetProcAddress(name.encode('utf-8'))
             if address:
                 return ctypes.cast(address, ftype)
         # If not Windows or if we did not return function object on Windows:
-        raise RuntimeError('Function %s not present in context.' % name)
+        raise RuntimeError('Function %s not present in context '
+                           '(OpenGL version %s).' % (name, gl_version))
 
 
 # Inject

--- a/vispy/gloo/gl/tests/test_basics.py
+++ b/vispy/gloo/gl/tests/test_basics.py
@@ -24,6 +24,19 @@ def teardown_module():
 def test_basics_desktop():
     """ Test desktop GL backend for basic functionality. """
     _test_basics('gl2')
+    with Canvas():
+        _test_setting_parameters()
+        _test_enabling_disabling()
+        _test_setting_stuff()
+        _test_object_creation_and_deletion()
+        _test_fbo()
+        try:
+            gl.gl2._get_gl_func('foo', None, ())
+        except RuntimeError as exp:
+            exp = str(exp)
+            assert 'version' in exp
+            assert 'unknown' not in exp
+        gl.glFinish()
 
 
 @requires_application()
@@ -155,7 +168,6 @@ def _test_setting_stuff():
     v = gl.glGetParameter(gl.GL_VERSION)
     assert_true(isinstance(v, string_types))
     assert_true(len(v) > 0)
-    
     gl.check_error()
 
 

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -11,6 +11,7 @@ Implementation to execute GL Intermediate Representation (GLIR)
 import sys
 import re
 import json
+import warnings
 
 import numpy as np
 
@@ -429,6 +430,10 @@ class GlirParser(BaseGlirParser):
                 gl.glGetParameter(gl.GL_VERSION).split(' ')[0]
             self.capabilities['max_texture_size'] = \
                 gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+            if int(self.capabilities['gl_version'].split('.')[0]) < 3:
+                warnings.warn('OpenGL version 3.0 or higher recommended, '
+                              'got %s. Some functionality may fail.'
+                              % self.capabilities['gl_version'])
 
 
 def glir_logger(parser_cls, file_or_filename):

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -4,14 +4,14 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 
-""" 
+"""
 Implementation to execute GL Intermediate Representation (GLIR)
 """
 
+import os
 import sys
 import re
 import json
-import warnings
 
 import numpy as np
 
@@ -426,14 +426,14 @@ class GlirParser(BaseGlirParser):
             gl.glEnable(GL_VERTEX_PROGRAM_POINT_SIZE)
             gl.glEnable(GL_POINT_SPRITE)
         if self.capabilities['max_texture_size'] is None:  # only do once
-            self.capabilities['gl_version'] = \
-                gl.glGetParameter(gl.GL_VERSION).split(' ')[0]
+            self.capabilities['gl_version'] = gl.glGetParameter(gl.GL_VERSION)
             self.capabilities['max_texture_size'] = \
                 gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
             if int(self.capabilities['gl_version'].split('.')[0]) < 3:
-                warnings.warn('OpenGL version 3.0 or higher recommended, '
-                              'got %s. Some functionality may fail.'
-                              % self.capabilities['gl_version'])
+                if os.getenv('VISPY_IGNORE_OLD_VERSION', '').lower() != 'true':
+                    logger.warning('OpenGL version 3.0 or higher recommended, '
+                                   'got %s. Some functionality may fail.'
+                                   % self.capabilities['gl_version'])
 
 
 def glir_logger(parser_cls, file_or_filename):

--- a/vispy/gloo/tests/test_context.py
+++ b/vispy/gloo/tests/test_context.py
@@ -56,6 +56,9 @@ def test_context_config():
     assert_raises(KeyError, GLContext, {'foo': 3})
     assert_raises(TypeError, GLContext, {'double_buffer': 'not_bool'})
 
+    # Capabilites are passed on
+    assert 'gl_version' in c.capabilities
+
 
 def test_context_taking():
     """ Test GLContext ownership and taking

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -51,6 +51,8 @@ def test_queue():
 
 @requires_application()
 def test_log_parser():
+    """Test GLIR log parsing
+    """
     glir_file = tempfile.TemporaryFile(mode='r+')
 
     config.update(glir_file=glir_file)
@@ -84,6 +86,15 @@ def test_log_parser():
     config.update(glir_file='')
 
 
+@requires_application()
+def test_capabilities():
+    """Test GLIR capability reporting
+    """
+    with Canvas() as c:
+        capabilities = c.context.shared.parser.capabilities
+        assert capabilities['max_texture_size'] is not None
+        assert capabilities['gl_version'] != 'unknown'
+
 # The rest is basically tested via our examples
-    
+
 run_tests_if_main()

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -76,7 +76,7 @@ def _unit(mode, extra_arg_string):
 
     # We want to set this for all app backends plus "nobackend" to
     # help ensure that app tests are appropriately decorated
-    env.update(dict(_VISPY_TESTING_APP=mode))
+    env.update(dict(_VISPY_TESTING_APP=mode, VISPY_IGNORE_OLD_VERSION='true'))
     env_str = '_VISPY_TESTING_APP=%s ' % mode
     if len(msg) > 0:
         msg = ('%s\n%s:\n%s%s'

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -167,11 +167,13 @@ _script = """
 import sys
 import time
 import warnings
+import os
 try:
     import faulthandler
     faulthandler.enable()
 except Exception:
     pass
+os.environ['VISPY_IGNORE_OLD_VERSION'] = 'true'
 import {0}
 
 if hasattr({0}, 'canvas'):


### PR DESCRIPTION
Closes #669.

This does the following:

1. gets us some information available at the GLIR consumer level for desktop
2. gives the GL version number when GL errors are thrown (e.g., no `glBindFramebuffer` when users have version < 3.0)

Now we can at least query some things like:
```
canvas.context.shared.parser.capabilities['max_texture_size']
```
It's a bit nested, but I'm not sure the best way to un-nest it. Should be a decent start.