### PR TITLE
Enable the definition of arrows along z-direction

### DIFF
--- a/vispy/glsl/arrowheads/arrowheads.frag
+++ b/vispy/glsl/arrowheads/arrowheads.frag
@@ -41,7 +41,7 @@
 varying float v_size;
 varying float v_point_size;
 varying vec4  v_color;
-varying vec2  v_orientation;
+varying vec3  v_orientation;
 varying float v_antialias;
 varying float v_linewidth;
 

--- a/vispy/glsl/arrowheads/arrowheads.vert
+++ b/vispy/glsl/arrowheads/arrowheads.vert
@@ -75,9 +75,9 @@ void main (void)
     v_color       = color;
     v_linewidth   = linewidth;
 
-    vec3 body = $transform(vec4(v2 - v1, 0.)).xyz;
+    vec3 body = $transform(v2).xyz - $transform(v1).xyz;
     v_orientation = (body / length(body));
 
-    gl_Position = $transform(vec4(v2, 1));
+    gl_Position = $transform(v2);
     gl_PointSize = v_point_size;
 }

--- a/vispy/glsl/arrowheads/arrowheads.vert
+++ b/vispy/glsl/arrowheads/arrowheads.vert
@@ -50,8 +50,8 @@ uniform float antialias;
 
 // Attributes
 // ------------------------------------
-attribute vec2  v1;
-attribute vec2  v2;
+attribute vec3  v1;
+attribute vec3  v2;
 attribute float size;
 attribute vec4  color;
 attribute float linewidth;
@@ -61,7 +61,7 @@ attribute float linewidth;
 varying float v_size;
 varying float v_point_size;
 varying vec4  v_color;
-varying vec2  v_orientation;
+varying vec3  v_orientation;
 varying float v_antialias;
 varying float v_linewidth;
 
@@ -75,10 +75,9 @@ void main (void)
     v_color       = color;
     v_linewidth   = linewidth;
 
-    vec2 body = v2 - v1;
+    vec3 body = $transform(vec4(v2 - v1, 0.)).xyz;
     v_orientation = (body / length(body));
-    v_orientation.y = -v_orientation.y;
 
-    gl_Position = $transform(vec4(v2, 0, 1));
+    gl_Position = $transform(vec4(v2, 1));
     gl_PointSize = v_point_size;
 }

--- a/vispy/glsl/arrowheads/arrowheads.vert
+++ b/vispy/glsl/arrowheads/arrowheads.vert
@@ -50,8 +50,8 @@ uniform float antialias;
 
 // Attributes
 // ------------------------------------
-attribute vec3  v1;
-attribute vec3  v2;
+attribute vec4  v1;
+attribute vec4  v2;
 attribute float size;
 attribute vec4  color;
 attribute float linewidth;

--- a/vispy/visuals/line/arrow.py
+++ b/vispy/visuals/line/arrow.py
@@ -11,6 +11,7 @@ from __future__ import division
 import numpy as np
 
 from ... import glsl, gloo
+from ..transforms._util import as_vec4
 from ..visual import Visual
 from .line import LineVisual
 
@@ -49,8 +50,8 @@ class _ArrowHeadVisual(Visual):
     ARROWHEAD_FRAGMENT_SHADER = glsl.get('arrowheads/arrowheads.frag')
 
     _arrow_vtype = np.dtype([
-        ('v1', np.float32, 3),
-        ('v2', np.float32, 3),
+        ('v1', np.float32, 4),
+        ('v2', np.float32, 4),
         ('size', np.float32, 1),
         ('color', np.float32, 4),
         ('linewidth', np.float32, 1)
@@ -90,9 +91,8 @@ class _ArrowHeadVisual(Visual):
         v = np.zeros(len(arrows), dtype=self._arrow_vtype)
         # 2d // 3d v1 v2.
         sh = int(arrows.shape[1] / 2)
-        v_complete = np.zeros((len(arrows), 3 - sh), dtype=arrows.dtype)
-        v['v1'] = np.c_[arrows[:, 0:sh], v_complete]
-        v['v2'] = np.c_[arrows[:, sh:int(2 * sh)], v_complete]
+        v['v1'] = as_vec4(arrows[:, 0:sh])
+        v['v2'] = as_vec4(arrows[:, sh:int(2 * sh)])
         v['size'][:] = self._parent.arrow_size
         v['color'][:] = self._parent._interpret_color(self._parent.arrow_color)
         v['linewidth'][:] = self._parent.width

--- a/vispy/visuals/line/arrow.py
+++ b/vispy/visuals/line/arrow.py
@@ -93,7 +93,7 @@ class _ArrowHeadVisual(Visual):
         v['v1'] = np.c_[arrows[:, 0:sh], v_complete]
         v['v2'] = np.c_[arrows[:, sh:int(2 * sh)], v_complete]
         v['size'][:] = self._parent.arrow_size
-        v['color'][:] = self._parent._interpret_color()
+        v['color'][:] = self._parent._interpret_color(self._parent.arrow_color)
         v['linewidth'][:] = self._parent.width
         self._arrow_vbo = gloo.VertexBuffer(v)
 
@@ -165,7 +165,8 @@ class ArrowVisual(LineVisual):
 
     def __init__(self, pos=None, color=(0.5, 0.5, 0.5, 1), width=1,
                  connect='strip', method='gl', antialias=False, arrows=None,
-                 arrow_type='stealth', arrow_size=None):
+                 arrow_type='stealth', arrow_size=None,
+                 arrow_color=(0.5, 0.5, 0.5, 1)):
 
         # Do not use the self._changed dictionary as it gets overwritten by
         # the LineVisual constructor.
@@ -177,6 +178,7 @@ class ArrowVisual(LineVisual):
 
         self.arrow_type = arrow_type
         self.arrow_size = arrow_size
+        self.arrow_color = arrow_color
 
         self.arrow_head = _ArrowHeadVisual(self)
 
@@ -267,6 +269,16 @@ class ArrowVisual(LineVisual):
             self._arrow_size = value
 
         self._arrows_changed = True
+
+    @property
+    def arrow_color(self):
+        return self._arrow_color
+
+    @arrow_color.setter
+    def arrow_color(self, value):
+        if value is not None:
+            self._arrow_color = value
+            self._arrows_changed = True
 
     @property
     def arrows(self):

--- a/vispy/visuals/line/arrow.py
+++ b/vispy/visuals/line/arrow.py
@@ -29,11 +29,12 @@ ARROW_TYPES = (
 
 
 class _ArrowHeadVisual(Visual):
-    """
-    ArrowHeadVisual: several shapes to put on the end of a line.
-    This visual differs from MarkersVisual in the sense that this visual
-    calculates the orientation of the visual on the GPU, by calculating the
-    tangent of the line between two given vertices.
+    """Arrow head visual
+
+    Several shapes to put on the end of a line. This visual differs from
+    MarkersVisual in the sense that this visual calculates the orientation of
+    the visual on the GPU, by calculating the tangent of the line between two
+    given vertices.
 
     This is not really a visual you would use on your own,
     use :class:`ArrowVisual` instead.
@@ -99,7 +100,7 @@ class _ArrowHeadVisual(Visual):
 
 
 class ArrowVisual(LineVisual):
-    """ArrowVisual
+    """Arrow visual
 
     A special line visual which can also draw optional arrow heads at the
     specified vertices.
@@ -142,10 +143,11 @@ class ArrowVisual(LineVisual):
         For method='gl', this specifies whether to use GL's line smoothing,
         which may be unavailable or inconsistent on some platforms.
     arrows : array
-        A Nx4 matrix where each row contains the x and y coordinate of the
-        first and second vertex of the arrow body. Remember that the second
-        vertex is used as center point for the arrow head, and the first
-        vertex is only used for determining the arrow head orientation.
+        A (N, 4) or (N, 6) matrix where each row contains the (x, y) or the
+        (x, y, z) coordinate of the first and second vertex of the arrow
+        body. Remember that the second vertex is used as center point for
+        the arrow head, and the first vertex is only used for determining
+        the arrow head orientation.
     arrow_type : string
         Specify the arrow head type, the currently available arrow head types
         are:
@@ -161,6 +163,10 @@ class ArrowVisual(LineVisual):
             * inhibitor_round
     arrow_size : float
         Specify the arrow size
+    arrow_color : Color, tuple, or array
+        The arrow head color. If an array is given, it must be of shape
+        (..., 4) and provide one rgba color per arrow head. Can also be a
+        colormap name, or appropriate `Function`.
     """
 
     def __init__(self, pos=None, color=(0.5, 0.5, 0.5, 1), width=1,
@@ -218,11 +224,11 @@ class ArrowVisual(LineVisual):
                 * numpy arrays specify the exact set of segment pairs to
                   connect.
         arrows : array
-            A Nx4 matrix where each row contains the x and y coordinate of the
-            first and second vertex of the arrow body. Remember that the second
-            vertex is used as center point for the arrow head, and the first
-            vertex is only used for determining the arrow head orientation.
-
+            A (N, 4) or (N, 6) matrix where each row contains the (x, y) or the
+            (x, y, z) coordinate of the first and second vertex of the arrow
+            body. Remember that the second vertex is used as center point for
+            the arrow head, and the first vertex is only used for determining
+            the arrow head orientation.
         """
 
         if arrows is not None:

--- a/vispy/visuals/line/arrow.py
+++ b/vispy/visuals/line/arrow.py
@@ -232,10 +232,6 @@ class ArrowVisual(LineVisual):
         """
 
         if arrows is not None:
-            assert isinstance(arrows, np.ndarray)
-            if arrows.shape[1] not in [4, 6]:
-                raise ValueError("Invalid arrows shape. Must either be a "
-                                 "(N, 4) or (N, 6) array.")
             self._arrows = arrows
             self._arrows_changed = True
 

--- a/vispy/visuals/line/line.py
+++ b/vispy/visuals/line/line.py
@@ -224,17 +224,18 @@ class LineVisual(CompoundVisual):
         else:
             return self._connect
 
-    def _interpret_color(self):
-        if isinstance(self._color, string_types):
+    def _interpret_color(self, color_in=None):
+        color_in = self._color if color_in is None else color_in
+        if isinstance(color_in, string_types):
             try:
-                colormap = get_colormap(self._color)
+                colormap = get_colormap(color_in)
                 color = Function(colormap.glsl_map)
             except KeyError:
-                color = Color(self._color).rgba
-        elif isinstance(self._color, Function):
-            color = Function(self._color)
+                color = Color(color_in).rgba
+        elif isinstance(color_in, Function):
+            color = Function(color_in)
         else:
-            color = ColorArray(self._color).rgba
+            color = ColorArray(color_in).rgba
             if len(color) == 1:
                 color = color[0]
         return color


### PR DESCRIPTION
This is related to : #1376 

```python
"""XYZ axis example
"""

import numpy as np
from vispy import scene, app
from vispy.scene.visuals import Arrow

can = scene.SceneCanvas(show=True)
wc = can.central_widget.add_view()
wc.camera = 'turntable'
wc.camera.center = (0., 0., 0.)
wc.camera.scale_factor = 3.

pos = np.array([[0., 0., 0.], [1., 0., 0.],
                [0., 0., 0.], [0., 1., 0.],
                [0., 0., 0.], [0., 0., 1.],
                ])
arrows = np.c_[pos[0::2], pos[1::2]]

line_color = ['red', 'red', 'green', 'green', 'blue', 'blue']
arrow_color = ['red', 'green', 'blue']

arr = Arrow(pos=pos, parent=wc.scene, connect='segments',
            arrows=arrows, arrow_type='triangle_60', arrow_size=20.,
            width=3., antialias=True, arrow_color=arrow_color,
            color=line_color)

can.show()
app.run()
```