### PR TITLE
Fix functionality tests on Intel and software GL.

### DIFF
--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -36,21 +36,21 @@ def teardown_module():
 @requires_application()
 def test_functionality_desktop():
     """ Test desktop GL backend for full functionality. """
-    _test_functonality('gl2')
+    _test_functionality('gl2')
 
 
 @requires_application()
 def test_functionality_proxy():
     """ Test GL proxy class for full functionality. """
     # By using debug mode, we are using the proxy class
-    _test_functonality('gl2 debug')
+    _test_functionality('gl2 debug')
 
 
 @requires_application()
 @requires_pyopengl()
 def test_functionality_pyopengl():
     """ Test pyopengl GL backend for full functionality. """
-    _test_functonality('pyopengl2')
+    _test_functionality('pyopengl2')
 
 
 @requires_application()
@@ -60,7 +60,7 @@ def test_functionality_es2():
         raise SkipTest('Skip es2 functionality test for now.')
     if not sys.platform.startswith('win'):
         raise SkipTest('Can only test es2 functionality on Windows.')
-    _test_functonality('es2')
+    _test_functionality('es2')
 
 
 def _clear_screen():
@@ -68,7 +68,7 @@ def _clear_screen():
     gl.glFinish()
 
 
-def _test_functonality(backend):
+def _test_functionality(backend):
     """ Create app and canvas so we have a context. Then run tests.
     """
     # use the backend
@@ -261,7 +261,7 @@ def _prepare_vis():
     
     # --- get information on attributes and uniforms
     
-    # Count attribbutes and uniforms
+    # Count attributes and uniforms
     natt = gl.glGetProgramParameter(hprog, gl.GL_ACTIVE_ATTRIBUTES)
     nuni = gl.glGetProgramParameter(hprog, gl.GL_ACTIVE_UNIFORMS)
     assert_equal(natt, 4)

--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -234,6 +234,15 @@ def _prepare_vis():
     # touch glDetachShader
     gl.glDetachShader(hprog, hvert)
     gl.glAttachShader(hprog, hvert)
+
+    # Bind all attributes - we could let this occur automatically, but some
+    # implementations bind an attribute to index 0, which has the unfortunate
+    # property of being unable to be modified.
+    gl.glBindAttribLocation(hprog, 1, 'a_1')
+    gl.glBindAttribLocation(hprog, 2, 'a_2')
+    gl.glBindAttribLocation(hprog, 3, 'a_3')
+    gl.glBindAttribLocation(hprog, 4, 'a_4')
+
     gl.glLinkProgram(hprog)
     
     # Test that indeed these shaders are attached
@@ -248,9 +257,6 @@ def _prepare_vis():
     
     # Use it!
     gl.glUseProgram(hprog)
-    
-    # Bind one attribute
-    gl.glBindAttribLocation(hprog, 1, 'a_2')
     
     # Check if all is ok
     assert_equal(gl.glGetError(), 0)


### PR DESCRIPTION
The attribute `a_1` is assigned generic vertex attribute 0, which has some magical properties on legacy desktop GL. By reversing the order, it no longer has such assignment, and works like any other attribute. The new first attribute `a_4` is not modified in the same way as `a_1`, and thus does not suffer due to the magical properties of index 0.

I also fixed a minor typo.

Fixes #649. CC @rossant who was also seeing this issue.