### PR TITLE
Unset widget parent when removed

### DIFF
--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -345,4 +345,5 @@ class Widget(Compound):
             The widget to remove.
         """
         self._widgets.remove(widget)
+        widget.parent = None
         self._update_child_widgets()


### PR DESCRIPTION
Following my previous PR at https://github.com/vispy/vispy/pull/1132, I now think that it's very important to set the parent of a widget to None when it's removed. If this isn't done, it's removed from the widget tree but not from the Node heirarchy (where parent is actually used), and so is actually still displayed on screen but in a funny buggy way.

I'm not certain what is the intended way for this to work, but I'm fairly confident this fix is an unambiguous improvement; with it, removing widgets seems to work as expected, and I haven't found any further problems.

The improperly-removed Nodes also seem to have been the reason for the mouse input problems I mentioned on gitter.