### PR TITLE
enable 3D plot in LinePlotVisual, add a demo using plot3d

### DIFF
--- a/examples/basics/visuals/line_plot3d.py
+++ b/examples/basics/visuals/line_plot3d.py
@@ -2,13 +2,15 @@
 """ plot3d using existing visuals : LinePlotVisual """
 
 import numpy as np
+import sys
+
 from vispy import app, visuals, scene
 
 # build visuals
 Plot3D = scene.visuals.create_visual_node(visuals.LinePlotVisual)
 
 # build canvas
-canvas = scene.SceneCanvas(keys='interactive', show=True)
+canvas = scene.SceneCanvas(keys='interactive', title='plot3d', show=True)
 
 # Add a ViewBox to let the user zoom/rotate
 view = canvas.central_widget.add_view()
@@ -24,9 +26,11 @@ z = np.linspace(-2, 2, N)
 
 # plot
 pos = np.c_[x, y, z]
-p1 = Plot3D(pos, width=2.0, color='red',
-            edge_color='w', symbol='o', face_color=(0.2, 0.2, 1, 0.8),
-            parent=view.scene)
+Plot3D(pos, width=2.0, color='red',
+       edge_color='w', symbol='o', face_color=(0.2, 0.2, 1, 0.8),
+       parent=view.scene)
 
-# run
-app.run()
+
+if __name__ == '__main__':
+    if sys.flags.interactive != 1:
+        app.run()

--- a/examples/basics/visuals/line_plot3d.py
+++ b/examples/basics/visuals/line_plot3d.py
@@ -1,0 +1,32 @@
+# pyline: disable=no-member
+""" plot3d using existing visuals : LinePlotVisual """
+
+import numpy as np
+from vispy import app, visuals, scene
+
+# build visuals
+Plot3D = scene.visuals.create_visual_node(visuals.LinePlotVisual)
+
+# build canvas
+canvas = scene.SceneCanvas(keys='interactive', show=True)
+
+# Add a ViewBox to let the user zoom/rotate
+view = canvas.central_widget.add_view()
+view.camera = 'turntable'
+view.camera.fov = 45
+view.camera.distance = 6
+
+# prepare data
+N = 60
+x = np.sin(np.linspace(-2, 2, N)*np.pi)
+y = np.cos(np.linspace(-2, 2, N)*np.pi)
+z = np.linspace(-2, 2, N)
+
+# plot
+pos = np.c_[x, y, z]
+p1 = Plot3D(pos, width=2.0, color='red',
+            edge_color='w', symbol='o', face_color=(0.2, 0.2, 1, 0.8),
+            parent=view.scene)
+
+# run
+app.run()

--- a/vispy/visuals/line_plot.py
+++ b/vispy/visuals/line_plot.py
@@ -15,8 +15,8 @@ class LinePlotVisual(CompoundVisual):
     Parameters
     ----------
     data : array-like
-        Arguments can be passed as ``(Y,)``, ``(X, Y)`` or
-        ``np.array((X, Y))``.
+        Arguments can be passed as ``(Y,)``, ``(X, Y)``, ``(X, Y, Z)`` or
+        ``np.array((X, Y))``, ``np.array((X, Y, Z))``.
     color : instance of Color
         Color of the line.
     symbol : str
@@ -104,8 +104,8 @@ class LinePlotVisual(CompoundVisual):
                 x = np.arange(pos.shape[0], dtype=np.float32)[:, np.newaxis]
                 pos = np.concatenate((x, pos), axis=1)
             # if args are empty, don't modify position
-            elif pos.shape[1] > 2:
-                raise TypeError("Too many coordinates given (%s; max is 2)."
+            elif pos.shape[1] > 3:
+                raise TypeError("Too many coordinates given (%s; max is 3)."
                                 % pos.shape[1])
 
         # todo: have both sub-visuals share the same buffers.

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -492,7 +492,7 @@ class MarkersVisual(Visual):
         Visual.__init__(self, vcode=vert, fcode=frag)
         self.shared_program.vert['v_size'] = self._v_size_var
         self.shared_program.frag['v_size'] = self._v_size_var
-        self.set_gl_state(depth_test=False, blend=True,
+        self.set_gl_state(depth_test=True, blend=True,
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
         self._draw_mode = 'points'
         if len(kwargs) > 0:


### PR DESCRIPTION
#1189 

In `gloo.visuals`, both `LineVisual` and `MarkersVisual` have 3D capability, but in `LinePlotVisual`, 3D is disabled, which makes some typical visual task such as `plot3d`, `scatter3d` not available. This patch enables this feature, and provides a simple demo on using `LinePlotVisual` as a `plot3d` or `scatter3d` command in `examples/basic/visuals`.