### PR TITLE
Fix codegen backend selection and fix PyOpenGL glGetParameter.

### DIFF
--- a/codegen/annotations.py
+++ b/codegen/annotations.py
@@ -427,6 +427,7 @@ def getTexParameter(target, pname):
 def getActiveAttrib(program, index):
     # --- gl es pyopengl
     bufsize = 256
+    # --- gl es
     length = (ctypes.c_int*1)()
     size = (ctypes.c_int*1)()
     type = (ctypes.c_uint*1)()
@@ -436,10 +437,8 @@ def getActiveAttrib(program, index):
     name = name[:length[0]].decode('utf-8')
     return name, size[0], type[0]
     # --- pyopengl
-    # pyopengl has a bug, this is a patch
-    GL.glGetActiveAttrib(program, index, bufsize, length, size, type, name)
-    name = name[:length[0]].decode('utf-8')
-    return name, size[0], type[0]
+    name, size, type = GL.glGetActiveAttrib(program, index, bufSize=bufsize)
+    return name.decode('utf-8'), size, type
     # --- mock
     return 'mock_val', 1, 5126
 

--- a/codegen/annotations.py
+++ b/codegen/annotations.py
@@ -134,9 +134,13 @@ def texSubImage2D(target, level, xoffset, yoffset, format, type, pixels):
 
 
 def readPixels(x, y, width, height, format, type):
-    # --- gl es mock
+    # --- es
     # GL_ALPHA, GL_RGB, GL_RGBA
     t = {6406:1, 6407:3, 6408:4}[format]
+    # --- gl mock
+    # GL_ALPHA, GL_RGB, GL_RGBA, GL_DEPTH_COMPONENT
+    t = {6406:1, 6407:3, 6408:4, 6402:1}[format]
+    # --- gl es mock
     # GL_UNSIGNED_BYTE, GL_FLOAT
     nb = {5121:1, 5126:4}[type]
     size = int(width*height*t*nb)
@@ -596,6 +600,8 @@ class FunctionAnnotation:
         """ Get the lines for this function based on the given backend. 
         The given API call is inserted at the correct location.
         """
+        if backend is None:
+            raise RuntimeError("Backend must be specified!")
         backend_selector = (backend, )  # first lines are for all backends
         lines = []
         for line in self.lines:

--- a/codegen/annotations.py
+++ b/codegen/annotations.py
@@ -342,15 +342,23 @@ def getParameter(pname):
         # GL_BLEND_COLOR GL_COLOR_CLEAR_VALUE GL_DEPTH_CLEAR_VALUE
         # GL_DEPTH_RANGE GL_LINE_WIDTH GL_POLYGON_OFFSET_FACTOR
         # GL_POLYGON_OFFSET_UNITS GL_SAMPLE_COVERAGE_VALUE
+        # --- gl es
         return _glGetFloatv(pname)
+        # --- pyopengl
+        return GL.glGetFloatv(pname)
+        # /---
     elif pname in [7936, 7937, 7938, 35724, 7939]:
         # GL_VENDOR, GL_RENDERER, GL_VERSION, GL_SHADING_LANGUAGE_VERSION, 
         # GL_EXTENSIONS are strings
         pass  # string handled below
     else:
+        # --- gl es
         return _glGetIntegerv(pname)
-    name = pname
+        # --- pyopengl
+        return GL.glGetIntegerv(pname)
+        # /---
     # --- gl es
+    name = pname
     ()
     return ctypes.string_at(res).decode('utf-8') if res else ''
     # --- pyopengl
@@ -607,6 +615,9 @@ class FunctionAnnotation:
         for line in self.lines:
             if line.lstrip().startswith('# ---'):
                 backend_selector = line.strip().split(' ')
+                continue
+            if line.lstrip().startswith('# /---'):
+                backend_selector = backend
                 continue
             if backend in backend_selector:
                 if line.strip() == '()':

--- a/codegen/createglapi.py
+++ b/codegen/createglapi.py
@@ -366,10 +366,12 @@ class ApiGenerator:
     """ Base API generator class. We derive several subclasses to implement
     the different backends.
     """
-    
+
+    backend_name = None
+
     DESCRIPTION = "GL API X"
     PREAMBLE = ""
-    
+
     def __init__(self):
         self.lines = []
     
@@ -508,6 +510,7 @@ class Gl2ApiGenerator(ApiGenerator):
     filename = os.path.join(GLDIR, '_gl2.py')
     write_c_sig = True
     define_argtypes_in_module = False
+    backend_name = 'gl'
     
     DESCRIPTION = "Subset of desktop GL API compatible with GL ES 2.0"
     PREAMBLE = """
@@ -606,7 +609,7 @@ class Gl2ApiGenerator(ApiGenerator):
             # Annotation available
             functions_anno.add(des.name)
             callline = self._native_call_line(des.name, es2func, prefix=prefix)
-            lines.extend( des.ann.get_lines(callline, 'gl') )
+            lines.extend( des.ann.get_lines(callline, self.backend_name) )
         
         elif es2func.group:
             # Group?
@@ -698,6 +701,7 @@ class Es2ApiGenrator(Gl2ApiGenerator):
     filename = os.path.join(GLDIR, '_es2.py')
     write_c_sig = True
     define_argtypes_in_module = True
+    backend_name = 'es'
     
     DESCRIPTION = "GL ES 2.0 API (via Angle/DirectX on Windows)"
     PREAMBLE = """
@@ -719,6 +723,8 @@ class PyOpenGL2ApiGenrator(ApiGenerator):
     """
     
     filename = os.path.join(GLDIR, '_pyopengl2.py')
+    backend_name = 'pyopengl'
+
     DESCRIPTION = 'Proxy API for GL ES 2.0 subset, via the PyOpenGL library.'
     PREAMBLE = """
     import ctypes
@@ -742,7 +748,7 @@ class PyOpenGL2ApiGenrator(ApiGenerator):
         # Get annotation lines
         ann_lines = []
         if des.ann is not None:
-            ann_lines = des.ann.get_lines(call_line, 'pyopengl')
+            ann_lines = des.ann.get_lines(call_line, self.backend_name)
         # Use annotation or not
         if ann_lines:
             self.lines.append('def %s(%s):' % (des.apiname, argstr))

--- a/codegen/headerparser.py
+++ b/codegen/headerparser.py
@@ -348,7 +348,7 @@ class Argument:
 
 if __name__ == '__main__':
     THISDIR = os.path.abspath(os.path.dirname(__file__))
-    print(THISDIR)
+
     # Some tests ...
     gl2 = Parser(os.path.join(THISDIR, 'headers', 'gl2.h'))
     import OpenGL.GL

--- a/codegen/headerparser.py
+++ b/codegen/headerparser.py
@@ -79,7 +79,10 @@ class Parser:
     def _get_lines(self):
         # Easy iterator
         while True:
-            yield self._get_line()
+            try:
+                yield self._get_line()
+            except StopIteration:
+                return
 
     def parse(self):
         """ Parse the header file!
@@ -345,7 +348,7 @@ class Argument:
 
 if __name__ == '__main__':
     THISDIR = os.path.abspath(os.path.dirname(__file__))
-
+    print(THISDIR)
     # Some tests ...
     gl2 = Parser(os.path.join(THISDIR, 'headers', 'gl2.h'))
     import OpenGL.GL

--- a/vispy/gloo/gl/_pyopengl2.py
+++ b/vispy/gloo/gl/_pyopengl2.py
@@ -144,14 +144,13 @@ def glGetParameter(pname):
         # GL_BLEND_COLOR GL_COLOR_CLEAR_VALUE GL_DEPTH_CLEAR_VALUE
         # GL_DEPTH_RANGE GL_LINE_WIDTH GL_POLYGON_OFFSET_FACTOR
         # GL_POLYGON_OFFSET_UNITS GL_SAMPLE_COVERAGE_VALUE
-        return _glGetFloatv(pname)
+        return GL.glGetFloatv(pname)
     elif pname in [7936, 7937, 7938, 35724, 7939]:
         # GL_VENDOR, GL_RENDERER, GL_VERSION, GL_SHADING_LANGUAGE_VERSION,
         # GL_EXTENSIONS are strings
         pass  # string handled below
     else:
-        return _glGetIntegerv(pname)
-    name = pname
+        return GL.glGetIntegerv(pname)
     res = GL.glGetString(pname)
     return res.decode('utf-8')
 

--- a/vispy/gloo/gl/_pyopengl2.py
+++ b/vispy/gloo/gl/_pyopengl2.py
@@ -88,14 +88,8 @@ def glCreateTexture():
 
 def glGetActiveAttrib(program, index):
     bufsize = 256
-    length = (ctypes.c_int*1)()
-    size = (ctypes.c_int*1)()
-    type = (ctypes.c_uint*1)()
-    name = ctypes.create_string_buffer(bufsize)
-    # pyopengl has a bug, this is a patch
-    GL.glGetActiveAttrib(program, index, bufsize, length, size, type, name)
-    name = name[:length[0]].decode('utf-8')
-    return name, size[0], type[0]
+    name, size, type = GL.glGetActiveAttrib(program, index, bufSize=bufsize)
+    return name.decode('utf-8'), size, type
 
 
 def glGetActiveUniform(program, index):


### PR DESCRIPTION
- Fix codegen so that opengl correctly parses annotations with backend
  set to 'es'.
- Actually fix commit 3dd6018d1cd79c1ca828526d377c5c880f168a0e so that
  it is applied in codegen and not by modifying an auto-generated file.
- Adds syntax "# /---" to stop backend selection in annotation parsing.
- This also properly fixes what was attempted with pull request #1273.