### PR TITLE
fix isosurface error : color can not be set

### DIFF
--- a/vispy/visuals/isosurface.py
+++ b/vispy/visuals/isosurface.py
@@ -39,7 +39,8 @@ class IsosurfaceVisual(MeshVisual):
 
         MeshVisual.__init__(self, **kwargs)
         if data is not None:
-            self.set_data(data)
+            self.set_data(data, vertex_colors=vertex_colors,
+                          face_colors=face_colors, color=color)
 
     @property
     def level(self):


### PR DESCRIPTION
Fix a error that the color parameter in `isosurface` can not be set.

#1176 