### PR TITLE
Fix integer division for Python3

### DIFF
--- a/vispy/glsl/build-spatial-filters.py
+++ b/vispy/glsl/build-spatial-filters.py
@@ -97,7 +97,7 @@ class SpatialFilter(object):
     def kernel(self, size=4*512):
         radius = self.radius
         r = int(max(1.0, math.ceil(radius)))
-        samples = size / r
+        samples = size // r
         n = size  # r*samples
         kernel = np.zeros(n)
         X = np.linspace(0, r, n)


### PR DESCRIPTION
The GLSL build script fails to build on Python3. This fixes the division error.

Edit: to clarify, by division error, I do not mean that the division fails, but that the later call to `np.zeros` fails with a TypeError.