### PR TITLE
FIX: Fix license

### DIFF
--- a/vispy/util/svg/geometry.py
+++ b/vispy/util/svg/geometry.py
@@ -1,25 +1,33 @@
-# ----------------------------------------------------------------------------
-#  Anti-Grain Geometry (AGG) - Version 2.5
-#  A high quality rendering engine for C++
-#  Copyright (C) 2002-2006 Maxim Shemanarev
-#  Contact: mcseem@antigrain.com
-#           mcseemagg@yahoo.com
-#           http://antigrain.com
+# Anti-Grain Geometry - Version 2.4
+# Copyright (C) 2002-2005 Maxim Shemanarev (McSeem)
 #
-#  AGG is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
 #
-#  AGG is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+#   1. Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with AGG; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+#   2. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#
+#   3. The name of the author may not be used to endorse or promote
+#      products derived from this software without specific prior
+#      written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 #
 # Python translation by Nicolas P. Rougier


### PR DESCRIPTION
Puts in the modified BSD license for AGG 2.4 derivative.

Closes #1065.

Ready for review/merge @rougier.