### PR TITLE
Call view_changed when camera.depth_value is set

### DIFF
--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -107,6 +107,7 @@ class BaseCamera(Node):
         if value <= 0:
             raise ValueError('depth value must be positive')
         self._depth_value = value
+        self.view_changed()
 
     def _depth_to_z(self, depth):
         """ Get the z-coord, given the depth value.


### PR DESCRIPTION
This calls `camera.view_changed` when `camera.depth_value` is set. Otherwise, one has to wait for the next view refresh to see the result.