### PR TITLE
add a warning when setup.py is unable to load setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,12 @@ Announcing:
 
 import os
 from os import path as op
+from warnings import warn
 
 try:
     # use setuptools namespace, allows for "develop"
     import setuptools  # noqa, analysis:ignore
 except ImportError:
-    from warnings import warn
     warn("unable to load setuptools. 'setup.py develop' will not work")
     pass  # it's not essential for installation
 from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ try:
     # use setuptools namespace, allows for "develop"
     import setuptools  # noqa, analysis:ignore
 except ImportError:
+    from warnings import warn
+    warn("unable to load setuptools. 'setup.py develop' will not work")
     pass  # it's not essential for installation
 from distutils.core import setup
 


### PR DESCRIPTION
This is useful if someone is trying to use `python setup.py develop` but doesn't have `setuptools`.

There's a nested import (which loads `warnings.warn`). I will move that to the top level if it is  necessary, but I think the nested import is "neater" since it isolates usage