### PR TITLE
Removed call to non-existent Widget.remove_parent

### DIFF
--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -345,5 +345,4 @@ class Widget(Compound):
             The widget to remove.
         """
         self._widgets.remove(widget)
-        widget.remove_parent(self)
         self._update_child_widgets()


### PR DESCRIPTION
I'm not sure if there are other problems related to this (like setting the parent in the first place - but other places do reference self.parent so maybe that's expected), but the method doesn't exist so this at least prevents an actual crash.