### PR TITLE
bugfix vispy.io.read_mesh fails because of numpy bug #823

### DIFF
--- a/vispy/geometry/calculations.py
+++ b/vispy/geometry/calculations.py
@@ -75,7 +75,7 @@ def _calculate_normals(rr, tris):
     nn = np.zeros((npts, 3))
     for verts in tris.T:  # note this only loops 3x (number of verts per tri)
         for idx in range(3):  # x, y, z
-            nn[:, idx] += np.bincount(verts, tri_nn[:, idx], minlength=npts)
+            nn[:, idx] += np.bincount(verts.astype(np.int32), tri_nn[:, idx], minlength=npts)
     size = np.sqrt(np.sum(nn * nn, axis=1))
     size[size == 0] = 1.0  # prevent ugly divide-by-zero
     nn /= size[:, np.newaxis]

--- a/vispy/geometry/calculations.py
+++ b/vispy/geometry/calculations.py
@@ -75,7 +75,8 @@ def _calculate_normals(rr, tris):
     nn = np.zeros((npts, 3))
     for verts in tris.T:  # note this only loops 3x (number of verts per tri)
         for idx in range(3):  # x, y, z
-            nn[:, idx] += np.bincount(verts.astype(np.int32), tri_nn[:, idx], minlength=npts)
+            nn[:, idx] += np.bincount(verts.astype(np.int32),
+                                      tri_nn[:, idx], minlength=npts)
     size = np.sqrt(np.sum(nn * nn, axis=1))
     size[size == 0] = 1.0  # prevent ugly divide-by-zero
     nn /= size[:, np.newaxis]


### PR DESCRIPTION
By some .obj files (for example obj files generated with FreeCAD) the read_mesh function fails because of a numpy bug (in numpy repository under bug 823, 4366 and 4384). 

Because handling the numpy bug would be too complex, I corrected the code here.

By using this modification I was able to read all obj files.