### PR TITLE
Correction in oscilloscope demo to handle numpy API change

### DIFF
--- a/examples/demo/scene/oscilloscope.py
+++ b/examples/demo/scene/oscilloscope.py
@@ -172,7 +172,7 @@ class Oscilloscope(scene.ScrollingLines):
     def plot(self, data, dx=0):
         self.set_data(self.plot_ptr, data)
         
-        self.color[..., 3] *= 0.98
+        np.multiply(self.color[..., 3], 0.98, out=self.color[..., 3], casting='unsafe')
         self.color[self.plot_ptr, 3] = 50
         self.set_color(self.color)
         self.pos_offset[self.plot_ptr] = (dx, 0, 0)


### PR DESCRIPTION
Fixes an error in the oscilloscope demo that was introduced by a recent numpy API change:

```
TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('uint8') with casting rule 'same_kind'
```