### PR TITLE
Remove misplaced flags from re.sub() call

### DIFF
--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -187,7 +187,7 @@ class Program(GLObject):
         
         # Get one string of code with comments removed
         code = '\n\n'.join(self._shaders)
-        code = re.sub(r'(.*)(//.*)', r'\1', code, re.M)
+        code = re.sub(r'(.*)(//.*)', r'\1', code)
         
         # Regexp to look for variable names
         var_regexp = ("\s*VARIABLE\s+"  # kind of variable


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.
Moreover, `re.M` affects only semantics of `^` and `$`, so it wouldn't have any effect on this regular expression.

Found using [pydiatra](https://github.com/jwilk/pydiatra).