### PR TITLE
Add new signature to `message_handler` for pyqt5

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -155,7 +155,7 @@ def message_handler(*args):
                "event."):
         return
     else:
-        if qt_lib == "pyqt4":
+        if qt_lib in ("pyqt4", "pyside"):
             logger.warning(msg.decode())
         elif qt_lib == "pyqt5":
             logger.warning(msg)

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -140,7 +140,7 @@ BUTTONMAP = {0: 0, 1: 1, 2: 2, 4: 3, 8: 4, 16: 5}
 # Also, ignore spam about tablet input
 def message_handler(*args):
 
-    if qt_lib == "pyqt4":
+    if qt_lib in ("pyqt4", "pyside"):
         msg_type, msg = args
     elif qt_lib == "pyqt5":
         msg_type, context, msg = args

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -138,14 +138,26 @@ BUTTONMAP = {0: 0, 1: 1, 2: 2, 4: 3, 8: 4, 16: 5}
 
 # Properly log Qt messages
 # Also, ignore spam about tablet input
-def message_handler(msg_type, msg):
+def message_handler(*args):
+
+    if qt_lib == "pyqt4":
+        msg_type, msg = args
+    elif qt_lib == "pyqt5":
+        msg_type, context, msg = args
+    elif qt_lib:
+        raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)
+    else:
+        raise RuntimeError("Module backends._qt should not be imported directly.")
+
     if msg == ("QCocoaView handleTabletEvent: This tablet device is "
                "unknown (received no proximity event for it). Discarding "
                "event."):
         return
     else:
-        logger.warning(msg)
-
+        if qt_lib == "pyqt4":
+            logger.warning(msg.decode())
+        elif qt_lib == "pyqt5":
+            logger.warning(msg)
 try:
     QtCore.qInstallMsgHandler(message_handler)
 except AttributeError:

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -32,6 +32,7 @@ from ..base import (BaseApplicationBackend, BaseCanvasBackend,
                     BaseTimerBackend)
 from ...util import keys
 from ...ext.six import text_type
+from ...ext.six import string_types
 from ... import config
 from . import qt_lib
 
@@ -155,10 +156,8 @@ def message_handler(*args):
                "event."):
         return
     else:
-        if qt_lib in ("pyqt4", "pyside"):
-            logger.warning(msg.decode())
-        elif qt_lib == "pyqt5":
-            logger.warning(msg)
+        msg = msg.decode() if not isinstance(msg, string_types) else msg
+        logger.warning(msg)
 try:
     QtCore.qInstallMsgHandler(message_handler)
 except AttributeError:

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -147,7 +147,8 @@ def message_handler(*args):
     elif qt_lib:
         raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)
     else:
-        raise RuntimeError("Module backends._qt should not be imported directly.")
+        raise RuntimeError("Module backends._qt ",
+                           "should not be imported directly.")
 
     if msg == ("QCocoaView handleTabletEvent: This tablet device is "
                "unknown (received no proximity event for it). Discarding "

--- a/vispy/app/qt.py
+++ b/vispy/app/qt.py
@@ -20,7 +20,7 @@ if qt_lib in ('pyqt4', 'pyside'):
     from PyQt4 import QtGui
     QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
 elif qt_lib == 'pyqt5':
-    from PyQt5 import QtGui, QtWidgets
+    from PyQt5 import QtWidgets
     QWidget, QGridLayout = QtWidgets.QWidget, QtWidgets.QGridLayout  # Compat
 elif qt_lib:
     raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)

--- a/vispy/app/qt.py
+++ b/vispy/app/qt.py
@@ -5,6 +5,8 @@
 # Force the selection of an application backend. If the user has already
 # imported PyQt or PySide, this should result in selection of the corresponding
 # backend.
+from .backends import qt_lib
+
 from . import use_app
 app = use_app()
 try:
@@ -13,16 +15,15 @@ except AttributeError:
     raise RuntimeError("Cannot import Qt library; non-Qt backend is already "
                        "in use.")
 
-from .backends import qt_lib
 
 if qt_lib == 'pyqt4':
-    from PyQt4 import QtGui, QtCore
+    from PyQt4 import QtGui
     QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
 elif qt_lib == 'pyqt5':
-    from PyQt5 import QtGui, QtCore, QtWidgets
+    from PyQt5 import QtGui, QtWidgets
     QWidget, QGridLayout = QtWidgets.QWidget, QtWidgets.QGridLayout  # Compat
 elif qt_lib == 'pyside':
-    from PySide import QtGui, QtCore
+    from PySide import QtGui
     QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
 elif qt_lib:
     raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)

--- a/vispy/app/qt.py
+++ b/vispy/app/qt.py
@@ -16,15 +16,12 @@ except AttributeError:
                        "in use.")
 
 
-if qt_lib == 'pyqt4':
+if qt_lib in ('pyqt4', 'pyside'):
     from PyQt4 import QtGui
     QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
 elif qt_lib == 'pyqt5':
     from PyQt5 import QtGui, QtWidgets
     QWidget, QGridLayout = QtWidgets.QWidget, QtWidgets.QGridLayout  # Compat
-elif qt_lib == 'pyside':
-    from PySide import QtGui
-    QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
 elif qt_lib:
     raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)
 else:

--- a/vispy/app/qt.py
+++ b/vispy/app/qt.py
@@ -13,14 +13,30 @@ except AttributeError:
     raise RuntimeError("Cannot import Qt library; non-Qt backend is already "
                        "in use.")
 
+from .backends import qt_lib
 
-class QtCanvas(QtGui.QWidget):
-    """ Qt widget containing a vispy Canvas. 
-    
+if qt_lib == 'pyqt4':
+    from PyQt4 import QtGui, QtCore
+    QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
+elif qt_lib == 'pyqt5':
+    from PyQt5 import QtGui, QtCore, QtWidgets
+    QWidget, QGridLayout = QtWidgets.QWidget, QtWidgets.QGridLayout  # Compat
+elif qt_lib == 'pyside':
+    from PySide import QtGui, QtCore
+    QWidget, QGridLayout = QtGui.QWidget, QtGui.QGridLayout  # Compat
+elif qt_lib:
+    raise RuntimeError("Invalid value for qt_lib %r." % qt_lib)
+else:
+    raise RuntimeError("Module backends._qt should not be imported directly.")
+
+
+class QtCanvas(QWidget):
+    """ Qt widget containing a vispy Canvas.
+
     This is a convenience class that allows a vispy canvas to be embedded
     directly into a Qt application.
     All methods and properties of the Canvas are wrapped by this class.
-    
+
     Parameters
     ----------
     parent : QWidget or None
@@ -29,7 +45,7 @@ class QtCanvas(QtGui.QWidget):
         The vispy Canvas to display inside this widget, or a Canvas subclass
         to instantiate using any remaining keyword arguments.
     """
-    
+
     def __init__(self, parent=None, canvas=None, **kwargs):
         from .canvas import Canvas
         if canvas is None:
@@ -37,20 +53,20 @@ class QtCanvas(QtGui.QWidget):
         if issubclass(canvas, Canvas):
             canvas = canvas(**kwargs)
         elif len(**kwargs) > 0:
-            raise TypeError('Invalid keyword arguments: %s' % 
+            raise TypeError('Invalid keyword arguments: %s' %
                             list(kwargs.keys()))
         if not isinstance(canvas, Canvas):
             raise TypeError('canvas argument must be an instance or subclass '
                             'of Canvas.')
-            
-        QtGui.QWidget.__init__(self, parent)
-        self.layout = QtGui.QGridLayout()
+
+        QWidget.__init__(self, parent)
+        self.layout = QGridLayout()
         self.setLayout(self.layout)
         self.layout.setContentsMargins(0, 0, 0, 0)
         self._canvas = canvas
         self.layout.addWidget(canvas.native)
         self.setSizePolicy(canvas.native.sizePolicy())
-        
+
     def __getattr__(self, attr):
         if hasattr(self._canvas, attr):
             return getattr(self._canvas, attr)
@@ -60,13 +76,13 @@ class QtCanvas(QtGui.QWidget):
     def update(self):
         """Call update() on both this widget and the internal canvas.
         """
-        QtGui.QWidget.update(self)
+        QWidget.update(self)
         self._canvas.update()
 
 
 class QtSceneCanvas(QtCanvas):
     """ Convenience class embedding a vispy SceneCanvas inside a QWidget.
-    
+
     See QtCanvas.
     """
     def __init__(self, parent=None, **kwargs):


### PR DESCRIPTION
A small bug fix in Qt backend.

In pyqt5 `QtCore.qInstallMessageHandler` takes a function with a different signature than pyqt4. The result was that all pyqt5 log message would display `TypeError: message_handler() takes 2 positional arguments but 3 were given`.

This PR fix the issue by checking wether `qt_lib` is pyqt4 or pyqt5.

PS: I also add a `.decode()` to pyqt4 logging message signature because it's return a byte and not an str. However it could raise issue with Python 2. This code has only been tested with Python 3.4.