### PR TITLE
Fix ResourceWarnings in six shim

### DIFF
--- a/vispy/ext/six.py
+++ b/vispy/ext/six.py
@@ -14,6 +14,7 @@ from distutils.version import StrictVersion
 
 
 _SIX_MIN_VERSION = StrictVersion('1.4.1')
+_SIX_SEARCH_PATH = ['vispy.ext._bundled.six', 'six']
 
 
 def _find_module(name, path=None):
@@ -32,28 +33,32 @@ def _find_module(name, path=None):
     return fh, path, descr
 
 
-for mod_name in ['vispy.ext._bundled.six', 'six']:
-    try:
-        mod_info = _find_module(mod_name)
-    except ImportError:
-        continue
+def _import_six(search_path=_SIX_SEARCH_PATH):
+    for mod_name in search_path:
+        try:
+            mod_info = _find_module(mod_name)
+        except ImportError:
+            continue
 
-    mod = imp.load_module(__name__, *mod_info)
+        mod = imp.load_module(__name__, *mod_info)
 
-    try:
-        if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
-            break
-    except (AttributeError, ValueError):
-        # Attribute error if the six module isn't what it should be and doesn't
-        # have a .__version__; ValueError if the version string exists but is
-        # somehow bogus/unparseable
-        continue
-else:
-    raise ImportError(
-        "Vispy requires the 'six' module of minimum version {0}; "
-        "normally this is bundled with the astropy package so if you get "
-        "this warning consult the packager of your Vispy "
-        "distribution.".format(_SIX_MIN_VERSION))
+        try:
+            if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
+                break
+        except (AttributeError, ValueError):
+            # Attribute error if the six module isn't what it should be and doesn't
+            # have a .__version__; ValueError if the version string exists but is
+            # somehow bogus/unparseable
+            continue
+    else:
+        raise ImportError(
+            "Vispy requires the 'six' module of minimum version {0}; "
+            "normally this is bundled with the Vispy package so if you get "
+            "this warning consult the packager of your Vispy "
+            "distribution.".format(_SIX_MIN_VERSION))
+
+
+_import_six()
 
 if PY3:
     file_types = (io.TextIOWrapper, io.BufferedRandom)

--- a/vispy/ext/six.py
+++ b/vispy/ext/six.py
@@ -29,6 +29,8 @@ def _find_module(name, path=None):
             path = [path]
 
         fh, path, descr = imp.find_module(part, path)
+        if fh is not None and part != parts[-1]:
+            fh.close()
 
     return fh, path, descr
 
@@ -40,7 +42,11 @@ def _import_six(search_path=_SIX_SEARCH_PATH):
         except ImportError:
             continue
 
-        mod = imp.load_module(__name__, *mod_info)
+        try:
+            mod = imp.load_module(__name__, *mod_info)
+        finally:
+            if mod_info[0] is not None:
+                mod_info[0].close()
 
         try:
             if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:


### PR DESCRIPTION
I've noticed a few new warnings due to the six shim that I didn't see earlier (because of Python 3.4 upgrade, probably).