### PR TITLE
Fix sphere passing rows/cols backwards

### DIFF
--- a/vispy/geometry/generation.py
+++ b/vispy/geometry/generation.py
@@ -403,7 +403,7 @@ def _ico(radius, subdivisions):
 
 def _cube(rows, cols, depth, radius):
     # vertices and faces of tessellated cube
-    verts, faces, _ = create_box(1, 1, 1, rows, cols, depth)
+    verts, faces, _ = create_box(1, 1, 1, cols, rows, depth)
     verts = verts['position']
 
     # make each vertex to lie on the sphere

--- a/vispy/visuals/sphere.py
+++ b/vispy/visuals/sphere.py
@@ -47,7 +47,7 @@ class SphereVisual(CompoundVisual):
                  method='latitude', vertex_colors=None, face_colors=None,
                  color=(0.5, 0.5, 1, 1), edge_color=None, **kwargs):
 
-        mesh = create_sphere(cols, rows, depth, radius=radius,
+        mesh = create_sphere(rows, cols, depth, radius=radius,
                              subdivisions=subdivisions, method=method)
 
         self._mesh = MeshVisual(vertices=mesh.get_vertices(),


### PR DESCRIPTION
Fix #1259 

Based on the above issue it seemed a little weird that no one would have noticed two parameters being backwards. What was actually wrong was that the code for the `cube` method was wrong twice so the issue wasn't showing. The `latitude` method was actually the method that showed the issue. If @kalexander92 and maybe @kmuehlbauer or @larsoner could test `examples/basics/scene/sphere.py` with this branch and try changing the rows and cols of the third sphere and see if the numbers make sense to them.