### PR TITLE
WIP: Performance updates for Scene

### DIFF
--- a/vispy/gloo/framebuffer.py
+++ b/vispy/gloo/framebuffer.py
@@ -245,8 +245,8 @@ class FrameBuffer(GLObject):
             3D array of pixels in np.uint8 format. 
             The array shape is (h, w, 3) or (h, w, 4), with the top-left 
             corner of the framebuffer at index [0, 0] in the returned array if
-            crop was not specified. If crop was given, the result will match the
-            offset and dimensions of the crop.
+            crop was not specified. If crop was given, the result will match
+            the offset and dimensions of the crop.
         
         """
         _check_valid('mode', mode, ['color', 'depth', 'stencil'])

--- a/vispy/gloo/framebuffer.py
+++ b/vispy/gloo/framebuffer.py
@@ -226,7 +226,7 @@ class FrameBuffer(GLObject):
                 shape_ = shape + (buf._inv_formats[buf.format], )
             buf.resize(shape_, buf.format)
     
-    def read(self, mode='color', alpha=True):
+    def read(self, mode='color', alpha=True, crop=None):
         """ Return array of pixel values in an attached buffer
         
         Parameters
@@ -235,20 +235,27 @@ class FrameBuffer(GLObject):
             The buffer type to read. May be 'color', 'depth', or 'stencil'.
         alpha : bool
             If True, returns RGBA array. Otherwise, returns RGB.
+        crop : array-like
+            If not None, specifies pixels to read from buffer.
+            Format is (x, y, w, h).
         
         Returns
         -------
         buffer : array
             3D array of pixels in np.uint8 format. 
             The array shape is (h, w, 3) or (h, w, 4), with the top-left 
-            corner of the framebuffer at index [0, 0] in the returned array.
+            corner of the framebuffer at index [0, 0] in the returned array if
+            crop was not specified. If crop was given, the result will match the
+            offset and dimensions of the crop.
         
         """
         _check_valid('mode', mode, ['color', 'depth', 'stencil'])
-        buffer = getattr(self, mode+'_buffer')
-        h, w = buffer.shape[:2]
+        if crop is None:
+            buffer = getattr(self, mode+'_buffer')
+            h, w = buffer.shape[:2]
+            crop = (0, 0, w, h)
         
         # todo: this is ostensibly required, but not available in gloo.gl
         #gl.glReadBuffer(buffer._target)
         
-        return read_pixels((0, 0, w, h), alpha=alpha)
+        return read_pixels(crop, alpha=alpha)

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -197,7 +197,7 @@ class SceneCanvas(app.Canvas, Frozen):
         # of the backend with additional updates.
         if not self._update_pending:
             self._update_pending = True
-            app.Canvas.update(self)
+            super(SceneCanvas, self).update()
 
     def on_draw(self, event):
         """Draw handler

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -470,7 +470,8 @@ class SceneCanvas(app.Canvas, Frozen):
         crop : array-like
             The crop (x, y, w, h) of the framebuffer to read. For picking the
             full canvas is rendered and cropped on read as it is much faster
-            than triggering transform updates across the scene with every click.
+            than triggering transform updates across the scene with every
+            click.
         """
         try:
             self._scene.picking = True

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -495,6 +495,11 @@ class Grid(Widget):
             else:
                 y = np.sum(value_vectorized(self._height_grid[col][0:row]))
 
+            # Ensure we only update the widgets when a change occurs. Allow for
+            # floating point discrepencies in the comparisons.
+            if abs(widget.size[0] - width) < 1e-4 and abs(widget.size[1] - height) < 1e-4 and \
+                abs(widget.pos[0] - x) < 1e-4 and abs(widget.pos[1] - y) < 1e-4:
+                continue
             if isinstance(widget, ViewBox):
                 widget.rect = Rect(x, y, width, height)
             else:

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -495,11 +495,6 @@ class Grid(Widget):
             else:
                 y = np.sum(value_vectorized(self._height_grid[col][0:row]))
 
-            # Ensure we only update the widgets when a change occurs. Allow for
-            # floating point discrepencies in the comparisons.
-            if abs(widget.size[0] - width) < 1e-4 and abs(widget.size[1] - height) < 1e-4 and \
-                abs(widget.pos[0] - x) < 1e-4 and abs(widget.pos[1] - y) < 1e-4:
-                continue
             if isinstance(widget, ViewBox):
                 widget.rect = Rect(x, y, width, height)
             else:

--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -77,6 +77,9 @@ class Widget(Compound):
         self._bgcolor = Color(bgcolor)
         self._face_colors = None
 
+        # Flag to allow rect setter to know if pos or size changed.
+        self._pos_or_size_changed = False
+
         Compound.__init__(self, [self._mesh, self._picking_mesh], **kwargs)
 
         self.transform = STTransform()
@@ -97,6 +100,7 @@ class Widget(Compound):
         if abs(p[0] - self.pos[0]) < 1e-4 and \
            abs(p[1] - self.pos[1]) < 1e-4:
             return
+        self._pos_or_size_changed = True
         self.transform.translate = p[0], p[1], 0, 0
         self._update_line()
 
@@ -117,6 +121,7 @@ class Widget(Compound):
         if abs(s[0] - self._size[0]) < 1e-4 and \
            abs(s[1] - self._size[1]) < 1e-4:
             return
+        self._pos_or_size_changed = True
         self._size = s
         self._update_line()
         self._update_child_widgets()
@@ -239,11 +244,13 @@ class Widget(Compound):
 
     @rect.setter
     def rect(self, r):
+        self._pos_or_size_changed = False
         with self.events.resize.blocker():
             self.pos = r.pos
             self.size = r.size
-        self.update()
-        self.events.resize()
+        if self._pos_or_size_changed:
+            self.update()
+            self.events.resize()
 
     @property
     def inner_rect(self):

--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -93,7 +93,9 @@ class Widget(Compound):
     def pos(self, p):
         assert isinstance(p, tuple)
         assert len(p) == 2
-        if p == self.pos:
+        # Handle floating point discrepancies
+        if abs(p[0] - self.pos[0]) < 1e-4 and \
+           abs(p[1] - self.pos[1]) < 1e-4:
             return
         self.transform.translate = p[0], p[1], 0, 0
         self._update_line()
@@ -111,7 +113,9 @@ class Widget(Compound):
     def size(self, s):
         assert isinstance(s, tuple)
         assert len(s) == 2
-        if self._size == s:
+        # Handle floating point discrepancies
+        if abs(s[0] - self._size[0]) < 1e-4 and \
+           abs(s[1] - self._size[1]) < 1e-4:
             return
         self._size = s
         self._update_line()


### PR DESCRIPTION
I have been playing with the performance of vispy a bit #628 - my main test is examples/benchmark/scene_test_2.py. I'm not sure about everyone else who runs the benchmark but I found it impossible to use the scene canvas with a pyglet backend.

If I understood things in the code correctly, one major performance bottleneck is the generation of many upon many of update calls to the scene canvas, which simply schedule future draw events to be executed from the backend. It seems the major source of these are the scene nodes, all of which look to inherit and hold a reference to the scene canvas, and if a node update it triggered, it also calls the update on the canvas.

This pull might be an easy fix/work-around or at the minimum highlight a possible cause of poor performance in the scene and a better fix can be found in that light. The fix is high level + general (in the scene canvas), and contained in only a few lines - I don't think it has any adverse impacts (it always allows at least one update to be scheduled if I worked through the logic correctly) though I have only tested it in a limited set of cases. With it the scene canvas in the benchmark test is very usable (maybe not 100% snappy) but before this change I couldn't even click and pan without Windows asking to kill the app). I also note that in #1312 the same issue flood of re-draw events is noted in the Tornado queue.

What do you guys think?

