### PR TITLE
Textured globe example

### DIFF
--- a/examples/demo/scene/textured_globe.py
+++ b/examples/demo/scene/textured_globe.py
@@ -1,0 +1,18 @@
+import sys
+import numpy as np
+from vispy.scene import visuals
+from vispy import scene
+
+canvas = scene.SceneCanvas(keys='interactive', show=True, bgcolor='k')
+
+view = canvas.central_widget.add_view()
+view.camera = 'arcball'
+view.camera.fov = 70
+enc = visuals.Sphere(radius=1, color=(0, 0, 1), rows=300, cols=300, depth=300,
+                             edge_color=None, shading='textured_globe', parent=view.scene)
+
+axis = visuals.XYZAxis(parent=view.scene, width=1)
+
+
+if __name__ == '__main__':
+    canvas.app.run()

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -17,9 +17,10 @@ from ..gloo import VertexBuffer, IndexBuffer
 from ..geometry import MeshData
 from ..color import Color
 
+import Image
 
-# Shaders for lit rendering (using phong shading)
-shading_vertex_template = """
+# shaders for lit rendering (using phong shading)
+shading_vertex_template = """ 
 varying vec3 v_normal_vec;
 varying vec3 v_light_vec;
 varying vec3 v_eye_vec;
@@ -66,7 +67,28 @@ void main() {
 }
 """
 
-shading_fragment_template = """
+textured_vertex_template = """
+varying vec3 v_normal_vec;
+
+uniform sampler2D u_texture;
+
+void main() {
+
+    vec4 pos_scene = $visual2scene($to_vec4($position));
+    vec4 normal_scene = $visual2scene(vec4($normal, 1));
+    vec4 origin_scene = $visual2scene(vec4(0, 0, 0, 1));
+
+    normal_scene /= normal_scene.w;
+    origin_scene /= origin_scene.w;
+
+    vec3 normal = normalize(normal_scene.xyz - origin_scene.xyz);
+    v_normal_vec = normal; //VARYING COPY
+
+    gl_Position = $transform($to_vec4($position));
+}
+"""
+
+shading_fragment_template = """ 
 varying vec3 v_normal_vec;
 varying vec3 v_light_vec;
 varying vec3 v_eye_vec;
@@ -98,10 +120,36 @@ void main() {
 
 
     gl_FragColor =
-       v_base_color * (v_ambientk + diffuse_color) + specular_color;
+        v_base_color * (v_ambientk + diffuse_color) + specular_color;
 
     //gl_FragColor = vec4(speculark, 0, 1, 1.0);
 
+}
+"""
+
+textured_fragment_template = """
+varying vec3 v_normal_vec;
+
+uniform sampler2D u_texture;
+
+void main() {
+    
+    float pi = 3.14159265359;
+
+    float phi = asin(v_normal_vec.z);
+    float theta = acos(v_normal_vec.x/cos(phi));
+    
+    if(sign(v_normal_vec.y) > 0){
+        theta = theta*-1;
+        theta += 2*pi;
+    }
+        
+
+    vec2 texcoord = vec2(theta/(2*pi), phi/pi + 0.5);
+
+    gl_FragColor = vec4(texture2D(u_texture, texcoord).xyz, 1.0);
+
+    //gl_FragColor = vec4(0.0 ,0.0 ,theta/(2*3.1416), 1.0);
 
 }
 """
@@ -170,9 +218,14 @@ class MeshVisual(Visual):
         # Visual.__init__ -> prepare_transforms() -> uses shading
         self.shading = shading
 
-        if shading is not None:
+        if shading is not None and shading != 'textured_globe':
             Visual.__init__(self, vcode=shading_vertex_template,
                             fcode=shading_fragment_template,
+                            **kwargs)
+        
+        elif shading == "textured_globe":
+            Visual.__init__(self, vcode=textured_vertex_template,
+                            fcode=textured_fragment_template,
                             **kwargs)
 
         else:
@@ -309,14 +362,14 @@ class MeshVisual(Visual):
             if v.shape[-1] == 2:
                 v = np.concatenate((v, np.zeros((v.shape[:-1] + (1,)))), -1)
             self._vertices.set_data(v, convert=True)
-            if self.shading == 'smooth':
+            if self.shading in ['smooth', 'textured_globe']:
                 normals = md.get_vertex_normals(indexed='faces')
                 self._normals.set_data(normals, convert=True)
             elif self.shading == 'flat':
                 normals = md.get_face_normals(indexed='faces')
                 self._normals.set_data(normals, convert=True)
             else:
-                self._normals.set_data(np.zeros((0, 3), dtype=np.float32))
+                self._normals.set_data(np.zeros((0,3), dtype = np.float32))
             self._index_buffer = None
             if md.has_vertex_color():
                 self._colors.set_data(md.get_vertex_colors(indexed='faces'),
@@ -327,6 +380,11 @@ class MeshVisual(Visual):
             else:
                 self._colors.set_data(np.zeros((0, 4), dtype=np.float32))
         self.shared_program.vert['position'] = self._vertices
+
+        if self.shading == 'textured_globe':
+            jpg = Image.open('Platecarretissot.png')
+
+            self.shared_program['u_texture'] = np.asarray(jpg)
 
         # Position input handling
         if v.shape[-1] == 2:
@@ -355,12 +413,13 @@ class MeshVisual(Visual):
                 normals = (1., 0., 0.)
 
             self.shared_program.vert['normal'] = normals
-            self.shared_program.vert['base_color'] = colors
+            if self.shading != 'textured_globe':
+                self.shared_program.vert['base_color'] = colors
 
-            # Additional phong properties
-            self.shared_program.vert['light_dir'] = (10, 5, -5)
-            self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
-            self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
+                # Additional phong properties
+                self.shared_program.vert['light_dir'] = (10, 5, -5)
+                self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
+                self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
 
         self._data_changed = False
 
@@ -372,7 +431,7 @@ class MeshVisual(Visual):
 
     @shading.setter
     def shading(self, value):
-        assert value in (None, 'flat', 'smooth')
+        assert value in (None, 'flat', 'smooth', 'textured_globe')
         self._shading = value
 
     def _prepare_draw(self, view):
@@ -394,8 +453,9 @@ class MeshVisual(Visual):
             scene2doc = view.transforms.get_transform('scene', 'document')
             doc2scene = view.transforms.get_transform('document', 'scene')
             view.shared_program.vert['visual2scene'] = visual2scene
-            view.shared_program.vert['scene2doc'] = scene2doc
-            view.shared_program.vert['doc2scene'] = doc2scene
+            if view.shading != 'textured_globe':
+                view.shared_program.vert['scene2doc'] = scene2doc
+                view.shared_program.vert['doc2scene'] = doc2scene
 
     def _compute_bounds(self, axis, view):
         if self._bounds is None:

--- a/vispy/visuals/sphere.py
+++ b/vispy/visuals/sphere.py
@@ -42,7 +42,7 @@ class SphereVisual(CompoundVisual):
     """
     def __init__(self, radius=1.0, cols=30, rows=30, depth=30, subdivisions=3,
                  method='latitude', vertex_colors=None, face_colors=None,
-                 color=(0.5, 0.5, 1, 1), edge_color=None, **kwargs):
+                 color=(0.5, 0.5, 1, 1), edge_color=None, shading=None, **kwargs):
 
         mesh = create_sphere(cols, rows, depth, radius=radius,
                              subdivisions=subdivisions, method=method)
@@ -50,14 +50,14 @@ class SphereVisual(CompoundVisual):
         self._mesh = MeshVisual(vertices=mesh.get_vertices(),
                                 faces=mesh.get_faces(),
                                 vertex_colors=vertex_colors,
-                                face_colors=face_colors, color=color)
+                                face_colors=face_colors, color=color,
+                                shading=shading)
         if edge_color:
             self._border = MeshVisual(vertices=mesh.get_vertices(),
                                       faces=mesh.get_edges(),
                                       color=edge_color, mode='lines')
         else:
             self._border = MeshVisual()
-
         CompoundVisual.__init__(self, [self._mesh, self._border], **kwargs)
         self.mesh.set_gl_state(polygon_offset_fill=True,
                                polygon_offset=(1, 1), depth_test=True)


### PR DESCRIPTION
Not intended for merge. For a project I was working on recently I thought I would try vispy as I was interested in using the `vispy.scene` sub package. The goal of the project was to display some data on a textured 3D globe. Unfortunately, the `MeshVisual` class doesn't seem to support custom shaders or texturing at the moment.

This PR contains my hack to add textures to a globe by mapping the normals to points on a Plate Carrée map ("the texture file for the map was too large for me to upload to github but any Plate Carée map should do just fine"). I was wondering if there is a better way to do this in vispy at the moment? And also whether there are plans to add more flexibility with shaders and/or adding texture options to the `MeshVisual` class?