### PR TITLE
Fix grid_widget when Fig gets a single element

### DIFF
--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -38,7 +38,7 @@ class Grid(Widget):
         if not isinstance(idxs, tuple):
             idxs = (idxs,)
         if len(idxs) == 1:
-            idxs = idxs + (slice(None),)
+            idxs = idxs + (slice(0, 1, None),)
         elif len(idxs) != 2:
             raise ValueError('Incorrect index: %s' % (idxs,))
         lims = np.empty((2, 2), int)


### PR DESCRIPTION
This PR i a fix when we use Fig class to create a grid.

There is a bug if you write

```
f = Fig()
ax = f[0]
...
```

Then the cspan is 0. The PR solves the problem by giving a default size to 1 for the column.

This PR adds also a _row_widgets that defines the widgets that take all the row and need to be expand when the column size of the grid has changed.

The idea is to have the same behavior if you do

```
f = Fig()
ax1 = f[0]
...
ax2 = f[1, :2]
```

or 

```
f = Fig()
ax1 = f[0, :2]
...
ax2 = f[1]
```

I think that we have to change also the stretch of the widget when we change the size of the cspan of the _grid_widgets in _update_child_widgets but if I do that I have a "maximum recursion depth exceeded" because modified stretch call again _update_child_widgets.
