### PR TITLE
top and right orientations in AxisWidget

### DIFF
--- a/vispy/scene/widgets/axis.py
+++ b/vispy/scene/widgets/axis.py
@@ -55,7 +55,8 @@ class AxisWidget(Widget):
         elif self.orientation == 'top':
             return np.array([[r.left, r.top], [r.right, r.top]])
         else:
-            raise RuntimeError('Orientation %s not supported.' % self.orientation)
+            raise RuntimeError(
+                'Orientation %s not supported.' % self.orientation)
         
     def link_view(self, view):
         """Link this axis to a ViewBox

--- a/vispy/scene/widgets/axis.py
+++ b/vispy/scene/widgets/axis.py
@@ -54,6 +54,8 @@ class AxisWidget(Widget):
             return np.array([[r.left, r.top], [r.left, r.bottom]])
         elif self.orientation == 'top':
             return np.array([[r.left, r.top], [r.right, r.top]])
+        else:
+            raise RuntimeError('Orientation %s not supported.' % self.orientation)
         
     def link_view(self, view):
         """Link this axis to a ViewBox

--- a/vispy/scene/widgets/axis.py
+++ b/vispy/scene/widgets/axis.py
@@ -50,6 +50,10 @@ class AxisWidget(Widget):
             return np.array([[r.right, r.top], [r.right, r.bottom]])
         elif self.orientation == 'bottom':
             return np.array([[r.left, r.bottom], [r.right, r.bottom]])
+        elif self.orientation == 'right':
+            return np.array([[r.left, r.top], [r.left, r.bottom]])
+        elif self.orientation == 'top':
+            return np.array([[r.left, r.top], [r.right, r.top]])
         
     def link_view(self, view):
         """Link this axis to a ViewBox


### PR DESCRIPTION
When instantiating AxisWidget class with *orientation='right'* or *orientation='top'*, the function AxisWidget.on_resize raises an exception because AxisWidget._axis_ends supports only 'left' and 'button' orientations.
This PR adds support for 'right' and 'top' orientations in function _axis_ends of AxisWidget class.