### PR TITLE
Only resolve grid layout using Cassowary if required

### DIFF
--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -458,8 +458,8 @@ class Grid(Widget):
             self._need_solver_recreate = False
             self._recreate_solver()
 
-        # yes, this little dance is necessary for cassowary
-        # to not screw up :/
+        # we only need to remove and add the height and width constraints of
+        # the solver if they are not the same as the current value
         if rect.height != self._var_h.value:
             if self._height_stay:
                 self._solver.remove_constraint(self._height_stay)

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -460,20 +460,21 @@ class Grid(Widget):
 
         # yes, this little dance is necessary for cassowary
         # to not screw up :/
-        if self._height_stay:
-            self._solver.remove_constraint(self._height_stay)
+        if rect.height != self._var_h.value:
+            if self._height_stay:
+                self._solver.remove_constraint(self._height_stay)
 
-        self._var_h.value = rect.height
-        self._height_stay = self._solver.add_stay(self._var_h,
-                                                  strength=STRONG)
+            self._var_h.value = rect.height
+            self._height_stay = self._solver.add_stay(self._var_h,
+                                                      strength=STRONG)
 
-        # self._var_w.value = rect.width
-        if self._width_stay:
-            self._solver.remove_constraint(self._width_stay)
+        if rect.width != self._var_w.value:
+            if self._width_stay:
+                self._solver.remove_constraint(self._width_stay)
 
-        self._var_w.value = rect.width
-        self._width_stay = self._solver.add_stay(self._var_w,
-                                                 strength=STRONG)
+            self._var_w.value = rect.width
+            self._width_stay = self._solver.add_stay(self._var_w,
+                                                     strength=STRONG)
 
         value_vectorized = np.vectorize(lambda x: x.value)
 


### PR DESCRIPTION
This PR makes the grid widget much more usable by not forcing the solver to re-solve if the overall width and height of the plots haven't changed.  This makes all the examples that use the grid widget extremely responsive compared to not using this pull request.

I couldn't find any case that was worse than without the patch, and I tested all the examples in `examples/basics/plotting` and `examples/basics/scene`.

This PR does not improve the situation whenever the entire canvas is resized, but it is no worse than without the PR.  It may improve issue #1182 as well.