### PR TITLE
FIX: cubehelix issues

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -969,7 +969,7 @@ _colormaps = dict(
     RdBu=_Diverging(220, 20, 0.75, 0.5),
 
     # Configurable colormaps
-    cubehelix=CubeHelixColormap(),
+    cubehelix=CubeHelixColormap,
     single_hue=_SingleHue,
     hsl=_HSL,
     husl=_HUSL,

--- a/vispy/ext/cubehelix.py
+++ b/vispy/ext/cubehelix.py
@@ -135,4 +135,4 @@ def cubehelix(start=0.5, rot=1, gamma=1.0, reverse=True, nlev=256.,
         blu = blu[::-1]
         grn = grn[::-1]
 
-    return np.array((red, blu, grn)).T
+    return np.array((red, grn, blu)).T


### PR DESCRIPTION
While co-working with VisPy and matplotlib I wondered why the VisPy cubehelix implementation misses the green parts of the colormap. First I thought this is with the standard cubehelix implementation and tried to change `start`, `rot` and other keywords. Nothing happened, this was due to `cubehelix` was already instantiated within `colormap`-module and no pure class any more. 

The colors were not influenced by this change, so I found that **rgb** was in the wrong order **rbg**. After changing this everything works as expected (as far I can see).