### PR TITLE
FIX: Restore missing values in hex-to-decimal dict.

### DIFF
--- a/vispy/util/svg/color.py
+++ b/vispy/util/svg/color.py
@@ -4,7 +4,7 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 
-from itertools import combinations
+from itertools import product
 from string import hexdigits
 
 
@@ -160,7 +160,7 @@ _keyword_colors = {
 
 
 _HEXDEC = {}
-for x, y in combinations(hexdigits, 2):
+for x, y in product(hexdigits, repeat=2):
     v = x + y
     _HEXDEC[v] = int(v, 16)
     


### PR DESCRIPTION
`itertools.combinations` != double loop comprehension. `combinations` excludes doubled entries, so values like '00' did not exist. This fixes the broken tiger example (are these not tested on Travis?).

Possibly the reason why it seemed in #932 that the explicit loop was twice as fast may be due to the fact that this code produces only 231 entries, when there should be 484.