### PR TITLE
Initialize gl_FragColor in iso volume renderer.

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -335,6 +335,7 @@ ISO_SNIPPETS = dict(
     before_loop="""
         vec4 color3 = vec4(0.0);  // final color
         vec3 dstep = 1.5 / u_shape;  // step to sample derivative
+        gl_FragColor = vec4(0.0);
     """,
     in_loop="""
         if (val > u_threshold-0.2) {


### PR DESCRIPTION
Sometimes the loop does not assign a value to gl_FragColor, and on some GPUs it produces rather unpleasant results.

Fixes #966.