### PR TITLE
Fix bug that caused settable Isosurface.color property to not work

### DIFF
--- a/vispy/visuals/isosurface.py
+++ b/vispy/visuals/isosurface.py
@@ -6,6 +6,7 @@ from __future__ import division
 
 from .mesh import MeshVisual
 from ..geometry.isosurface import isosurface
+from ..color import Color
 
 
 class IsosurfaceVisual(MeshVisual):
@@ -21,9 +22,13 @@ class IsosurfaceVisual(MeshVisual):
     Notes
     -----
     """
-    def __init__(self, data=None, level=None, **kwargs):
+    def __init__(self, data=None, level=None, vertex_colors=None,
+                 face_colors=None, color=(0.5, 0.5, 1, 1), **kwargs):
         self._data = None
         self._level = level
+        self._vertex_colors = vertex_colors
+        self._face_colors = face_colors
+        self._color = Color(color)
         self._recompute = True
         MeshVisual.__init__(self, **kwargs)
         if data is not None:
@@ -42,7 +47,7 @@ class IsosurfaceVisual(MeshVisual):
         self._recompute = True
         self.update()
 
-    def set_data(self, data):
+    def set_data(self, data=None, vertex_colors=None, face_colors=None, color=None):
         """ Set the scalar array data
 
         Parameters
@@ -50,8 +55,22 @@ class IsosurfaceVisual(MeshVisual):
         data : ndarray
             A 3D array of scalar values. The isosurface is constructed to show
             all locations in the scalar field equal to ``self.level``.
+        vertex_colors : array-like | None
+            Colors to use for each vertex.
+        face_colors : array-like | None
+            Colors to use for each face.
+        color : instance of Color
+            The color to use.
         """
-        self._data = data
+        # We only change the internal variables if they are provided by the user
+        if data is not None:
+            self._data = data
+        if vertex_colors is not None:
+            self._vertex_colors = vertex_colors
+        if face_colors is not None:
+            self._face_colors = face_colors
+        if color is not None:
+            self._color = Color(color)
         self._recompute = True
         self.update()
 
@@ -61,7 +80,8 @@ class IsosurfaceVisual(MeshVisual):
 
         if self._recompute:
             verts, faces = isosurface(self._data, self._level)
-            MeshVisual.set_data(self, vertices=verts, faces=faces)
+            MeshVisual.set_data(self, vertices=verts, faces=faces,
+                                color=self._color)
             self._recompute = False
 
         return MeshVisual._prepare_draw(self, view)

--- a/vispy/visuals/isosurface.py
+++ b/vispy/visuals/isosurface.py
@@ -47,7 +47,8 @@ class IsosurfaceVisual(MeshVisual):
         self._recompute = True
         self.update()
 
-    def set_data(self, data=None, vertex_colors=None, face_colors=None, color=None):
+    def set_data(self, data=None, vertex_colors=None, face_colors=None,
+                 color=None):
         """ Set the scalar array data
 
         Parameters
@@ -62,7 +63,7 @@ class IsosurfaceVisual(MeshVisual):
         color : instance of Color
             The color to use.
         """
-        # We only change the internal variables if they are provided by the user
+        # We only change the internal variables if they are provided
         if data is not None:
             self._data = data
         if vertex_colors is not None:

--- a/vispy/visuals/isosurface.py
+++ b/vispy/visuals/isosurface.py
@@ -101,6 +101,8 @@ class IsosurfaceVisual(MeshVisual):
             MeshVisual.set_data(self,
                                 vertices=self._vertices_cache,
                                 faces=self._faces_cache,
+                                vertex_colors=self._vertex_colors,
+                                face_colors=self._face_colors,
                                 color=self._color)
             self._update_meshvisual = False
 

--- a/vispy/visuals/isosurface.py
+++ b/vispy/visuals/isosurface.py
@@ -37,7 +37,6 @@ class IsosurfaceVisual(MeshVisual):
         self._recompute = True
         self._update_meshvisual = True
 
-
         MeshVisual.__init__(self, **kwargs)
         if data is not None:
             self.set_data(data)
@@ -93,7 +92,7 @@ class IsosurfaceVisual(MeshVisual):
 
         if self._recompute:
             self._vertices_cache, self._faces_cache = isosurface(self._data,
-                                                              self._level)
+                                                                 self._level)
             self._recompute = False
             self._update_meshvisual = True
 

--- a/vispy/visuals/tests/test_isosurface.py
+++ b/vispy/visuals/tests/test_isosurface.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from vispy import scene
+
+from vispy.testing import run_tests_if_main, requires_pyopengl
+
+
+@requires_pyopengl()
+def test_isosurface():
+
+    # Create data
+    vol = np.arange(1000).reshape((10, 10, 10)).astype(np.float32)
+
+    # Create visual
+    iso = scene.visuals.Isosurface(vol, level=200)
+
+    # Change color (regression test for a bug that caused this to crash)
+    iso.color = (1.0, 0.8, 0.9, 1.0)
+
+
+run_tests_if_main()


### PR DESCRIPTION
In master, if one creates an ``IsosurfaceVisual``, the ``color`` property which is normally settable for ``MeshVisual`` is not settable for ``IsosurfaceVisual`` because ``set_data`` doesn't accept colors:

```
In [2]: surface.color = (1, 0.5, 0.3, 1.0)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-c4c805007590> in <module>()
----> 1 surface.color = (1, 0.5, 0.3, 1.0)

/Users/tom/tmp/vispy/vispy/util/frozen.py in __setattr__(self, key, value)
     15                                  '"unfreeze()" to allow addition of new '
     16                                  'attributes' % (key, self))
---> 17         object.__setattr__(self, key, value)
     18 
     19     def freeze(self):

/Users/tom/tmp/vispy/vispy/visuals/mesh.py in color(self, c)
    278     @color.setter
    279     def color(self, c):
--> 280         self.set_data(color=c)
    281 
    282     def mesh_data_changed(self):

TypeError: set_data() got an unexpected keyword argument 'color'
```

I just went ahead and made it possible to set the colors via ``set_data``, which solves the issue.
