### PR TITLE
add spatial-filters example in examples/basic/gloo

### DIFF
--- a/examples/basics/gloo/spatial-filters.py
+++ b/examples/basics/gloo/spatial-filters.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vispy: gallery 2
+"""
+Example demonstrating spatial filtering using spatial-filters fragment shader.
+Left and Right Arrow Keys toggle through available filters.
+"""
+
+import os
+import numpy as np
+
+from vispy.util.transforms import ortho
+from vispy.io import _data_dir
+from vispy import gloo
+from vispy import app
+
+
+# Image to be displayed
+W, H = 100, 100
+I = np.random.uniform(0,1,(5,5,3)).astype(np.float32)
+
+# A simple texture quad
+data = np.zeros(4, dtype=[('a_position', np.float32, 2),
+                          ('a_texcoord', np.float32, 2)])
+data['a_position'] = np.array([[0, 0], [W, 0], [0, H], [W, H]])
+data['a_texcoord'] = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+
+
+VERT_SHADER = """
+// Uniforms
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_projection;
+uniform float u_antialias;
+
+// Attributes
+attribute vec2 a_position;
+attribute vec2 a_texcoord;
+
+// Varyings
+varying vec2 v_texcoord;
+
+// Main
+void main (void)
+{
+    v_texcoord = a_texcoord;
+    gl_Position = u_projection * u_view * u_model * vec4(a_position,0.0,1.0);
+}
+"""
+
+FRAG_SHADER = """
+#include "misc/spatial-filters.frag"
+uniform sampler2D u_texture;
+uniform vec2      u_shape;
+uniform float     u_interpolation;
+varying vec2 v_texcoord;
+void main()
+{
+    //gl_FragColor = texture2D(u_texture, v_texcoord);
+    //gl_FragColor.a = 1.0;
+    
+    if (u_interpolation < 0.5)       gl_FragColor = Nearest(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 1.5)  gl_FragColor = Bilinear(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 2.5)  gl_FragColor = Hanning(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 3.5)  gl_FragColor = Hamming(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 4.5)  gl_FragColor = Hermite(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 5.5)  gl_FragColor = Kaiser(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 6.5)  gl_FragColor = Quadric(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 7.5)  gl_FragColor = Bicubic(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 8.5)  gl_FragColor = CatRom(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 9.5)  gl_FragColor = Mitchell(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 10.5) gl_FragColor = Spline16(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 11.5) gl_FragColor = Spline36(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 12.5) gl_FragColor = Gaussian(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 13.5) gl_FragColor = Bessel(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 14.5) gl_FragColor = Sinc(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 15.5) gl_FragColor = Lanczos(u_texture, u_shape, v_texcoord);
+    else                             gl_FragColor = Blackman(u_texture, u_shape, v_texcoord);
+}
+
+"""
+
+
+class Canvas(app.Canvas):
+
+    def __init__(self):
+        app.Canvas.__init__(self, keys='interactive', size=((W*5), (H*5)))
+
+        self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
+        self.texture = gloo.Texture2D(I, interpolation='nearest')
+
+        self.kernel = gloo.Texture2D(np.load(os.path.join(_data_dir, 'spatial-filters.npy')),
+                                     interpolation='nearest')
+
+        self.program['u_texture'] = self.texture
+        self.program['u_kernel'] = self.kernel
+        self.program['u_shape'] = I.shape[1], I.shape[0]
+        self.program['u_interpolation'] = 0
+
+        self.names = [
+            "Nearest", "Bilinear", "Hanning", "Hamming",
+            "Hermite", "Kaiser", "Quadric", "Bicubic",
+            "CatRom", "Mitchell", "Spline16", "Spline36",
+            "Gaussian", "Bessel", "Sinc", "Lanczos", "Blackman"]
+
+        self.title = 'Spatial Filtering using %s Filter' % \
+                     self.names[int(self.program['u_interpolation'])]
+
+        self.program.bind(gloo.VertexBuffer(data))
+
+        self.view = np.eye(4, dtype=np.float32)
+        self.model = np.eye(4, dtype=np.float32)
+        self.projection = np.eye(4, dtype=np.float32)
+
+        self.program['u_model'] = self.model
+        self.program['u_view'] = self.view
+        self.projection = ortho(0, W, 0, H, -1, 1)
+        self.program['u_projection'] = self.projection
+
+        gloo.set_clear_color('white')
+
+        self.show()
+
+    def on_key_press(self, event):
+
+
+        if event.key in ['Left', 'Right']:
+            if event.key == 'Right':
+                step = 1
+            else:
+                step = -1
+            self.program['u_interpolation'] = \
+                (self.program['u_interpolation'] + step) % 17
+        self.title = 'Spatial Filtering using %s Filter' % \
+                     self.names[int(self.program['u_interpolation'])]
+
+        self.update()
+
+    def on_resize(self, event):
+        width, height = event.physical_size
+        gloo.set_viewport(0, 0, width, height)
+        self.projection = ortho(0, width, 0, height, -100, 100)
+        self.program['u_projection'] = self.projection
+
+        # Compute the new size of the quad
+        r = width / float(height)
+        R = W / float(H)
+        if r < R:
+            w, h = width, width / R
+            x, y = 0, int((height - h) / 2)
+        else:
+            w, h = height * R, height
+            x, y = int((width - w) / 2), 0
+        data['a_position'] = np.array(
+            [[x, y], [x + w, y], [x, y + h], [x + w, y + h]])
+        self.program.bind(gloo.VertexBuffer(data))
+
+    def on_draw(self, event):
+        gloo.clear(color=True, depth=True)
+        self.program.draw('triangle_strip')
+
+
+if __name__ == '__main__':
+    c = Canvas()
+    app.run()

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -90,7 +90,7 @@ class Canvas(app.Canvas):
         self.texture = gloo.Texture2D(I, interpolation='nearest')
 
         self.kernel = gloo.Texture2D(np.load(os.path.join(_data_dir, 'spatial-filters.npy')),
-                                     interpolation='nearest')
+                                     interpolation='nearest', internalformat='r16f')
 
         self.program['u_texture'] = self.texture
         self.program['u_kernel'] = self.kernel

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -5,10 +5,9 @@ Example demonstrating spatial filtering using spatial-filters fragment shader.
 Left and Right Arrow Keys toggle through available filters.
 """
 
-import os
 import numpy as np
 
-from vispy.io import _data_dir
+from vispy.io import load_spatial_filters
 from vispy import gloo
 from vispy import app
 
@@ -20,7 +19,7 @@ I[1::2, 2] = 0.5
 I[2, 2] = 1.0
 
 # loading interpolation kernel
-kernel = np.load(os.path.join(_data_dir, 'spatial-filters.npy'))
+kernel = load_spatial_filters()
 
 # A simple texture quad
 data = np.zeros(4, dtype=[('a_position', np.float32, 2),

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -125,8 +125,7 @@ class Canvas(app.Canvas):
         self.program['u_shape'] = I.shape[1], I.shape[0]
         self.program['u_interpolation'] = 0
 
-        self.names = ["Nearest"]
-        self.names.extend(names)
+        self.names = tuple(["Nearest"]) + names
 
         self.title = 'Spatial Filtering using %s Filter' % \
                      self.names[int(self.program['u_interpolation'])]

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -148,9 +148,9 @@ class Canvas(app.Canvas):
                 step = -1
             self.program['u_interpolation'] = \
                 (self.program['u_interpolation'] + step) % 17
-        self.title = 'Spatial Filtering using %s Filter' % \
-                     self.names[int(self.program['u_interpolation'])]
-        self.update()
+            self.title = 'Spatial Filtering using %s Filter' % \
+                         self.names[int(self.program['u_interpolation'])]
+            self.update()
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -55,54 +55,54 @@ void main()
     // using if-statements here is inefficient
     // used here just for selection of interpolation function
     if (u_interpolation < 0.5) {
-        gl_FragColor = Nearest(u_texture, u_shape, v_texcoord);
-    }
-    else if (u_interpolation < 1.5) {
         gl_FragColor = Bilinear(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 2.5) {
+    else if (u_interpolation < 1.5) {
         gl_FragColor = Hanning(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 3.5) {
+    else if (u_interpolation < 2.5) {
         gl_FragColor = Hamming(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 4.5) {
+    else if (u_interpolation < 3.5) {
         gl_FragColor = Hermite(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 5.5) {
+    else if (u_interpolation < 4.5) {
         gl_FragColor = Kaiser(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 6.5) {
+    else if (u_interpolation < 5.5) {
         gl_FragColor = Quadric(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 7.5) {
+    else if (u_interpolation < 6.5) {
         gl_FragColor = Bicubic(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 8.5) {
+    else if (u_interpolation < 7.5) {
         gl_FragColor = CatRom(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 9.5) {
+    else if (u_interpolation < 8.5) {
         gl_FragColor = Mitchell(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 10.5) {
+    else if (u_interpolation < 9.5) {
         gl_FragColor = Spline16(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 11.5) {
+    else if (u_interpolation < 10.5) {
         gl_FragColor = Spline36(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 12.5) {
+    else if (u_interpolation < 11.5) {
         gl_FragColor = Gaussian(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 13.5) {
+    else if (u_interpolation < 12.5) {
         gl_FragColor = Bessel(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 14.5) {
+    else if (u_interpolation < 13.5) {
         gl_FragColor = Sinc(u_texture, u_shape, v_texcoord);
     }
-    else if (u_interpolation < 15.5) {
+    else if (u_interpolation < 14.5) {
         gl_FragColor = Lanczos(u_texture, u_shape, v_texcoord);
     }
-    else gl_FragColor = Blackman(u_texture, u_shape, v_texcoord);
+    else if (u_interpolation < 15.5) {
+        gl_FragColor = Blackman(u_texture, u_shape, v_texcoord);
+    }
+    else gl_FragColor = Nearest(u_texture, u_shape, v_texcoord);
 }
 
 """
@@ -123,9 +123,9 @@ class Canvas(app.Canvas):
         self.program['u_texture'] = self.texture
         self.program['u_kernel'] = self.kernel
         self.program['u_shape'] = I.shape[1], I.shape[0]
-        self.program['u_interpolation'] = 0
+        self.program['u_interpolation'] = 16
 
-        self.names = tuple(["Nearest"]) + names
+        self.names = names
 
         self.title = 'Spatial Filtering using %s Filter' % \
                      self.names[int(self.program['u_interpolation'])]

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# vispy: gallery 2
 """
 Example demonstrating spatial filtering using spatial-filters fragment shader.
 Left and Right Arrow Keys toggle through available filters.
@@ -9,30 +8,28 @@ Left and Right Arrow Keys toggle through available filters.
 import os
 import numpy as np
 
-from vispy.util.transforms import ortho
 from vispy.io import _data_dir
 from vispy import gloo
 from vispy import app
 
+# create 5x5 matrix with border pixels 0, center pixels 1
+# and other pixels 0.5
+I = np.zeros(25).reshape((5, 5)).astype(np.float32)
+I[1:4, 1::2] = 0.5
+I[1::2, 2] = 0.5
+I[2, 2] = 1.0
 
-# Image to be displayed
-W, H = 100, 100
-I = np.random.uniform(0,1,(5,5,3)).astype(np.float32)
+# loading interpolation kernel
+kernel = np.load(os.path.join(_data_dir, 'spatial-filters.npy'))
 
 # A simple texture quad
 data = np.zeros(4, dtype=[('a_position', np.float32, 2),
                           ('a_texcoord', np.float32, 2)])
-data['a_position'] = np.array([[0, 0], [W, 0], [0, H], [W, H]])
-data['a_texcoord'] = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+data['a_position'] = np.array([[-1, -1], [+1, -1], [-1, +1], [+1, +1]])
+data['a_texcoord'] = np.array([[1, 0], [1, 1], [0, 0], [0, 1]])
 
 
 VERT_SHADER = """
-// Uniforms
-uniform mat4 u_model;
-uniform mat4 u_view;
-uniform mat4 u_projection;
-uniform float u_antialias;
-
 // Attributes
 attribute vec2 a_position;
 attribute vec2 a_texcoord;
@@ -44,7 +41,7 @@ varying vec2 v_texcoord;
 void main (void)
 {
     v_texcoord = a_texcoord;
-    gl_Position = u_projection * u_view * u_model * vec4(a_position,0.0,1.0);
+    gl_Position = vec4(a_position,0.0,1.0);
 }
 """
 
@@ -53,29 +50,60 @@ FRAG_SHADER = """
 uniform sampler2D u_texture;
 uniform vec2      u_shape;
 uniform float     u_interpolation;
-varying vec2 v_texcoord;
+varying vec2      v_texcoord;
 void main()
 {
-    //gl_FragColor = texture2D(u_texture, v_texcoord);
-    //gl_FragColor.a = 1.0;
-    
-    if (u_interpolation < 0.5)       gl_FragColor = Nearest(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 1.5)  gl_FragColor = Bilinear(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 2.5)  gl_FragColor = Hanning(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 3.5)  gl_FragColor = Hamming(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 4.5)  gl_FragColor = Hermite(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 5.5)  gl_FragColor = Kaiser(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 6.5)  gl_FragColor = Quadric(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 7.5)  gl_FragColor = Bicubic(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 8.5)  gl_FragColor = CatRom(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 9.5)  gl_FragColor = Mitchell(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 10.5) gl_FragColor = Spline16(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 11.5) gl_FragColor = Spline36(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 12.5) gl_FragColor = Gaussian(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 13.5) gl_FragColor = Bessel(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 14.5) gl_FragColor = Sinc(u_texture, u_shape, v_texcoord);
-    else if (u_interpolation < 15.5) gl_FragColor = Lanczos(u_texture, u_shape, v_texcoord);
-    else                             gl_FragColor = Blackman(u_texture, u_shape, v_texcoord);
+    // using if-statements here is inefficient
+    // used here just for selection of interpolation function
+    if (u_interpolation < 0.5) {
+        gl_FragColor = Nearest(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 1.5) {
+        gl_FragColor = Bilinear(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 2.5) {
+        gl_FragColor = Hanning(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 3.5) {
+        gl_FragColor = Hamming(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 4.5) {
+        gl_FragColor = Hermite(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 5.5) {
+        gl_FragColor = Kaiser(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 6.5) {
+        gl_FragColor = Quadric(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 7.5) {
+        gl_FragColor = Bicubic(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 8.5) {
+        gl_FragColor = CatRom(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 9.5) {
+        gl_FragColor = Mitchell(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 10.5) {
+        gl_FragColor = Spline16(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 11.5) {
+        gl_FragColor = Spline36(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 12.5) {
+        gl_FragColor = Gaussian(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 13.5) {
+        gl_FragColor = Bessel(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 14.5) {
+        gl_FragColor = Sinc(u_texture, u_shape, v_texcoord);
+    }
+    else if (u_interpolation < 15.5) {
+        gl_FragColor = Lanczos(u_texture, u_shape, v_texcoord);
+    }
+    else gl_FragColor = Blackman(u_texture, u_shape, v_texcoord);
 }
 
 """
@@ -84,13 +112,14 @@ void main()
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, keys='interactive', size=((W*5), (H*5)))
+        app.Canvas.__init__(self, keys='interactive', size=((512), (512)))
 
         self.program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         self.texture = gloo.Texture2D(I, interpolation='nearest')
 
-        self.kernel = gloo.Texture2D(np.load(os.path.join(_data_dir, 'spatial-filters.npy')),
-                                     interpolation='nearest', internalformat='r16f')
+        # using internalformat 'r16f' as discussed in issue #1017
+        self.kernel = gloo.Texture2D(kernel, interpolation='nearest',
+                                     internalformat='r16f')
 
         self.program['u_texture'] = self.texture
         self.program['u_kernel'] = self.kernel
@@ -108,22 +137,11 @@ class Canvas(app.Canvas):
 
         self.program.bind(gloo.VertexBuffer(data))
 
-        self.view = np.eye(4, dtype=np.float32)
-        self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
-
-        self.program['u_model'] = self.model
-        self.program['u_view'] = self.view
-        self.projection = ortho(0, W, 0, H, -1, 1)
-        self.program['u_projection'] = self.projection
-
         gloo.set_clear_color('white')
 
         self.show()
 
     def on_key_press(self, event):
-
-
         if event.key in ['Left', 'Right']:
             if event.key == 'Right':
                 step = 1
@@ -133,27 +151,7 @@ class Canvas(app.Canvas):
                 (self.program['u_interpolation'] + step) % 17
         self.title = 'Spatial Filtering using %s Filter' % \
                      self.names[int(self.program['u_interpolation'])]
-
         self.update()
-
-    def on_resize(self, event):
-        width, height = event.physical_size
-        gloo.set_viewport(0, 0, width, height)
-        self.projection = ortho(0, width, 0, height, -100, 100)
-        self.program['u_projection'] = self.projection
-
-        # Compute the new size of the quad
-        r = width / float(height)
-        R = W / float(H)
-        if r < R:
-            w, h = width, width / R
-            x, y = 0, int((height - h) / 2)
-        else:
-            w, h = height * R, height
-            x, y = int((width - w) / 2), 0
-        data['a_position'] = np.array(
-            [[x, y], [x + w, y], [x, y + h], [x + w, y + h]])
-        self.program.bind(gloo.VertexBuffer(data))
 
     def on_draw(self, event):
         gloo.clear(color=True, depth=True)

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -19,7 +19,7 @@ I[1::2, 2] = 0.5
 I[2, 2] = 1.0
 
 # loading interpolation kernel
-kernel = load_spatial_filters()
+kernel, names = load_spatial_filters()
 
 # A simple texture quad
 data = np.zeros(4, dtype=[('a_position', np.float32, 2),
@@ -125,11 +125,8 @@ class Canvas(app.Canvas):
         self.program['u_shape'] = I.shape[1], I.shape[0]
         self.program['u_interpolation'] = 0
 
-        self.names = [
-            "Nearest", "Bilinear", "Hanning", "Hamming",
-            "Hermite", "Kaiser", "Quadric", "Bicubic",
-            "CatRom", "Mitchell", "Spline16", "Spline36",
-            "Gaussian", "Bessel", "Sinc", "Lanczos", "Blackman"]
+        self.names = ["Nearest"]
+        self.names.extend(names)
 
         self.title = 'Spatial Filtering using %s Filter' % \
                      self.names[int(self.program['u_interpolation'])]

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -132,8 +132,8 @@ class Canvas(app.Canvas):
 
         self.program.bind(gloo.VertexBuffer(data))
 
-        gloo.set_clear_color('white')
-
+        self.context.set_clear_color('white')
+        self.context.set_viewport(0, 0, 512, 512)
         self.show()
 
     def on_key_press(self, event):
@@ -148,8 +148,11 @@ class Canvas(app.Canvas):
                          self.names[int(self.program['u_interpolation'])]
             self.update()
 
+    def on_resize(self, event):
+        self.context.set_viewport(0, 0, *event.physical_size)
+
     def on_draw(self, event):
-        gloo.clear(color=True, depth=True)
+        self.context.clear(color=True, depth=True)
         self.program.draw('triangle_strip')
 
 

--- a/vispy/io/__init__.py
+++ b/vispy/io/__init__.py
@@ -8,7 +8,8 @@ Utilities related to data reading, writing, fetching, and generation.
 
 from os import path as _op
 
-from .datasets import load_iris, load_crate, load_data_file  # noqa
+from .datasets import (load_iris, load_crate, load_data_file,  # noqa
+                       load_spatial_filters)  # noqa
 from .mesh import read_mesh, write_mesh  # noqa
 from .image import (read_png, write_png, imread, imsave, _make_png,  # noqa
                     _check_img_lib)  # noqa
@@ -16,5 +17,6 @@ from .image import (read_png, write_png, imread, imsave, _make_png,  # noqa
 _data_dir = _op.join(_op.dirname(__file__), '_data')
 
 __all__ = ['imread', 'imsave', 'load_iris', 'load_crate',
-           'load_data_file', 'read_mesh', 'read_png', 'write_mesh',
+           'load_spatial_filters', 'load_data_file',
+           'read_mesh', 'read_png', 'write_mesh',
            'write_png']

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -42,5 +42,11 @@ def load_spatial_filters():
     -------
     kernel : array
         16x1024 16 interpolation kernel with length 1024 each.
+    names : list with respective interpolation names
     """
-    return np.load(op.join(DATA_DIR, 'spatial-filters.npy'))
+    names = ["Bilinear", "Hanning", "Hamming", "Hermite",
+             "Kaiser", "Quadric", "Bicubic", "CatRom",
+             "Mitchell", "Spline16", "Spline36", "Gaussian",
+             "Bessel", "Sinc", "Lanczos", "Blackman"]
+
+    return (np.load(op.join(DATA_DIR, 'spatial-filters.npy')), names)

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -42,11 +42,13 @@ def load_spatial_filters():
     -------
     kernel : array
         16x1024 16 interpolation kernel with length 1024 each.
-    names : list with respective interpolation names
+    names : tuple of strings
+        Respective interpolation names, plus "Nearest" which does
+        not require a filter but can still be used
     """
     names = ("Bilinear", "Hanning", "Hamming", "Hermite",
              "Kaiser", "Quadric", "Bicubic", "CatRom",
              "Mitchell", "Spline16", "Spline36", "Gaussian",
-             "Bessel", "Sinc", "Lanczos", "Blackman")
+             "Bessel", "Sinc", "Lanczos", "Blackman", "Nearest")
 
     return (np.load(op.join(DATA_DIR, 'spatial-filters.npy')), names)

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -33,3 +33,14 @@ def load_crate():
         256x256x3 crate image.
     """
     return np.load(load_data_file('orig/crate.npz'))['crate']
+
+
+def load_spatial_filters():
+    """Load spatial-filters kernel
+
+    Returns
+    -------
+    kernel : array
+        16x1024 16 interpolation kernel with length 1024 each.
+    """
+    return np.load(op.join(DATA_DIR, 'spatial-filters.npy'))

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -44,9 +44,9 @@ def load_spatial_filters():
         16x1024 16 interpolation kernel with length 1024 each.
     names : list with respective interpolation names
     """
-    names = ["Bilinear", "Hanning", "Hamming", "Hermite",
+    names = ("Bilinear", "Hanning", "Hamming", "Hermite",
              "Kaiser", "Quadric", "Bicubic", "CatRom",
              "Mitchell", "Spline16", "Spline36", "Gaussian",
-             "Bessel", "Sinc", "Lanczos", "Blackman"]
+             "Bessel", "Sinc", "Lanczos", "Blackman")
 
     return (np.load(op.join(DATA_DIR, 'spatial-filters.npy')), names)


### PR DESCRIPTION
PR suggested in #1017 and as follow up to #1048.
 
The added example shows the available 17 interpolations in spatial-filters.frag . Toggling with 'Left' and 'Right' arrow keys. The actual used filter is shown in the window title.