### PR TITLE
WIP: add interpolation to ImageVisual and respective example

### DIFF
--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -33,7 +33,7 @@ view.camera = scene.PanZoomCamera(aspect=1)
 # flip y-axis to have correct aligment
 view.camera.flip = (0, 1, 0)
 view.camera.set_range()
-view.camera.zoom(0.1, (250,200))
+view.camera.zoom(0.1, (250, 200))
 
 # get interpolation functions from Image
 names = image.interpolation_functions

--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -33,6 +33,7 @@ view.camera = scene.PanZoomCamera(aspect=1)
 # flip y-axis to have correct aligment
 view.camera.flip = (0, 1, 0)
 view.camera.set_range()
+view.camera.zoom(0.1, (250,200))
 
 # get interpolation functions from Image
 names = image.interpolation_functions

--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -10,30 +10,7 @@ Simple use of SceneCanvas to display an Image.
 import sys
 from vispy import scene
 from vispy import app
-import numpy as np
-
-
-def get_image():
-    """Load an image from the demo-data repository if possible. Otherwise,
-    just return a randomly generated image.
-    """
-    from vispy.io import load_data_file, read_png
-
-    try:
-        return read_png(load_data_file('mona_lisa/mona_lisa_sm.png'))
-    except Exception as exc:
-        # fall back to random image
-        print("Error loading demo image data: %r" % exc)
-
-    # generate random image
-    image = np.random.normal(size=(100, 100, 3))
-    image[20:80, 20:80] += 3.
-    image[50] += 3.
-    image[:, 50] += 3.
-    image = ((image - image.min()) *
-             (253. / (image.max() - image.min()))).astype(np.ubyte)
-
-    return image
+from vispy.io import load_data_file, read_png
 
 canvas = scene.SceneCanvas(keys='interactive')
 canvas.size = 800, 600
@@ -43,8 +20,10 @@ canvas.show()
 view = canvas.central_widget.add_view()
 
 # Create the image
+img_data = read_png(load_data_file('mona_lisa/mona_lisa_sm.png'))
 interpolation = 'Nearest'
-image = scene.visuals.Image(get_image(), interpolation=interpolation,
+
+image = scene.visuals.Image(img_data, interpolation=interpolation,
                             parent=view.scene, method='subdivide')
 
 canvas.title = 'Spatial Filtering using %s Filter' % interpolation
@@ -59,7 +38,6 @@ view.camera.set_range()
 names = image.interpolation_functions
 names = list(names)
 names.sort()
-print(names)
 act = 17
 
 
@@ -72,11 +50,11 @@ def on_key_press(event):
             step = 1
         else:
             step = -1
-    act = (act + step) % len(names)
-    interpolation = names[act]
-    image.interpolation = interpolation
-    canvas.title = 'Spatial Filtering using %s Filter' % interpolation
-    canvas.update()
+        act = (act + step) % len(names)
+        interpolation = names[act]
+        image.interpolation = interpolation
+        canvas.title = 'Spatial Filtering using %s Filter' % interpolation
+        canvas.update()
 
 
 if __name__ == '__main__' and sys.flags.interactive == 0:

--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -11,6 +11,7 @@ import sys
 from vispy import scene
 from vispy import app
 import numpy as np
+from itertools import cycle
 
 canvas = scene.SceneCanvas(keys='interactive')
 canvas.size = 800, 600
@@ -20,12 +21,29 @@ canvas.show()
 view = canvas.central_widget.add_view()
 
 # Create the image
-img_data = np.random.normal(size=(100, 100, 3), loc=128,
-                            scale=50).astype(np.ubyte)
-image = scene.visuals.Image(img_data, parent=view.scene)
-
+#img_data = np.random.normal(size=(100, 100, 3), loc=128,
+#                            scale=50).astype(np.ubyte)
+img_data = np.zeros(25).reshape((5, 5)).astype(np.float32)
+img_data[1:4, 1::2] = 0.5
+img_data[1::2, 2] = 0.5
+img_data[2, 2] = 1.0
+ipol = 'Nearest'
+image = scene.visuals.Image(img_data, ipol=ipol, parent=view.scene)
+canvas.title = 'Spatial Filtering using %s Filter' % ipol
 # Set 2D camera (the camera will scale to the contents in the scene)
 view.camera = scene.PanZoomCamera(aspect=1)
+view.camera.set_range()
+
+names = cycle(image._names)
+
+# Implement key presses
+@canvas.events.key_press.connect
+def on_key_press(event):
+    ipol = next(names)
+    image.ipol = ipol
+    canvas.title = 'Spatial Filtering using %s Filter' % ipol
+    canvas.update()
+
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     app.run()

--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -11,7 +11,6 @@ import sys
 from vispy import scene
 from vispy import app
 import numpy as np
-from itertools import cycle
 
 canvas = scene.SceneCanvas(keys='interactive')
 canvas.size = 800, 600
@@ -21,29 +20,41 @@ canvas.show()
 view = canvas.central_widget.add_view()
 
 # Create the image
-#img_data = np.random.normal(size=(100, 100, 3), loc=128,
+# img_data = np.random.normal(size=(100, 100, 3), loc=128,
 #                            scale=50).astype(np.ubyte)
 img_data = np.zeros(25).reshape((5, 5)).astype(np.float32)
 img_data[1:4, 1::2] = 0.5
 img_data[1::2, 2] = 0.5
 img_data[2, 2] = 1.0
-ipol = 'Nearest'
-image = scene.visuals.Image(img_data, ipol=ipol, parent=view.scene)
-canvas.title = 'Spatial Filtering using %s Filter' % ipol
+interpolation = 'nearest'
+act = 0
+image = scene.visuals.Image(img_data, interpolation=interpolation,
+                            parent=view.scene)
+canvas.title = 'Spatial Filtering using %s Filter' % interpolation
+
 # Set 2D camera (the camera will scale to the contents in the scene)
 view.camera = scene.PanZoomCamera(aspect=1)
 view.camera.set_range()
 
-names = cycle(image._names)
+# hack for now, should rename "names" to something useful
+# and make public
+names = image._names
+
 
 # Implement key presses
 @canvas.events.key_press.connect
 def on_key_press(event):
-    ipol = next(names)
-    image.ipol = ipol
-    canvas.title = 'Spatial Filtering using %s Filter' % ipol
+    global act
+    if event.key in ['Left', 'Right']:
+        if event.key == 'Right':
+            step = 1
+        else:
+            step = -1
+    act = (act + step) % len(names)
+    interpolation = names[act]
+    image.interpolation = interpolation
+    canvas.title = 'Spatial Filtering using %s Filter' % interpolation
     canvas.update()
-
 
 if __name__ == '__main__' and sys.flags.interactive == 0:
     app.run()

--- a/examples/basics/scene/image.py
+++ b/examples/basics/scene/image.py
@@ -21,7 +21,7 @@ view = canvas.central_widget.add_view()
 
 # Create the image
 img_data = read_png(load_data_file('mona_lisa/mona_lisa_sm.png'))
-interpolation = 'Nearest'
+interpolation = 'nearest'
 
 image = scene.visuals.Image(img_data, interpolation=interpolation,
                             parent=view.scene, method='subdivide')

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -123,11 +123,11 @@ class ImageVisual(Visual):
         interpolation methods and the available interpolation methods defined
         in vispy/gloo/glsl/misc/spatial_filters.frag
 
-            * 'Nearest': Default, uses 'nearest' with Texture2D interpolation.
-            * 'Bilinear': uses 'linear' with Texture2D interpolation.
-            * 'Hanning', 'Hamming', 'Hermite', 'Kaiser', 'Quadric', 'Bicubic',
-                'CatRom', 'Mitchell', 'Spline16', 'Spline36', 'Gaussian',
-                'Bessel', 'Sinc', 'Lanczos', 'Blackman'
+            * 'nearest': Default, uses 'nearest' with Texture2D interpolation.
+            * 'bilinear': uses 'linear' with Texture2D interpolation.
+            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'bicubic',
+                'catrom', 'mitchell', 'spline16', 'spline36', 'gaussian',
+                'bessel', 'sinc', 'lanczos', 'blackman'
 
     **kwargs : dict
         Keyword arguments to pass to `Visual`.
@@ -139,12 +139,12 @@ class ImageVisual(Visual):
     """
     def __init__(self, data=None, method='auto', grid=(1, 1),
                  cmap='cubehelix', clim='auto',
-                 interpolation='Nearest', **kwargs):
+                 interpolation='nearest', **kwargs):
         self._data = None
 
         # check texture interpolation
         self._interpolation = interpolation
-        if self._interpolation == 'Bilinear':
+        if self._interpolation == 'bilinear':
             texture_interpolation = 'linear'
         else:
             texture_interpolation = 'nearest'
@@ -162,18 +162,18 @@ class ImageVisual(Visual):
 
         # load interpolation kernel
         self._kernel, self._interpolation_names = load_spatial_filters()
-
         # create interpolation shader functions for available
         # interpolations
         fun = [Function(_interpolation_template % n)
                for n in self._interpolation_names]
+        self._interpolation_names = [n.lower() for n in self._interpolation_names]
         self._interpolation_fun = dict(zip(self._interpolation_names, fun))
         self.interpolation_filters = self._interpolation_names
 
-        # overwrite "Nearest" and "Bilinear" spatial-filters
+        # overwrite "nearest" and "bilinear" spatial-filters
         # with  "hardware" interpolation _data_lookup_fn
-        self._interpolation_fun['Nearest'] = Function(_texture_lookup)
-        self._interpolation_fun['Bilinear'] = Function(_texture_lookup)
+        self._interpolation_fun['nearest'] = Function(_texture_lookup)
+        self._interpolation_fun['bilinear'] = Function(_texture_lookup)
 
         # create interpolation kernel Texture2D, using 'r16f'
         # as discussed in issue #1017
@@ -293,13 +293,13 @@ class ImageVisual(Visual):
         self.shared_program.frag['get_data'] = self._data_lookup_fn
 
         # only 'Bilinear' uses 'linear' texture interpolation
-        if interpolation == 'Bilinear':
+        if interpolation == 'bilinear':
             texture_interpolation = 'linear'
         else:
             # 'Nearest' (and also 'Bilinear') doesn't use spatial_filters.frag
             # so u_kernel and shape setting is skipped
             texture_interpolation = 'nearest'
-            if interpolation != 'Nearest':
+            if interpolation != 'nearest':
                 self.shared_program['u_kernel'] = self._kerneltex
                 self._data_lookup_fn['shape'] = self._data.shape[:2][::-1]
 

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -294,6 +294,8 @@ class ImageVisual(Visual):
     def interpolation_functions(self):
         return self._interpolation_names
 
+    # The interpolation code could be transferred to a dedicated filter
+    # function in visuals/filters as discussed in #1051
     def _build_interpolation(self):
         """Rebuild the _data_lookup_fn using different interpolations within
         the shader
@@ -302,11 +304,11 @@ class ImageVisual(Visual):
         self._data_lookup_fn = self._interpolation_fun[interpolation]
         self.shared_program.frag['get_data'] = self._data_lookup_fn
 
-        # only 'Bilinear' uses 'linear' texture interpolation
+        # only 'bilinear' uses 'linear' texture interpolation
         if interpolation == 'bilinear':
             texture_interpolation = 'linear'
         else:
-            # 'Nearest' (and also 'Bilinear') doesn't use spatial_filters.frag
+            # 'nearest' (and also 'bilinear') doesn't use spatial_filters.frag
             # so u_kernel and shape setting is skipped
             texture_interpolation = 'nearest'
             if interpolation != 'nearest':

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -283,7 +283,8 @@ class ImageVisual(Visual):
     @interpolation.setter
     def interpolation(self, i):
         if i not in self._interpolation_names:
-            raise ValueError("interpolation must be one of %s" % ', '.join(self._interpolation_names))
+            raise ValueError("interpolation must be one of %s" %
+                             ', '.join(self._interpolation_names))
         if self._interpolation != i:
             self._interpolation = i
             self._need_interpolation_update = True

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -267,7 +267,6 @@ class ImageVisual(Visual):
         the shader
         """
         interpolation = self._interpolation
-        print(interpolation)
 
         self._data_lookup_fn = self._interpolation_fun[interpolation]
         self.shared_program.frag['get_data'] = self._data_lookup_fn


### PR DESCRIPTION
As discussed in #1017:

This is a first attempt to implement spatial filtering to image visual.
The example works, but the handling with the "hardware" modes ('nearest', 'linear') is still broken. 

For every interpolation a dedicated lookup_function is created and fit to the shader_program as needed. I'm open for any suggestions to improve this. I already thought about subclassing ImageVisual, but that should not be mandatory.

There is sure a lot of room for improvement.