### PR TITLE
Update bundled six to 1.8.0 and allow it to be frozen

### DIFF
--- a/vispy/ext/_bundled/png.py
+++ b/vispy/ext/_bundled/png.py
@@ -45,8 +45,8 @@ import struct
 import zlib
 # http://www.python.org/doc/2.4.4/lib/module-warnings.html
 import warnings
-from .six.moves import map as imap
-from .six import string_types
+from ..six.moves import map as imap
+from ..six import string_types
 import itertools
 
 

--- a/vispy/ext/six.py
+++ b/vispy/ext/six.py
@@ -7,8 +7,13 @@
 Handle loading six package from system or from the bundled copy
 """
 
-import imp
+try:
+    import importlib
+except ImportError:
+    importlib = None
+    import imp
 import io
+import sys
 
 from distutils.version import StrictVersion
 
@@ -37,24 +42,32 @@ def _find_module(name, path=None):
 
 def _import_six(search_path=_SIX_SEARCH_PATH):
     for mod_name in search_path:
-        try:
-            mod_info = _find_module(mod_name)
-        except ImportError:
-            continue
+        if importlib is not None:
+            try:
+                six_mod = importlib.import_module(mod_name)
+            except ImportError:
+                continue
+        else:
+            try:
+                mod_info = _find_module(mod_name)
+            except ImportError:
+                continue
+            else:
+                try:
+                    # Using __name__ causes the import to effectively overwrite
+                    # this shim.
+                    six_mod = imp.load_module(__name__, *mod_info)
+                finally:
+                    if mod_info[0] is not None:
+                        mod_info[0].close()
 
         try:
-            mod = imp.load_module(__name__, *mod_info)
-        finally:
-            if mod_info[0] is not None:
-                mod_info[0].close()
-
-        try:
-            if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
+            if StrictVersion(six_mod.__version__) >= _SIX_MIN_VERSION:
                 break
         except (AttributeError, ValueError):
-            # Attribute error if the six module isn't what it should be and doesn't
-            # have a .__version__; ValueError if the version string exists but is
-            # somehow bogus/unparseable
+            # Attribute error if the six module isn't what it should be and
+            # doesn't have a .__version__; ValueError if the version string
+            # exists but is somehow bogus/unparseable
             continue
     else:
         raise ImportError(
@@ -62,6 +75,28 @@ def _import_six(search_path=_SIX_SEARCH_PATH):
             "normally this is bundled with the Vispy package so if you get "
             "this warning consult the packager of your Vispy "
             "distribution.".format(_SIX_MIN_VERSION))
+
+    # Using importlib does not overwrite this shim, so do it ourselves.
+    this_module = sys.modules[__name__]
+    if not hasattr(this_module, '_importer'):
+        # Copy all main six attributes.
+        for name, value in six_mod.__dict__.items():
+            if name.startswith('__'):
+                continue
+            this_module.__dict__[name] = value
+
+        # Tell six's importer to accept this shim's name as its own.
+        importer = six_mod._importer
+        known_modules = list(importer.known_modules.items())
+        for name, mod in known_modules:
+            this_name = __name__ + name[len(mod_name):]
+            importer.known_modules[this_name] = mod
+
+        # Turn this shim into a package just like six does.
+        this_module.__path__ = []  # required for PEP 302 and PEP 451
+        this_module.__package__ = __name__  # see PEP 366
+        if this_module.__dict__.get('__spec__') is not None:
+            this_module.__spec__.submodule_search_locations = []  # PEP 451
 
 
 _import_six()

--- a/vispy/ext/six.py
+++ b/vispy/ext/six.py
@@ -13,7 +13,7 @@ import io
 from distutils.version import StrictVersion
 
 
-_SIX_MIN_VERSION = StrictVersion('1.4.1')
+_SIX_MIN_VERSION = StrictVersion('1.8.0')
 _SIX_SEARCH_PATH = ['vispy.ext._bundled.six', 'six']
 
 


### PR DESCRIPTION
Six 1.8.0 appears to be the latest version available on Debian stable. Ubuntu and Fedora are both on 1.9.0. I changed the shim to use `importlib` where available (2.7+) which should allow vispy to be frozen.

@jdreaver Can you see if this works? Right now, it seems like you need to freeze `six` as well, even though the bundled copy is there. I haven't figured out why it can't see it, but I think this is a good enough work-around for the time being.

Fixes #1074 hopefully.