### PR TITLE
Fix oscilloscope demo without pyaudio installed

### DIFF
--- a/examples/demo/scene/oscilloscope.py
+++ b/examples/demo/scene/oscilloscope.py
@@ -157,7 +157,7 @@ class Oscilloscope(scene.ScrollingLines):
 rolling_tex = """
 float rolling_texture(vec2 pos) {
     if( pos.x < 0 || pos.x > 1 || pos.y < 0 || pos.y > 1 ) {
-        return 0;
+        return 0.0f;
     }
     vec2 uv = vec2(mod(pos.x+$shift, 1), pos.y);
     return texture2D($texture, uv).r;

--- a/examples/demo/scene/oscilloscope.py
+++ b/examples/demo/scene/oscilloscope.py
@@ -68,6 +68,8 @@ except ImportError:
                                          * 0.2, (0.4, 8))
             self.data += gaussian_filter(np.random.normal(size=self.data.shape)
                                          * 0.005, (0, 1))
+            self.data += np.sin(t * 1760 * np.pi)  # 880 Hz
+            self.data = (self.data * 2**10 - 2**9).astype('int16')
             self.ptr = 0
             
         def get_frames(self):

--- a/examples/demo/scene/oscilloscope.py
+++ b/examples/demo/scene/oscilloscope.py
@@ -218,7 +218,7 @@ grid = win.central_widget.add_grid()
 
 view3 = grid.add_view(row=0, col=0, col_span=2, camera='panzoom',
                       border_color='grey')
-image = ScrollingImage((1 + fft_samples//2, 10000), parent=view3.scene)
+image = ScrollingImage((1 + fft_samples // 2, 4000), parent=view3.scene)
 image.transform = scene.LogTransform((0, 10, 0))
 #view3.camera.rect = (0, 0, image.size[1], np.log10(image.size[0]))
 view3.camera.rect = (3493.32, 1.85943, 605.554, 1.41858)


### PR DESCRIPTION
See #1025.

I'm still seeing a `RuntimeError: OpenGL got errors (glTexImage2D): GL_INVALID_VALUE` though.