### PR TITLE
Refactor ellipse and rectangle visuals

### DIFF
--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -375,7 +375,7 @@ def get_test_data_repo():
     # This tag marks the test-data commit that this version of vispy should
     # be tested against. When adding or changing test images, create
     # and push a new tag and update this variable.
-    test_data_tag = 'test-data-6'
+    test_data_tag = 'test-data-7'
 
     data_path = config['test_data_path']
     git_path = 'http://github.com/vispy/test-data'

--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -150,7 +150,7 @@ def assert_image_approved(image, standard_file, message=None, **kwargs):
                 raise Exception("Test standard %s does not exist." % std_file)
             else:
                 if os.getenv('TRAVIS') is not None or \
-                                os.getenv('APPVEYOR') is not None:
+                        os.getenv('APPVEYOR') is not None:
                     _save_failed_test(image, std_image, standard_file)
                 raise
 

--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -149,7 +149,8 @@ def assert_image_approved(image, standard_file, message=None, **kwargs):
             if std_image is None:
                 raise Exception("Test standard %s does not exist." % std_file)
             else:
-                if os.getenv('TRAVIS') is not None:
+                if os.getenv('TRAVIS') is not None or \
+                                os.getenv('APPVEYOR') is not None:
                     _save_failed_test(image, std_image, standard_file)
                 raise
 

--- a/vispy/visuals/ellipse.py
+++ b/vispy/visuals/ellipse.py
@@ -27,6 +27,8 @@ class EllipseVisual(PolygonVisual):
         The border color to use.
     border_width: float
         The width of the border in pixels
+        Line widths > 1px are only
+        guaranteed to work when using `border_method='agg'` method.
     radius : float | tuple
         Radius or radii of the ellipse
         Defaults to  (0.1, 0.1)

--- a/vispy/visuals/ellipse.py
+++ b/vispy/visuals/ellipse.py
@@ -39,6 +39,8 @@ class EllipseVisual(PolygonVisual):
     num_segments : int
         Number of segments to be used to draw the ellipse
         Defaults to 100
+    **kwargs : dict
+        Keyword arguments to pass to `PolygonVisual`.
     """
     def __init__(self, center=None, color='black', border_color=None,
                  border_width=1, radius=(0.1, 0.1), start_angle=0.,

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -34,16 +34,27 @@ class PolygonVisual(CompoundVisual):
         Border color of the polygon.
     border_width : int
         Border width in pixels.
+        Line widths > 1px are only
+        guaranteed to work when using `border_method='agg'` method.
+    border_method : str
+        Mode to use for drawing the border line (see `LineVisual`).
+
+            * "agg" uses anti-grain geometry to draw nicely antialiased lines
+              with proper joins and endcaps.
+            * "gl" uses OpenGL's built-in line rendering. This is much faster,
+              but produces much lower-quality results and is not guaranteed to
+              obey the requested line width or join/endcap styles.
+
     triangulate : boolean
         Triangulate the set of vertices
     **kwargs : dict
         Keyword arguments to pass to `CompoundVisual`.
     """
     def __init__(self, pos=None, color='black',
-                 border_color=None, border_width=1, triangulate=True,
-                 **kwargs):
+                 border_color=None, border_width=1, border_method='gl',
+                 triangulate=True, **kwargs):
         self._mesh = MeshVisual()
-        self._border = LineVisual()
+        self._border = LineVisual(method=border_method)
         self._pos = pos
         self._color = Color(color)
         self._border_width = border_width

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -38,13 +38,15 @@ class PolygonVisual(CompoundVisual):
         Keyword arguments to pass to `CompoundVisual`.
     """
     def __init__(self, pos=None, color='black',
-                 border_color=None, border_width=1, **kwargs):
+                 border_color=None, border_width=1, triangulate=True,
+                 **kwargs):
         self._mesh = MeshVisual()
         self._border = LineVisual()
         self._pos = pos
         self._color = Color(color)
         self._border_width = border_width
         self._border_color = Color(border_color)
+        self._triangulate = triangulate
 
         self._update()
         CompoundVisual.__init__(self, [self._mesh, self._border], **kwargs)
@@ -53,25 +55,27 @@ class PolygonVisual(CompoundVisual):
         self.freeze()
 
     def _update(self):
-        self.data = PolygonData(vertices=np.array(self._pos, dtype=np.float32))
         if self._pos is None:
             return
-        if not self._color.is_blank:
-            pts, tris = self.data.triangulate()
+        if not self._color.is_blank and self._triangulate:
+            data = PolygonData(vertices=np.array(self._pos, dtype=np.float32))
+            pts, tris = data.triangulate()
             set_state(polygon_offset_fill=False)
             self._mesh.set_data(vertices=pts, faces=tris.astype(np.uint32),
                                 color=self._color.rgba)
+        elif not self._color.is_blank:
+            self.mesh.set_data(vertices=self._pos,
+                               color=self._color.rgba)
 
         if not self._border_color.is_blank:
             # Close border if it is not already.
             border_pos = self._pos
-            if np.any(border_pos[0] != border_pos[1]):
+            if np.any(border_pos[0] != border_pos[-1]):
                 border_pos = np.concatenate([border_pos, border_pos[:1]],
                                             axis=0)
             self._border.set_data(pos=border_pos,
                                   color=self._border_color.rgba,
-                                  width=self._border_width,
-                                  connect='strip')
+                                  width=self._border_width)
 
             self._border.update()
 

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -35,7 +35,7 @@ class PolygonVisual(CompoundVisual):
     border_width : int
         Border width in pixels.
     **kwargs : dict
-        Keyword arguments to pass to `PolygonVisual`.
+        Keyword arguments to pass to `CompoundVisual`.
     """
     def __init__(self, pos=None, color='black',
                  border_color=None, border_width=1, **kwargs):

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -34,6 +34,8 @@ class PolygonVisual(CompoundVisual):
         Border color of the polygon.
     border_width : int
         Border width in pixels.
+    triangulate : boolean
+        Triangulate the set of vertices
     **kwargs : dict
         Keyword arguments to pass to `CompoundVisual`.
     """

--- a/vispy/visuals/rectangle.py
+++ b/vispy/visuals/rectangle.py
@@ -37,6 +37,8 @@ class RectangleVisual(PolygonVisual):
     radius : float | array
         Radii of curvatures of corners in clockwise order from top-left
         Defaults to 0.
+    **kwargs : dict
+        Keyword arguments to pass to `PolygonVisual`.
     """
     def __init__(self, center=None, color='black', border_color=None,
                  border_width=1, height=1.0, width=1.0,
@@ -196,7 +198,7 @@ class RectangleVisual(PolygonVisual):
         self._update()
 
     def _update(self):
-        if not self._center:
+        if self._center is None:
             return
 
         if self._radius is None:
@@ -222,4 +224,5 @@ class RectangleVisual(PolygonVisual):
         # to the edge
         if not self._border_color.is_blank:
             self.border.set_data(pos=vertices[1:, ..., :2],
-                                 color=self._border_color.rgba)
+                                 color=self._border_color.rgba,
+                                 width=self._border_width)

--- a/vispy/visuals/rectangle.py
+++ b/vispy/visuals/rectangle.py
@@ -28,6 +28,8 @@ class RectangleVisual(PolygonVisual):
         The border color to use.
     border_width : int
         Border width in pixels.
+        Line widths > 1px are only
+        guaranteed to work when using `border_method='agg'` method.
     height : float
         Length of the rectangle along y-axis
         Defaults to 1.0

--- a/vispy/visuals/tests/test_rectangle.py
+++ b/vispy/visuals/tests/test_rectangle.py
@@ -53,6 +53,14 @@ def test_rectangle_draw():
 
         assert_image_approved(c.render(), 'visuals/rectpolygon5.png')
 
+        rectpolygon.parent = None
+        rectpolygon = visuals.Rectangle(center=(50, 50, 0), height=60.,
+                                        width=80., radius=[25, 10, 0, 15],
+                                        color='red', border_color=(0, 1, 1, 1),
+                                        border_width=5, parent=c.scene)
+
+        assert_image_approved(c.render(), 'visuals/rectpolygon10.png')
+
 
 @requires_application()
 def test_rectpolygon_draw():

--- a/vispy/visuals/tests/test_rectangle.py
+++ b/vispy/visuals/tests/test_rectangle.py
@@ -57,7 +57,8 @@ def test_rectangle_draw():
         rectpolygon = visuals.Rectangle(center=(50, 50, 0), height=60.,
                                         width=80., radius=[25, 10, 0, 15],
                                         color='red', border_color=(0, 1, 1, 1),
-                                        border_width=5, parent=c.scene)
+                                        border_width=5, border_method='agg',
+                                        parent=c.scene)
 
         assert_image_approved(c.render(), 'visuals/rectpolygon10.png')
 


### PR DESCRIPTION
Fix #1349

Issues fixed:

 - Border width was not used in RectangleVisual
 - Border loops were not properly being closed due to a 1 versus -1 index error.

This refactor tries to reduce the amount of duplicated code. There is something weird going on in the original code where the center point of the polygon's face (ellipse and rectangle) was being passed as a mesh vertex but as far as I can tell it is not needed.

Lastly, updating the rectangle/ellipse vertices could be done differently but I would argue no less ugly (`_regen_pos()`).