### PR TITLE
[WIP] ENH: Use new QOpenGL API with Qt 5.4+.

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -304,7 +304,11 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         # Qt supports OS double-click events, so we set this here to
         # avoid double events
         self._double_click_supported = True
-        self._physical_size = p.size
+
+        # We call this here to set the physical size. We do this rather than set
+        # the physical size directly, because resizeGL takes into account any
+        # non-unity device pixel ratio.
+        self.resizeGL(*p.size)
 
         # Activate touch and gesture.
         # NOTE: we only activate touch on OS X because there seems to be
@@ -727,6 +731,12 @@ class CanvasBackendDesktop(QtBaseCanvasBackend, QGLWidget):
     def resizeGL(self, w, h):
         if self._vispy_canvas is None:
             return
+        if qt_lib == 'pyqt5':
+            # We take into account devicePixelRatio, which is non-unity on
+            # e.g HiDPI displays.
+            ratio = self.devicePixelRatio()
+            w = w * ratio
+            h = h * ratio
         self._vispy_set_physical_size(w, h)
         self._vispy_canvas.events.resize(size=(self.width(), self.height()),
                                          physical_size=(w, h))

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -713,6 +713,12 @@ class CanvasBackendDesktop(QtBaseCanvasBackend, QGLWidget):
         else:
             self.swapBuffers()
 
+    def _vispy_get_fb_bind_location(self):
+        if QT5_NEW_API:
+            return self.defaultFramebufferObject()
+        else:
+            return QtBaseCanvasBackend._vispy_get_fb_bind_location(self)
+
     def initializeGL(self):
         if self._vispy_canvas is None:
             return

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -26,6 +26,7 @@ import os
 import sys
 import atexit
 import ctypes
+from distutils.version import LooseVersion
 
 from ...util import logger
 from ..base import (BaseApplicationBackend, BaseCanvasBackend,
@@ -66,6 +67,7 @@ def _check_imports(lib):
 # Get what qt lib to try. This tells us wheter this module is imported
 # via _pyside or _pyqt4 or _pyqt5
 QGLWidget = object
+QT5_NEW_API = False
 if qt_lib == 'pyqt4':
     _check_imports('PyQt4')
     if not USE_EGL:
@@ -75,7 +77,13 @@ if qt_lib == 'pyqt4':
 elif qt_lib == 'pyqt5':
     _check_imports('PyQt5')
     if not USE_EGL:
-        from PyQt5.QtOpenGL import QGLWidget, QGLFormat
+        from PyQt5.QtCore import PYQT_VERSION_STR
+        if LooseVersion(PYQT_VERSION_STR) >= '5.4.0':
+            from PyQt5.QtWidgets import QOpenGLWidget as QGLWidget
+            from PyQt5.QtGui import QSurfaceFormat as QGLFormat
+            QT5_NEW_API = True
+        else:
+            from PyQt5.QtOpenGL import QGLWidget, QGLFormat
     from PyQt5 import QtGui, QtCore, QtWidgets, QtTest
     QWidget, QApplication = QtWidgets.QWidget, QtWidgets.QApplication  # Compat
 elif qt_lib == 'pyside':
@@ -191,15 +199,21 @@ def _set_config(c):
     glformat.setGreenBufferSize(c['green_size'])
     glformat.setBlueBufferSize(c['blue_size'])
     glformat.setAlphaBufferSize(c['alpha_size'])
-    glformat.setAccum(False)
-    glformat.setRgba(True)
-    glformat.setDoubleBuffer(True if c['double_buffer'] else False)
-    glformat.setDepth(True if c['depth_size'] else False)
+    if QT5_NEW_API:
+        # Qt5 >= 5.4.0 - below options automatically enabled if nonzero.
+        glformat.setSwapBehavior(glformat.DoubleBuffer if c['double_buffer']
+                                 else glformat.SingleBuffer)
+    else:
+        # Qt4 and Qt5 < 5.4.0 - buffers must be explicitly requested.
+        glformat.setAccum(False)
+        glformat.setRgba(True)
+        glformat.setDoubleBuffer(True if c['double_buffer'] else False)
+        glformat.setDepth(True if c['depth_size'] else False)
+        glformat.setStencil(True if c['stencil_size'] else False)
+        glformat.setSampleBuffers(True if c['samples'] else False)
     glformat.setDepthBufferSize(c['depth_size'] if c['depth_size'] else 0)
-    glformat.setStencil(True if c['stencil_size'] else False)
     glformat.setStencilBufferSize(c['stencil_size'] if c['stencil_size']
                                   else 0)
-    glformat.setSampleBuffers(True if c['samples'] else False)
     glformat.setSamples(c['samples'] if c['samples'] else 0)
     glformat.setStereo(c['stereo'])
     return glformat
@@ -211,6 +225,9 @@ class ApplicationBackend(BaseApplicationBackend):
 
     def __init__(self):
         BaseApplicationBackend.__init__(self)
+        if QT5_NEW_API:
+            # For Qt5 >= 5.4.0 - Enable sharing of context between windows.
+            QApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts, True)
 
     def _vispy_get_backend_name(self):
         name = QtCore.__name__.split('.')[0]
@@ -651,25 +668,34 @@ class CanvasBackendDesktop(QtBaseCanvasBackend, QGLWidget):
                 raise RuntimeError('Cannot use vispy to share context and '
                                    'use built-in shareWidget.')
 
-        # first arg can be glformat, or a gl context
         if p.always_on_top or not p.decorate:
             hint = 0
             hint |= 0 if p.decorate else QtCore.Qt.FramelessWindowHint
             hint |= QtCore.Qt.WindowStaysOnTopHint if p.always_on_top else 0
         else:
             hint = QtCore.Qt.Widget  # can also be a window type
-        QGLWidget.__init__(self, glformat, p.parent, widget, hint)
+        if QT5_NEW_API:
+            # Qt5 >= 5.4.0 - sharing is automatic
+            QGLWidget.__init__(self, p.parent, hint)
+        else:
+            # Qt4 and Qt5 < 5.4.0 - sharing is explicitly requested
+            QGLWidget.__init__(self, p.parent, widget, hint)
+        self.setFormat(glformat)
         self._initialized = True
-        if not self.isValid():
+        if not QT5_NEW_API and not self.isValid():
+            # On Qt5 >= 5.4.0, isValid is only true once the widget is shown
             raise RuntimeError('context could not be created')
-        self.setAutoBufferSwap(False)  # to make consistent with other backends
+        if not QT5_NEW_API:
+            # to make consistent with other backends
+            self.setAutoBufferSwap(False)
         self.setFocusPolicy(QtCore.Qt.WheelFocus)
 
     def _vispy_close(self):
         # Force the window or widget to shut down
         self.close()
         self.doneCurrent()
-        self.context().reset()
+        if not QT5_NEW_API:
+            self.context().reset()
 
     def _vispy_set_current(self):
         if self._vispy_canvas is None:
@@ -681,7 +707,11 @@ class CanvasBackendDesktop(QtBaseCanvasBackend, QGLWidget):
         # Swap front and back buffer
         if self._vispy_canvas is None:
             return
-        self.swapBuffers()
+        if QT5_NEW_API:
+            ctx = self.context()
+            ctx.swapBuffers(ctx.surface())
+        else:
+            self.swapBuffers()
 
     def initializeGL(self):
         if self._vispy_canvas is None:

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -170,6 +170,11 @@ class BaseCanvasBackend(object):
         # Most backends would not need to implement this
         return self
 
+    def _vispy_get_fb_bind_location(self):
+        # Should return the default FrameBuffer bind location
+        # Most backends would not need to implement this
+        return 0
+
     def _vispy_mouse_press(self, **kwargs):
         # default method for delivering mouse press events to the canvas
         kwargs.update(self._vispy_mouse_data)

--- a/vispy/app/tests/test_backends.py
+++ b/vispy/app/tests/test_backends.py
@@ -56,6 +56,7 @@ def _test_module_properties(_module=None):
         '_vispy_mouse_release',
         '_vispy_mouse_double_click',
         '_vispy_detect_double_click',
+        '_vispy_get_fb_bind_location',
         '_vispy_get_geometry',
         '_vispy_get_physical_size',
         '_vispy_sleep',

--- a/vispy/gloo/context.py
+++ b/vispy/gloo/context.py
@@ -167,7 +167,12 @@ class GLContext(BaseGlooFunctions):
         """
         if self._do_CURRENT_command:
             self._do_CURRENT_command = False
-            self.shared.parser.parse([('CURRENT', 0)])
+            canvas = get_current_canvas()
+            if canvas and hasattr(canvas, '_backend'):
+                fbo = canvas._backend._vispy_get_fb_bind_location()
+            else:
+                fbo = 0
+            self.shared.parser.parse([('CURRENT', 0, fbo)])
         self.glir.flush(self.shared.parser)
         
     def set_viewport(self, *args):

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -383,7 +383,8 @@ class GlirParser(BaseGlirParser):
             # This context is made current
             self.env.clear()
             self._gl_initialize()
-            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+            self.env['fbo'] = args[0]
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, args[0])
         elif cmd == 'FUNC':
             # GL function call
             args = [as_enum(a) for a in args]
@@ -1270,13 +1271,15 @@ class GlirFrameBuffer(GlirObject):
             self.deactivate()
     
     def activate(self):
-        stack = self._parser.env.setdefault('fb_stack', [0])
+        stack = self._parser.env.setdefault('fb_stack',
+                                            [self._parser.env['fbo']])
         if stack[-1] != self._handle:
             stack.append(self._handle)
             gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self._handle)
     
     def deactivate(self):
-        stack = self._parser.env.setdefault('fb_stack', [0])
+        stack = self._parser.env.setdefault('fb_stack',
+                                            [self._parser.env['fbo']])
         while self._handle in stack:
             stack.remove(self._handle)
         gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, stack[-1])

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -71,8 +71,15 @@ def test_log_parser():
 
     i = 0
 
-    assert lines[i] == json.dumps(['CURRENT', 0])
+    # The FBO argument may be anything based on the backend.
+    expected = json.dumps(['CURRENT', 0, 1])
+    assert len(lines[i]) >= len(expected)
+    expected = expected.split('1')
+    assert lines[i].startswith(expected[0])
+    assert lines[i].endswith(expected[1])
+    assert int(lines[i][len(expected[0]):-len(expected[1])]) is not None
     i += 1
+
     # The 'CURRENT' command may have been called multiple times
     while lines[i] == lines[i - 1]:
         i += 1


### PR DESCRIPTION
This is not really complete yet; it's really more for documenting the change since it doesn't work just yet. Most of the visual tests fail, not all the others do somehow.

Apparently, the new [QOpenGLWidget embeds better and is more compatible than the old QGLWidget](https://blog.qt.io/blog/2014/09/10/qt-weekly-19-qopenglwidget/). Unfortunately, there are some differences, so it may not integrate into vispy quite so easily.
- [QGLWidget](http://doc.qt.io/qt-4.8/qglwidget.html) -> [QOpenGLWidget](https://doc-snapshots.qt.io/qt5-5.4/qopenglwidget.html)
- [QGLContext](http://doc.qt.io/qt-4.8/qglcontext.html) -> [QOpenGLContext](http://doc.qt.io/qt-5/qopenglcontext.html)
- [QGLFormat](http://doc.qt.io/qt-4.8/qglformat.html) -> [QSurfaceFormat](http://doc.qt.io/qt-5/qsurfaceformat.html)
