### PR TITLE
Fix Travis failures by pinning Qt/PyQt versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,9 +130,9 @@ install:
     # No wx on py27 or py34, wxpython doesn't work properly there
     # If we only need a single backend (DEPS=backend), then use PyQT4
     - if [ "${DEPS}" == "backend" ]; then
-        conda install --yes --quiet pyqt pyopengl;
+        conda install --yes --quiet pyqt=4 pyopengl;
       elif [ "${DEPS}" == "full" ]; then
-        conda install --yes --quiet pyqt pyopengl;
+        conda install --yes --quiet pyqt=4 pyopengl;
         pip install -q pyglet;
         if [ "${PYTHON}" == "2.6" ]; then
           conda install --yes --quiet wxpython numpy$NUMPY > ${REDIRECT_TO};


### PR DESCRIPTION
I think continuum recently added PyQt5 to conda and called it pyqt with version 5, so we need to pin the version to 4.