### PR TITLE
Modify gloo.read_pixels to allow different formats.

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -610,7 +610,7 @@ class CanvasBackendEgl(QtBaseCanvasBackend, QWidget):
             if not hasattr(self, '_gl_buffer'):
                 self._gl_buffer = np.ones((3000 * 3000 * 4), np.uint8) * 255
             # Take screenshot and turn into RGB QImage
-            im = gloo.read_pixels()
+            im = gloo.read_pixels(format='rgba')
             sze = im.shape[0] * im.shape[1]
             self._gl_buffer[0:0+sze*4:4] = im[:, :, 2].ravel()
             self._gl_buffer[1:0+sze*4:4] = im[:, :, 1].ravel()

--- a/vispy/gloo/framebuffer.py
+++ b/vispy/gloo/framebuffer.py
@@ -250,5 +250,10 @@ class FrameBuffer(GLObject):
         
         # todo: this is ostensibly required, but not available in gloo.gl
         #gl.glReadBuffer(buffer._target)
-        
-        return read_pixels((0, 0, w, h), alpha=alpha)
+
+        if mode == 'color':
+            format = 'rgba' if alpha else 'rgb'
+        elif mode == 'depth':
+            format = 'depth'
+
+        return read_pixels((0, 0, w, h), format=format)

--- a/vispy/gloo/tests/test_wrappers.py
+++ b/vispy/gloo/tests/test_wrappers.py
@@ -170,7 +170,7 @@ def test_wrappers():
         assert_true(isinstance(x, np.ndarray))
         assert_true(isinstance(gloo.read_pixels((0, 0, 1, 1)), np.ndarray))
         assert_raises(ValueError, gloo.read_pixels, (0, 0, 1))  # bad port
-        y = gloo.read_pixels(alpha=False, out_type=np.ubyte)
+        y = gloo.read_pixels(format='rgb', out_type=np.ubyte)
         assert_equal(y.shape, x.shape[:2] + (3,))
         assert_array_equal(x[..., :3], y)
         y = gloo.read_pixels(out_type='float')
@@ -236,7 +236,7 @@ def test_read_pixels():
         c._program.draw('triangle_strip')
 
         # Check if the return of read_pixels is the same as our drawing
-        img = read_pixels(alpha=False)
+        img = read_pixels(format='rgb')
         assert_equal(img.shape[:2], c.size[::-1])
         top_left = sum(img[0, 0])
         assert_true(top_left > 0)  # Should be > 0 (255*4)

--- a/vispy/gloo/util.py
+++ b/vispy/gloo/util.py
@@ -27,7 +27,8 @@ def _screenshot(viewport=None, alpha=True):
         3D array of pixels in np.uint8 format
     """
     # gl.glReadBuffer(gl.GL_BACK)  Not avaliable in ES 2.0
-    return read_pixels(viewport, alpha)
+    format = 'rgba' if alpha else 'rgb'
+    return read_pixels(viewport, format=format)
 
 
 KEYWORDS = set(['active', 'asm', 'cast', 'class', 'common', 'default',


### PR DESCRIPTION
Currently gloo.read_pixels only allows RGB and RGBA values to be read.
This commit changes the API to have an format argument instead of an
alpha argument allowing the addition of 'depth'. Other buffers such as
the stencil may be added later.