### PR TITLE
Different method of associating glir queues (for better performance)

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -12,6 +12,7 @@ import os
 import sys
 import re
 import json
+import weakref
 
 import numpy as np
 
@@ -67,22 +68,14 @@ def as_enum(enum):
     return enum
 
 
-class GlirQueue(object):
-    """ Representation of a queue of GLIR commands
-    
-    One instance of this class is attached to each context object, and
-    to each gloo object.
-    
-    Upon drawing (i.e. `Program.draw()`) and framebuffer switching, the
-    commands in the queue are pushed to a parser, which is stored at
-    context.shared. The parser can interpret the commands in Python,
-    send them to a browser, etc.
+class _GlirQueueShare(object):
     """
-    
-    def __init__(self):
+    """
+    def __init__(self, queue):
         self._commands = []  # local commands
         self._verbose = False
-        self._associations = set()
+        # queues that have been merged with this one
+        self._associations = weakref.WeakKeyDictionary({queue: None})
     
     def command(self, *args):
         """ Send a command. See the command spec at:
@@ -101,10 +94,6 @@ class GlirQueue(object):
         """ Print the list of commands currently in the queue. If filter is
         given, print only commands that match the filter.
         """
-        # Show commands in associated queues
-        for q in self._associations:
-            q.show()
-        
         for command in self._commands:
             if command[0] is None:  # or command[1] in self._invalid_objects:
                 continue  # Skip nill commands 
@@ -127,32 +116,13 @@ class GlirQueue(object):
         """ Pop the whole queue (and associated queues) and return a
         list of commands.
         """
-        
-        # Get all commands, discard deletable queues (ques no longer in use)
-        commands = []
-        for q in list(self._associations):
-            commands.extend(q.clear())
-            if hasattr(q, '_deletable'):  # this flag gets set by GLObject
-                self._associations.discard(q)
-        commands.extend(self._commands)
-        self._commands[:] = []
+        commands = self._commands
+        self._commands = []
         return commands
-    
-    def associate(self, queue):
-        """ Associate the given queue. When the current queue gets
-        cleared, it first clears all the associated queues and prepends
-        these commands to the total list. One should call associate()
-        on the queue that relies on the other 
-        (e.g. ``program.glir.associate(texture.glir``).
-        """
-        assert isinstance(queue, GlirQueue)
-        self._associations.add(queue)
     
     def flush(self, parser):
         """ Flush all current commands to the GLIR interpreter.
         """
-#         if self._parser is None:
-#             raise RuntimeError('Cannot flush queue if parser is None')
         if self._verbose:
             show = self._verbose if isinstance(self._verbose, str) else None
             self.show(show)
@@ -182,6 +152,67 @@ class GlirQueue(object):
         return convert_shaders(convert, shaders)
 
 
+class GlirQueue(object):
+    """ Representation of a queue of GLIR commands
+    
+    One instance of this class is attached to each context object, and
+    to each gloo object.
+    
+    Upon drawing (i.e. `Program.draw()`) and framebuffer switching, the
+    commands in the queue are pushed to a parser, which is stored at
+    context.shared. The parser can interpret the commands in Python,
+    send them to a browser, etc.
+    """
+    def __init__(self):
+        # We do not actually queue any commands here, but on a shared queue
+        # object that may be joined with others as queues are associated.
+        self._shared = _GlirQueueShare(self)
+
+    def command(self, *args):
+        """ Send a command. See the command spec at:
+        https://github.com/vispy/vispy/wiki/Spec.-Gloo-IR
+        """
+        self._shared.command(*args)
+        
+    def set_verbose(self, verbose):
+        """ Set verbose or not. If True, the GLIR commands are printed
+        right before they get parsed. If a string is given, use it as
+        a filter.
+        """
+        self._shared.set_verbose(verbose)
+    
+    def clear(self):
+        """ Pop the whole queue (and associated queues) and return a
+        list of commands.
+        """
+        return self._shared.clear()
+    
+    def associate(self, queue):
+        """Merge this queue with another. 
+        
+        Both queues will use a shared command list and either one can be used
+        to fill or flush the shared queue.
+        """
+        assert isinstance(queue, GlirQueue)
+        if queue._shared is self._shared:
+            return
+        
+        # merge commands
+        self._shared._commands.extend(queue.clear())
+        self._shared._verbose |= queue._shared._verbose
+        self._shared._associations[queue] = None
+        # update queue and all related queues to use the same _shared object 
+        for ch in queue._shared._associations:
+            ch._shared = self._shared
+            self._shared._associations[ch] = None
+        queue._shared = self._shared
+        
+    def flush(self, parser):
+        """ Flush all current commands to the GLIR interpreter.
+        """
+        self._shared.flush(parser)
+    
+        
 def convert_shaders(convert, shaders):
     """ Modify shading code so that we can write code once
     and make it run "everywhere".
@@ -327,7 +358,6 @@ class GlirParser(BaseGlirParser):
     def _parse(self, command):
         """ Parse a single command.
         """
-
         cmd, id_, args = command[0], command[1], command[2:]
             
         if cmd == 'CURRENT':

--- a/vispy/gloo/globject.py
+++ b/vispy/gloo/globject.py
@@ -11,8 +11,12 @@ On queues
 ---------
 
 The queue on the GLObject can be associated with other queues. These
-can be queues of other gloo objects, or of the canvas.context. A program
-associates the textures/buffers when they are set via __setitem__. A
+can be queues of other gloo objects, or of the canvas.context. Queues that are
+associated behave as if they are a single queue; this allows GL commands for
+two or more interdependent GL objects to be combined such that they are always
+sent to the same context together.
+
+A program associates the textures/buffers when they are set via __setitem__. A
 FrameBuffer does so when assigning buffers. A program associates itself
 with the canvas.context in draw(). A FrameBuffer does the same in
 activate().
@@ -22,18 +26,16 @@ Example:
     prog1, prog2 = Program(), Program()
     tex1, tex2 = Texture(), Texture()
 
-    prog1.glir.associate(tex1.glir)
-    prog1.glir.associate(tex2.glir)
+    prog1.glir.associate(tex1.glir)  # prog1 and tex1 now share a queue
+    prog2.glir.associate(tex2.glir)  # prog2 and tex2 now share a queue
 
-    canvas1.context.glir.associate(prog1.glir)
-    canvas1.context.glir.associate(prog2.glir)
-    canvas2.context.glir.associate(prog2.glir)
-
-Now, when canvas1 flushes its queue, it takes all the pending commands
-from prog1 and prog2, and subsequently from tex1 and tex2. When canvas2
-is flushed, only commands from prog2 get taken. A similar situation
-holds for a texture that is associated with a program and a frame
-buffer.
+    # this causes prog1, tex1, and canvas.context to all share a queue:
+    canvas.context.glir.associate(prog1.glir)
+    # and now all objects share a single queue
+    canvas.context.glir.associate(prog2.glir)
+ 
+Now, when the canvas flushes its queue, it takes all the pending commands
+from prog1, prog2, tex1, and tex2. 
 """
 
 from .glir import GlirQueue

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -24,13 +24,13 @@ def test_queue():
     # Test filter 1
     cmds1 = [('DATA', 1), ('SIZE', 1), ('FOO', 1), ('SIZE', 1), ('FOO', 1), 
              ('DATA', 1), ('DATA', 1)]
-    cmds2 = [c[0] for c in q._filter(cmds1, parser)]
+    cmds2 = [c[0] for c in q._shared._filter(cmds1, parser)]
     assert cmds2 == ['FOO', 'SIZE', 'FOO', 'DATA', 'DATA']
     
     # Test filter 2
     cmds1 = [('DATA', 1), ('SIZE', 1), ('FOO', 1), ('SIZE', 2), ('SIZE', 2), 
              ('DATA', 2), ('SIZE', 1), ('FOO', 1), ('DATA', 1), ('DATA', 1)]
-    cmds2 = q._filter(cmds1, parser)
+    cmds2 = q._shared._filter(cmds1, parser)
     assert cmds2 == [('FOO', 1), ('SIZE', 2), ('DATA', 2), ('SIZE', 1), 
                      ('FOO', 1), ('DATA', 1), ('DATA', 1)]
 
@@ -39,13 +39,13 @@ def test_queue():
         precision highp float;uniform mediump vec4 u_foo;uniform vec4 u_bar;
         """.strip().replace(';', ';\n')
     # Convert for desktop
-    shader2 = q._convert_shaders('desktop', ['', shader1])[1]
+    shader2 = q._shared._convert_shaders('desktop', ['', shader1])[1]
     assert 'highp' not in shader2
     assert 'mediump' not in shader2
     assert 'precision' not in shader2
     
     # Convert for es2
-    shader3 = q._convert_shaders('es2', ['', shader2])[1]
+    shader3 = q._shared._convert_shaders('es2', ['', shader2])[1]
     assert 'precision highp float;' in shader3
 
 


### PR DESCRIPTION
Ready for review/merge.

This resolves a performance issue where scenes with a large number of visuals were visiting `GlirQueue.clear()` thousands of times per draw.