### PR TITLE
FIX: Remove core distinction

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,8 @@ Vispy licensing terms
 
 Vispy is licensed under the terms of the (new) BSD license:
 
-Copyright (c) 2013, Vispy Development Team
+Copyright (c) 2015, authors of Vispy
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -34,18 +35,3 @@ Exceptions
 
 The examples code in the examples directory can be considered public 
 domain, unless otherwise indicated in the corresponding source file.
-
-
-The Vispy Development Team
---------------------------
-
-The Vispy Development Team is the set of all contributors to the Vispy
-project. The core team that coordinates development consists of: 
-
-  * Luke Campagnola
-  * Nicolas Rougier
-  * Cyrille Rossant
-  * Almar Klein
-  * Eric Larson
-
- 


### PR DESCRIPTION
Core distinction is unnecessary, this gets rid of it for the license. Ready for review/merge. I'll tackle the website hopefully soon.