### PR TITLE
Fix spatial_filters example on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,11 +115,16 @@ install:
     - if [ "${DEPS}" == "full" ]; then
         conda install --yes pyopengl scipy numpy$NUMPY networkx;
         pip install -q numpydoc PySDL2;
-        if [ "${PYTHON}" == "3.6" ]; then
-          pip install -q freetype-py husl pypng cassowary pillow decorator six;
-          rm -rf ${SRC_DIR}/vispy/ext/_bundled;
+        if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+          if [ "${PYTHON}" == "3.6" ]; then
+            pip install -q freetype-py husl pypng cassowary pillow decorator six;
+            rm -rf ${SRC_DIR}/vispy/ext/_bundled;
+          else
+            conda install --yes --quiet wxpython matplotlib jupyter pyqt=4;
+            pip install -q mock;
+          fi;
         else
-          conda install --yes --quiet wxpython matplotlib jupyter pyqt=4;
+          conda install --yes --quiet matplotlib jupyter pyqt=4;
           pip install -q mock;
         fi;
       fi;
@@ -151,7 +156,7 @@ before_script:
     # For OSX: https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
     - if [ "${TEST}" != "osmesa" ]; then
         export DISPLAY=:99.0;
-        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1400x900x24 +extension GLX +render +iglx; echo ok )& fi;
+        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1400x900x24 +render +iglx; echo ok )& fi;
         if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render;
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ before_install:
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -p ~/anaconda
     - export PATH=~/anaconda/bin:$PATH
+    - conda config --add channels conda-forge
     - conda update --yes --quiet conda
 
     - SRC_DIR=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,12 @@ matrix:
 
 
 before_install:
-    - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+        wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget -q http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+      fi;
+
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -p ~/anaconda
     - export PATH=~/anaconda/bin:$PATH
@@ -135,15 +140,21 @@ install:
       fi
 
     # Install OSMesa
-    - wget https://github.com/vispy/demo-data/raw/master/osmesa/osmesa_11.0.0_12.04.tar.bz2 -O /tmp/osmesa.tar.bz2
-    - mkdir $HOME/osmesa; tar -xvjf /tmp/osmesa.tar.bz2 -C $HOME/osmesa
+    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+        wget https://github.com/vispy/demo-data/raw/master/osmesa/osmesa_11.0.0_12.04.tar.bz2 -O /tmp/osmesa.tar.bz2;
+        mkdir $HOME/osmesa; tar -xvjf /tmp/osmesa.tar.bz2 -C $HOME/osmesa;
+      fi;
 
 
 before_script:
     # We need to create a (fake) display on Travis, let's use a funny resolution
+    # For OSX: https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
     - if [ "${TEST}" != "osmesa" ]; then
         export DISPLAY=:99.0;
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render;
+        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1400x900x24 +extension GLX +render +iglx; echo ok )& fi;
+        if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render;
+        fi;
       fi;
     - if [ "${TEST}" == "osmesa" ]; then
         export LD_LIBRARY_PATH=$HOME/osmesa/lib;

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,10 @@ before_install:
         git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
         git tag travis-merge-target;
         git gc --aggressive;
-        TARGET_SIZE=`du -s . | sed -e "s/\t.*//"`;
+        TARGET_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
         git pull origin ${GIT_SOURCE_EXTRA};
         git gc --aggressive;
-        MERGE_SIZE=`du -s . | sed -e "s/\t.*//"`;
+        MERGE_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
         if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
           SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \)`;
         else

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ matrix:
     - env: PYTHON=3.6 DEPS=minimal TEST=standard
       os: osx
       language: generic
-    - env: PYTHON=3.6 DEPS=full TEST=examples
-      os: osx
-      language: generic
+# Travis Examples are extremely slow for OSX (times out)
+#    - env: PYTHON=3.6 DEPS=full TEST=examples
+#      os: osx
+#      language: generic
     - env: PYTHON=3.6 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,8 @@ install:
     # On conda, can't install pyside-pyzo b/c it conflicts with pyqt4,
     # which is required by matplotlib :(
     # No wx on py27 or py34, wxpython doesn't work properly there
+    # wxpython available from conda-forge but not for OSX:
+    #     https://github.com/conda-forge/wxpython-feedstock/issues/2
     # If we only need a single backend (DEPS=backend), then use PyQT4
     # Don't test Pyglet because it currently segfaults (but AppVeyor checks it)
     # PyQt5 is currently broken, but will be installed on 3.6 so don't do it
@@ -121,11 +123,11 @@ install:
             pip install -q freetype-py husl pypng cassowary pillow decorator six;
             rm -rf ${SRC_DIR}/vispy/ext/_bundled;
           else
-            conda install --yes --quiet wxpython matplotlib jupyter pyqt=4;
+            conda install --yes wxpython matplotlib jupyter pyqt=4;
             pip install -q mock;
           fi;
         else
-          conda install --yes --quiet matplotlib jupyter pyqt=4;
+          conda install --yes matplotlib jupyter pyqt=4;
           pip install -q mock;
         fi;
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
   include:
     - env: PYTHON=3.6 DEPS=minimal TEST=standard
       os: osx
+      language: generic
+    - env: PYTHON=3.6 DEPS=full TEST=examples
+      os: osx
+      language: generic
     - env: PYTHON=3.6 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
 
 matrix:
   include:
+    - env: PYTHON=3.6 DEPS=minimal TEST=standard
+      os: osx
     - env: PYTHON=3.6 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
       addons:
         apt:
@@ -47,6 +49,8 @@ matrix:
           packages:
             - *mesa_apt
             - *full_apt
+  allow_failures:
+    - os: osx
 
 
 before_install:

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -10,6 +10,12 @@ import numpy as np
 from vispy.io import load_spatial_filters
 from vispy import gloo
 from vispy import app
+from vispy.util.logs import set_log_level
+# turn off INFO messages, see PR #1363
+# Some shader compilers will optimize out the 'u_shape' and 'u_kernel'
+# uniforms for the Nearest filter since they are unused, resulting in
+# an INFO message about them not being active
+set_log_level('warning')
 
 # create 5x5 matrix with border pixels 0, center pixels 1
 # and other pixels 0.5
@@ -105,11 +111,5 @@ class Canvas(app.Canvas):
 
 
 if __name__ == '__main__':
-    from vispy.util.logs import use_log_level
-    # turn off INFO messages, see PR #1363
-    # Some shader compilers will optimize out the 'u_shape' and 'u_kernel'
-    # uniforms for the Nearest filter since they are unused, resulting in
-    # an INFO message about them not being active
-    with use_log_level('warning', print_msg=False):
-        c = Canvas()
-        app.run()
+    c = Canvas()
+    app.run()

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -68,6 +68,7 @@ class Canvas(app.Canvas):
         # using packed data as discussed in pr #1069
         self.kernel = gloo.Texture2D(kernel, interpolation='nearest')
         self.program['u_texture'] = self.texture
+        self.program['u_shape'] = I.shape[1], I.shape[0]
 
         self.names = names
         self.filter = 16
@@ -90,9 +91,8 @@ class Canvas(app.Canvas):
             self.program.set_shaders(VERT_SHADER,
                                      FRAG_SHADER % self.names[self.filter])
 
-            if self.names[self.filter] != 'Nearest':
-                self.program['u_kernel'] = self.kernel
-                self.program['u_shape'] = I.shape[1], I.shape[0]
+            self.program['u_kernel'] = self.kernel
+            self.program['u_shape'] = I.shape[1], I.shape[0]
             self.title = 'Spatial Filtering using %s Filter' % \
                          self.names[self.filter]
             self.update()

--- a/examples/basics/gloo/spatial_filters.py
+++ b/examples/basics/gloo/spatial_filters.py
@@ -69,6 +69,7 @@ class Canvas(app.Canvas):
         self.kernel = gloo.Texture2D(kernel, interpolation='nearest')
         self.program['u_texture'] = self.texture
         self.program['u_shape'] = I.shape[1], I.shape[0]
+        self.program['u_kernel'] = self.kernel
 
         self.names = names
         self.filter = 16
@@ -91,8 +92,6 @@ class Canvas(app.Canvas):
             self.program.set_shaders(VERT_SHADER,
                                      FRAG_SHADER % self.names[self.filter])
 
-            self.program['u_kernel'] = self.kernel
-            self.program['u_shape'] = I.shape[1], I.shape[0]
             self.title = 'Spatial Filtering using %s Filter' % \
                          self.names[self.filter]
             self.update()
@@ -106,5 +105,11 @@ class Canvas(app.Canvas):
 
 
 if __name__ == '__main__':
-    c = Canvas()
-    app.run()
+    from vispy.util.logs import use_log_level
+    # turn off INFO messages, see PR #1363
+    # Some shader compilers will optimize out the 'u_shape' and 'u_kernel'
+    # uniforms for the Nearest filter since they are unused, resulting in
+    # an INFO message about them not being active
+    with use_log_level('warning', print_msg=False):
+        c = Canvas()
+        app.run()

--- a/examples/basics/visuals/line_transform.py
+++ b/examples/basics/visuals/line_transform.py
@@ -14,8 +14,6 @@ import numpy as np
 from vispy import app, gloo, visuals
 from vispy.visuals.transforms import (STTransform, LogTransform,
                                       MatrixTransform, PolarTransform)
-import vispy.util
-vispy.util.use_log_level('debug')
 
 # vertex positions of data to draw
 N = 200

--- a/vispy/app/backends/_wx.py
+++ b/vispy/app/backends/_wx.py
@@ -140,7 +140,10 @@ class ApplicationBackend(BaseApplicationBackend):
         for _ in range(3):  # trial-and-error found this to work (!)
             while self._event_loop.Pending():
                 self._event_loop.Dispatch()
-            _wx_app.ProcessIdle()
+            if hasattr(_wx_app, 'ProcessIdle'):
+                _wx_app.ProcessIdle()
+            else:
+                self._event_loop.ProcessIdle()
             sleep(0.01)
 
     def _vispy_run(self):
@@ -155,7 +158,11 @@ class ApplicationBackend(BaseApplicationBackend):
         global _wx_app
         _wx_app = wx.GetApp()  # in case the user already has one
         if _wx_app is None:
-            _wx_app = wx.PySimpleApp()
+            if hasattr(wx, 'PySimpleApp'):
+                # legacy wx
+                _wx_app = wx.PySimpleApp()
+            else:
+                _wx_app = wx.App()
         _wx_app.SetExitOnFrameDelete(True)
         return _wx_app
 

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -308,6 +308,12 @@ def _examples(fnames_str):
                 elif line.startswith('# vispy: ') and 'testskip' in line:
                     good = False
                     break
+        if (fname.endswith('colorbar.py') and
+                os.getenv('TRAVIS', 'false') == 'true' and
+                sys.platform == 'darwin'):
+            print("Skipping example that fails on " +
+                  "Travis CI OSX: {}".format(fname))
+            good = False
         if not good:
             n_ran -= 1
             n_skipped += 1

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -300,9 +300,9 @@ def _examples(fnames_str):
         root_name = op.join(op.split(op.split(root_name[0])[0])[1],
                             op.split(root_name[0])[1], root_name[1])
         good = True
-        with open(fname, 'r') as fid:
+        with open(fname, 'rb') as fid:
             for _ in range(10):  # just check the first 10 lines
-                line = fid.readline()
+                line = fid.readline().decode('utf-8')
                 if line == '':
                     break
                 elif line.startswith('# vispy: ') and 'testskip' in line:

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -251,6 +251,22 @@ with canvas as c:
 """
 
 
+def _skip_example(fname):
+    if os.getenv('TRAVIS', 'false') == 'true' and sys.platform == 'darwin':
+        # example scripts that contain non-ascii text
+        # seem to fail on Travis OSX
+        bad_examples = [
+            'examples/basics/plotting/colorbar.py',
+            'examples/basics/plotting/plot.py',
+            'examples/demo/gloo/high_frequency.py',
+        ]
+        for bad_ex in bad_examples:
+            if fname.endswith(bad_ex):
+                return True
+
+    return False
+
+
 def _examples(fnames_str):
     """Run examples and make sure they work.
 
@@ -308,9 +324,7 @@ def _examples(fnames_str):
                 elif line.startswith('# vispy: ') and 'testskip' in line:
                     good = False
                     break
-        if (fname.endswith('colorbar.py') and
-                os.getenv('TRAVIS', 'false') == 'true' and
-                sys.platform == 'darwin'):
+        if _skip_example(fname):
             print("Skipping example that fails on " +
                   "Travis CI OSX: {}".format(fname))
             good = False

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -312,6 +312,7 @@ def _examples(fnames_str):
             n_ran -= 1
             n_skipped += 1
             continue
+        print("Running example: {}".format(fname))
         sys.stdout.flush()
         cwd = op.dirname(fname)
         cmd = [sys.executable, '-c', _script.format(op.split(fname)[1][:-3])]


### PR DESCRIPTION
Mac OSX complains about the program having unset variables.

```
Example basics/gloo/spatial_filters.py failed (0):
----------------------------------------------------------------------
INFO: Program has unset variables: {'u_shape'}
```