### PR TITLE
Fix initial axis limits in PlotWidget

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Add documentation to the source tarball but not in the installation
-include doc/Makefile doc/.nojekyll doc/conf.py
+include doc/Makefile doc/.nojekyll doc/conf.py LICENSE.txt
 include doc/*.rst
 recursive-include doc/ext *
 recursive-include doc/_static *

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -5,7 +5,9 @@
 from __future__ import division
 import numpy as np
 
+from vispy.geometry import Rect
 from .widget import Widget
+from .viewbox import ViewBox
 
 from ...ext.cassowary import (SimplexSolver, expression,
                               Variable, WEAK, REQUIRED,
@@ -25,7 +27,6 @@ class Grid(Widget):
         Keyword arguments to pass to `Widget`.
     """
     def __init__(self, spacing=6, **kwargs):
-        from .viewbox import ViewBox
         self._next_cell = [0, 0]  # row, col
         self._cells = {}
         self._grid_widgets = {}
@@ -235,7 +236,6 @@ class Grid(Widget):
         **kwargs : dict
             Keyword arguments to pass to `ViewBox`.
         """
-        from .viewbox import ViewBox
         view = ViewBox(**kwargs)
         return self.add_widget(view, row, col, row_span, col_span)
 
@@ -495,8 +495,11 @@ class Grid(Widget):
             else:
                 y = np.sum(value_vectorized(self._height_grid[col][0:row]))
 
-            widget.size = (width, height)
-            widget.pos = (x, y)
+            if isinstance(widget, ViewBox):
+                widget.rect = Rect(x, y, width, height)
+            else:
+                widget.size = (width, height)
+                widget.pos = (x, y)
 
     @property
     def _widget_grid(self):


### PR DESCRIPTION
Fix #1385 

Includes adding LICENSE.txt to MANIFEST.in for source tarball distributions.

Using the test script below I found out where I think the axes limits are being messed up in the initial drawing of the plot.

```
import numpy as np
import vispy.plot as vp
from vispy import app
x = np.linspace(0, 1000, 1000)
y = np.linspace(0, 50000, 1000)
line = None
fig = None
fig = vp.Fig(size=(1200, 380), position=(-40, -50))
fig.create_native()

x = np.linspace(0, 1000, 1000)
y = np.linspace(0, 50000, 1000)
line = fig[0, 0].plot((x, y), width=1, color='blue', xlabel='',
                                ylabel='', marker_size=-10)
                                
app.run()  
```

Note that the above script differs from the one in #1385 by using the default `'gl'` line instead of `'agg'`. The 'agg' line method does not clip lines outside of the drawing axes box.

The main issue that I discovered was that after the Figures main grid box started resizing (on the original resize) it would resize its various child widgets and then reach the main ViewBox widget. By resizing the ViewBox widget in the previous way it would trigger a transform change event. This transform change would cause a recalculation of the tick labels *before* the axes object had been properly resized causing the values to be incorrect. This PR blocks the resize event inside the Viewbox (using the `rect.setter` property) which allows all child widgets to be resized before a transform change event (scene update) is propagated through the scene/node graph.