### PR TITLE
Add OSX standard/unit tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,6 @@ install:
     # Also install PyQt4, imaging (PIL or pillow), scipy, mpl, egl
     # On conda, can't install pyside-pyzo b/c it conflicts with pyqt4,
     # which is required by matplotlib :(
-    # No wx on py27 or py34, wxpython doesn't work properly there
     # wxpython available from conda-forge but not for OSX:
     #     https://github.com/conda-forge/wxpython-feedstock/issues/2
     # If we only need a single backend (DEPS=backend), then use PyQT4
@@ -121,11 +120,11 @@ install:
         conda install --yes pyopengl scipy numpy$NUMPY networkx;
         pip install -q numpydoc PySDL2;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+          conda install --yes wxpython matplotlib jupyter pyqt=4;
           if [ "${PYTHON}" == "3.6" ]; then
             pip install -q freetype-py husl pypng cassowary pillow decorator six;
             rm -rf ${SRC_DIR}/vispy/ext/_bundled;
           else
-            conda install --yes wxpython matplotlib jupyter pyqt=4;
             pip install -q mock;
           fi;
         else
@@ -140,7 +139,8 @@ install:
     - python setup.py develop
     - cd ~
 
-    - if [ "${DEPS}" == "full" ]; then
+    # Install glfw (fails with virtual buffer on OSX)
+    - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
         git clone git://github.com/glfw/glfw.git;
         cd glfw;
         cmake -DCMAKE_INSTALL_PREFIX=$HOME -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,13 @@ matrix:
           packages:
             - *mesa_apt
             - *full_apt
-    - env: PYTHON=2.7 DEPS=full TEST=standard NUMPY="=1.9"
+    - env: PYTHON=3.6 DEPS=full TEST=examples  # test examples
+      addons:
+        apt:
+          packages:
+            - *mesa_apt
+            - *full_apt
+    - env: PYTHON=2.7 DEPS=full TEST=standard
       addons:
         apt:
           packages:
@@ -45,17 +51,10 @@ matrix:
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
-    - env: PYTHON=2.7 DEPS=full TEST=osmesa NUMPY="=1.9"
+    - env: PYTHON=2.7 DEPS=full TEST=osmesa
       addons:
         apt:
           packages:
-            - *full_apt
-    # Run on 2.7 so we have PyQt4 (some examples need it)
-    - env: PYTHON=2.7 DEPS=full TEST=examples  # test examples
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
             - *full_apt
 
 
@@ -121,6 +120,7 @@ install:
         pip install -q numpydoc PySDL2;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
           conda install --yes wxpython matplotlib jupyter pyqt=4 pillow decorator six;
+          rm -rf ${SRC_DIR}/vispy/ext/_bundled;
           if [ "${PYTHON}" == "3.6" ]; then
             pip install -q freetype-py husl pypng cassowary;
           else

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,10 +120,9 @@ install:
         conda install --yes pyopengl scipy numpy$NUMPY networkx;
         pip install -q numpydoc PySDL2;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          conda install --yes wxpython matplotlib jupyter pyqt=4;
+          conda install --yes wxpython matplotlib jupyter pyqt=4 pillow decorator six;
           if [ "${PYTHON}" == "3.6" ]; then
-            pip install -q freetype-py husl pypng cassowary pillow decorator six;
-            rm -rf ${SRC_DIR}/vispy/ext/_bundled;
+            pip install -q freetype-py husl pypng cassowary;
           else
             pip install -q mock;
           fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,9 +147,9 @@ install:
         make install;
         cd ~;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          export PYGLFW_LIBRARY=${HOME}/lib/libglfw.so;
+          export GLFW_LIBRARY=${HOME}/lib/libglfw.so;
         else
-          export PYGLFW_LIBRARY=${HOME}/lib/libglfw.dylib;
+          export GLFW_LIBRARY=${HOME}/lib/libglfw.dylib;
         fi;
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     - env: PYTHON=3.6 DEPS=minimal TEST=standard
       os: osx
       language: generic
+    - env: PYTHON=3.6 DEPS=full TEST=standard
+      os: osx
+      language: generic
 # Travis Examples are extremely slow for OSX (times out)
 #    - env: PYTHON=3.6 DEPS=full TEST=examples
 #      os: osx
@@ -54,8 +57,6 @@ matrix:
           packages:
             - *mesa_apt
             - *full_apt
-  allow_failures:
-    - os: osx
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,11 @@ install:
         cmake -DCMAKE_INSTALL_PREFIX=$HOME -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
         make install;
         cd ~;
-        export GLFW_LIBRARY=${HOME}/lib/libglfw.so;
+        if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+          export PYGLFW_LIBRARY=${HOME}/lib/libglfw.so;
+        else
+          export PYGLFW_LIBRARY=${HOME}/lib/libglfw.dylib;
+        fi;
       fi
 
     # Install OSMesa

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,9 +120,9 @@ install:
         pip install -q numpydoc PySDL2;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
           conda install --yes wxpython matplotlib jupyter pyqt=4 pillow decorator six;
-          rm -rf ${SRC_DIR}/vispy/ext/_bundled;
           if [ "${PYTHON}" == "3.6" ]; then
-            pip install -q freetype-py husl pypng cassowary;
+            pip install -q freetype-py husl pypng cassowary imageio;
+            rm -rf ${SRC_DIR}/vispy/ext/_bundled;
           else
             pip install -q mock;
           fi;

--- a/vispy/app/backends/_wx.py
+++ b/vispy/app/backends/_wx.py
@@ -158,11 +158,11 @@ class ApplicationBackend(BaseApplicationBackend):
         global _wx_app
         _wx_app = wx.GetApp()  # in case the user already has one
         if _wx_app is None:
-            if hasattr(wx, 'PySimpleApp'):
+            if hasattr(wx, 'App'):
+                _wx_app = wx.App()
+            else:
                 # legacy wx
                 _wx_app = wx.PySimpleApp()
-            else:
-                _wx_app = wx.App()
         _wx_app.SetExitOnFrameDelete(True)
         return _wx_app
 
@@ -329,7 +329,12 @@ class CanvasBackend(GLCanvas, BaseCanvasBackend):
         # Set size of the widget or window
         if not self._init:
             self._size_init = (w, h)
-        self.SetSizeWH(w, h)
+        if hasattr(self, 'SetSize'):
+            # phoenix
+            self.SetSize(w, h)
+        else:
+            # legacy
+            self.SetSizeWH(w, h)
 
     def _vispy_set_position(self, x, y):
         # Set positionof the widget or window. May have no effect for widgets

--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -23,6 +23,7 @@ from vispy.testing import (requires_application, requires_pyopengl, SkipTest,
                            run_tests_if_main, assert_equal, assert_true)
 
 from vispy.gloo import gl
+import pytest
 
 # All these tests require a working backend.
 
@@ -33,12 +34,16 @@ def teardown_module():
     gl.use_gl()  # Reset to default
 
 
+@pytest.mark.xfail(sys.platform == 'darwin',
+                   reason='functionality fails on OSX (see #1178)')
 @requires_application()
 def test_functionality_desktop():
     """ Test desktop GL backend for full functionality. """
     _test_functionality('gl2')
 
 
+@pytest.mark.xfail(sys.platform == 'darwin',
+                   reason='functionality fails on OSX (see #1178)')
 @requires_application()
 def test_functionality_proxy():
     """ Test GL proxy class for full functionality. """
@@ -46,6 +51,8 @@ def test_functionality_proxy():
     _test_functionality('gl2 debug')
 
 
+@pytest.mark.xfail(sys.platform == 'darwin',
+                   reason='functionality fails on OSX (see #1178)')
 @requires_application()
 @requires_pyopengl()
 def test_functionality_pyopengl():


### PR DESCRIPTION
Certain tests fail when a backend is used on OSX (see #1178). Currently Travis includes an OSX standard set of tests but without using any backends. This PR adds a test environment for unit testing backends. Currently this is just PyQt4, but should include wxPython once it is available for OSX on conda-forge (currently takes to long to build on CI).

This PR includes removing OSX as an environment that is allowed to fail. I'm assuming that `test_functionality.py` will fail also which will require some special handling (again see #1178).