### PR TITLE
BUG: Type casting error in agg_path_collection.py

### DIFF
--- a/vispy/visuals/collections/agg_path_collection.py
+++ b/vispy/visuals/collections/agg_path_collection.py
@@ -175,12 +175,12 @@ class AggPathCollection(Collection):
             # uint16 for WebGL
             I = np.resize(
                 np.array([0, 1, 2, 1, 2, 3], dtype=np.uint32), n * 2 * 3)
-            I += np.repeat(4 * np.arange(n), 6)
+            I += np.repeat(4 * np.arange(n, dtype=np.uint32), 6)
             I[-6:] = 4 * n - 6, 4 * n - 5, 0, 4 * n - 5, 0, 1
         else:
             I = np.resize(
                 np.array([0, 1, 2, 1, 2, 3], dtype=np.uint32), (n - 1) * 2 * 3)
-            I += np.repeat(4 * np.arange(n - 1), 6)
+            I += np.repeat(4 * np.arange(n - 1, dtype=np.uint32), 6)
         I = I.ravel()
 
         # Uniforms


### PR DESCRIPTION
I had troubles running examples `collections\tiger.py`and `collections\chloropleth.py` because of a small problem with type casting in newer versions of numpy.

So I hope this tiny fix is helpful.