### PR TITLE
webgl backend fix for updated versions of ipython/jupyter notebook

### DIFF
--- a/vispy/html/static/js/webgl-backend.js
+++ b/vispy/html/static/js/webgl-backend.js
@@ -18,7 +18,7 @@ define(function(require) {
     }
 
     var vispy = require("/nbextensions/vispy/vispy.min.js");
-    var widget = require("widgets/js/widget");
+    var widget = require("jupyter-js-widgets");
 
     var VispyView = widget.DOMWidgetView.extend({
 


### PR DESCRIPTION
The location of the widgets has changed in current versions of ipython/jupyter. Credit goes to @SamiAhola who posted this fix several months ago on the gitter vispy channel. However no PR for the fix has been made so I have made one here.