### PR TITLE
Fix typo in setup requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     platforms='any',
     provides=['vispy'],
     install_requires=['numpy'],
-    extras_requires={
+    extras_require={
         'ipython-static': ['ipython'],
         'ipython-vnc': ['ipython>=2'],
         'ipython-webgl': ['ipython>=2', 'tornado'],


### PR DESCRIPTION
So, I just realized I made a silly typo here. Although why `setuptools` developers decided to make everything plural _except_ this one option, I don't know...