### PR TITLE
Fix type of canvas size.

### DIFF
--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -113,7 +113,7 @@ class Canvas(object):
                  config=None, shared=None, keys=None, parent=None, dpi=None,
                  always_on_top=False, px_scale=1):
 
-        size = [int(s) * px_scale for s in size]
+        size = tuple(int(s) * px_scale for s in size)
         if len(size) != 2:
             raise ValueError('size must be a 2-element list')
         title = str(title)


### PR DESCRIPTION
It must be a tuple to match other usage of dimensions.

For example, [here](../blob/master/vispy/scene/canvas.py#L266):
```python
         prof('create SceneDrawEvent')

         vp = (0, 0) + self.physical_size if viewport is None else viewport
         scene_event.push_viewport(vp)
         prof('push_viewport')
         try:
```