### PR TITLE
Enable Python 3.5 on AppVeyor

### DIFF
--- a/.opengl_info.py
+++ b/.opengl_info.py
@@ -1,0 +1,2 @@
+import vispy
+print(vispy.sys_info())

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
       MINICONDA_VERSION: "3.5.5"
       PYTHON: "C:\\conda"
       CONDA_DEPENDENCIES: "numpy scipy pyqt=4 matplotlib setuptools nose pytest coverage ipython=4.2.0 ipython-notebook pytest-cov"
+      PIP_DEPENDENCIES: "pytest-faulthandler"
 
   matrix:
       - PYTHON_VERSION: "3.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,5 +52,5 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Run the project tests (don't do examples because they are too slow)
-  - "python make test nobackend"
-  - "python make test pyqt4"
+  - "python -X faulthandler make test nobackend"
+  - "python -X faulthandler make test pyqt4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ environment:
   matrix:
       - PYTHON_VERSION: "3.4"
         PYTHON_ARCH: "64"
-
+      - PYTHON_VERSION: "3.5"
+        PYTHON_ARCH: "64"
 platform:
     -x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,9 @@ install:
   # Install vispy
   - "python setup.py develop"
 
+  # Print out OpenGL info
+  - "python .opengl_info.py"
+
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -88,7 +88,7 @@ def _unit(mode, extra_arg_string, coverage=False):
         else:
             extra_args += ['-a', 'vispy_app_test']
     if coverage and use_pytest:
-        extra_args += ['--cov', 'vispy', '--no-cov-on-fail']
+        extra_args += ['--cov', 'vispy', '--no-cov-on-fail', '-v', '-s']
     # make a call to "python" so that it inherits whatever the system
     # thinks is "python" (e.g., virtualenvs)
     extra_arg_string = ' '.join(extra_args)


### PR DESCRIPTION
I think this will fail currently, but this will show that there are issues in Python 3.5. I think that https://github.com/vispy/vispy/issues/1277 and https://github.com/vispy/vispy/issues/1276 are due to this.
