### PR TITLE
allow conflicting library, if the user has chosen one

### DIFF
--- a/vispy/app/application.py
+++ b/vispy/app/application.py
@@ -164,6 +164,9 @@ class Application(object):
         # with requires_application()
         test_name = os.getenv('_VISPY_TESTING_APP', None)
 
+        if backend_name is not None:
+            backends.SELECTED_BY_USER_BACKEND = backend_name.lower()
+
         # Check whether the given name is valid
         if backend_name is not None:
             if backend_name.lower() == 'default':

--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -46,5 +46,8 @@ BACKENDMAP = dict([(be[0].lower(), be) for be in BACKENDS])
 # List of attempted backends. For logging.
 TRIED_BACKENDS = []
 
+# For allow conflicted libraries if user select some one.
+SELECTED_BY_USER_BACKEND = None
+
 # Flag for _pyside, _pyqt4 and _qt modules to communicate.
 qt_lib = None

--- a/vispy/app/backends/_pyqt4.py
+++ b/vispy/app/backends/_pyqt4.py
@@ -17,8 +17,14 @@ try:
     for lib in ['PySide', 'PyQt5']:
         lib += '.QtCore'
         if lib in sys.modules:
-            raise RuntimeError("Refusing to import PyQt4 because %s is "
-                               "already imported." % lib)
+            # If user choose this backend then load it, print warning about conflict.
+            if backends.SELECTED_BY_USER_BACKEND == 'pyqt4':
+                logger.warning('It was found a library "%s" that conflicts with "%s"'
+                               % (lib, 'PyQt4.QtCore'))
+            # else pass import.
+            else:
+                raise RuntimeError("Refusing to import PyQt4 because %s is "
+                                   "already imported." % lib)
     # Try importing (QtOpenGL first to fail without import QtCore)
     if not USE_EGL:
         from PyQt4 import QtOpenGL  # noqa

--- a/vispy/app/backends/_pyside.py
+++ b/vispy/app/backends/_pyside.py
@@ -17,8 +17,14 @@ try:
     for lib in ['PyQt4', 'PyQt5']:
         lib += '.QtCore'
         if lib in sys.modules:
-            raise RuntimeError("Refusing to import PySide because %s is "
-                               "already imported." % lib)
+            # If user choose this backend then load it, print warning about conflict.
+            if backends.SELECTED_BY_USER_BACKEND == 'pyside':
+                logger.warning('It was found a library "%s" that conflicts with "%s"'
+                               % (lib, 'PySide.QtCore'))
+            # else pass import.
+            else:
+                raise RuntimeError("Refusing to import PySide because %s is "
+                                   "already imported." % lib)
     # Try importing (QtOpenGL first to fail without import QtCore)
     if not USE_EGL:
         from PySide import QtOpenGL  # noqa

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -34,7 +34,7 @@ from ...util import keys
 from ...ext.six import text_type
 from ...ext.six import string_types
 from ... import config
-from . import qt_lib
+from . import qt_lib, SELECTED_BY_USER_BACKEND
 
 USE_EGL = config['gl_backend'].lower().startswith('es')
 
@@ -54,6 +54,9 @@ elif sys.platform.startswith('win'):
 
 
 def _check_imports(lib):
+    # If user select library then OK.
+    if lib is not None and SELECTED_BY_USER_BACKEND == lib.lower():
+        return True
     # Make sure no conflicting libraries have been imported.
     libs = ['PyQt4', 'PyQt5', 'PySide']
     libs.remove(lib)


### PR DESCRIPTION
Fix #1144
If interpreter has both PySide and PyQT4 simultaneously and I chose one by app.use_app then print warning instead raise exception
