### PR TITLE
Fix for shared_context.py  in /examples/tutorial/app/

### DIFF
--- a/examples/tutorial/app/shared_context.py
+++ b/examples/tutorial/app/shared_context.py
@@ -9,8 +9,6 @@ This is a very simple example that demonstrates using a shared context
 between two Qt widgets.
 """
 
-# XXX THIS IS CURRENTLY BROKEN
-
 from PyQt4 import QtGui, QtCore  # can also use pyside
 from functools import partial
 
@@ -56,13 +54,17 @@ class Window(QtGui.QWidget):
         self.show()
 
     def on_init(self, event):
-        self.text = Text('Initialized', font_size=40.,
+        self.text0 = Text('Initialized', font_size=40.,
                          anchor_x='left', anchor_y='top',
-                         parent=[self.vb_0.scene, self.vb_1.scene])
+                         parent=self.vb_0.scene)
+        self.text1 = Text('Initialized', font_size=40.,
+                         anchor_x='left', anchor_y='top',
+                         parent=self.vb_1.scene)
 
     def on_timer(self, event):
         self.tick_count += 1
-        self.text.text = 'Tick #%s' % self.tick_count
+        self.text0.text = 'Tick #%s' % self.tick_count
+        self.text1.text = 'Tick #%s' % self.tick_count
         self.canvas_0.update()
         self.canvas_1.update()
 


### PR DESCRIPTION
The Text object from vispy.scene.visuals did not accept a list of parents. I'm not sure if that is the whole point of this file. But I made it work by adding two Text objects each with one parent scene.

Being able to integrate Vispy into a PyQt or PySide app will be very useful.