### PR TITLE
Fixed a bug when using rectangular vector field

### DIFF
--- a/examples/demo/scene/flow_lines.py
+++ b/examples/demo/scene/flow_lines.py
@@ -36,7 +36,7 @@ class VectorFieldVisual(visuals.Visual):
         dist = index.y * seg_len;
         
         vec2 local;
-        ij = vec2(mod(index.x, shape.x), floor(index.x / shape.y));
+        ij = vec2(mod(index.x, shape.x), floor(index.x / shape.x));
         // *off* is a random offset to the starting location, which prevents
         // the appearance of combs in the field 
         vec2 off = texture2D(offset, ij / shape).xy - 0.5;


### PR DESCRIPTION
When calculating the row and column indices, there was a division by shape.y instead of shape.x, causing bugs when using a non-square vector field.