### PR TITLE
FIX: correct rows/cols in IsocurveVisual 

### DIFF
--- a/examples/basics/scene/isocurve.py
+++ b/examples/basics/scene/isocurve.py
@@ -21,8 +21,8 @@ canvas.show()
 view = canvas.central_widget.add_view()
 
 # Create the image
-img_data = np.empty((100, 100, 3), dtype=np.ubyte)
-noise = np.random.normal(size=(100, 100), loc=50, scale=150)
+img_data = np.empty((200, 100, 3), dtype=np.ubyte)
+noise = np.random.normal(size=(200, 100), loc=50, scale=150)
 noise = gaussian_filter(noise, (4, 4, 0))
 img_data[:] = noise[..., np.newaxis]
 image = scene.visuals.Image(img_data, parent=view.scene)

--- a/examples/basics/scene/isocurve_updates.py
+++ b/examples/basics/scene/isocurve_updates.py
@@ -44,13 +44,13 @@ for box in vb:
     box.camera.aspect = 1.0
 
 # Create random image
-img_data1 = np.empty((100, 100, 3), dtype=np.ubyte)
-noise = np.random.normal(size=(100, 100), loc=50, scale=150)
+img_data1 = np.empty((200, 100, 3), dtype=np.ubyte)
+noise = np.random.normal(size=(200, 100), loc=50, scale=150)
 noise = gaussian_filter(noise, (4, 4, 0))
 img_data1[:] = noise[..., np.newaxis]
 
 # create 2d array with some function
-x, y = np.mgrid[0:2*np.pi:101j, 0:2*np.pi:101j]
+x, y = np.mgrid[0:2*np.pi:201j, 0:2*np.pi:101j]
 myfunc = np.cos(2*x[:-1, :-1]) + np.sin(2*y[:-1, :-1])
 
 # add image to viewbox1
@@ -84,8 +84,8 @@ curve2b = scene.visuals.Isocurve(
     myfunc, levels=levels2, color_lev='cubehelix', parent=vb4.scene)
 
 # set viewport
-vb3.camera.set_range((0, 100), (0, 100))
-vb4.camera.set_range((0, 100), (0, 100))
+vb3.camera.set_range((-100, 200), (0, 200))
+vb4.camera.set_range((0, 100), (0, 200))
 
 
 # setup update parameters

--- a/vispy/visuals/isocurve.py
+++ b/vispy/visuals/isocurve.py
@@ -104,9 +104,9 @@ class IsocurveVisual(LineVisual):
         # if using matplotlib isoline algorithm we have to check for meshgrid
         # and we can setup the tracer object here
         if _HAS_MPL:
-            if self._X is None or self._X.T.shape != data.shape:
-                self._X, self._Y = np.meshgrid(np.arange(data.shape[0]),
-                                               np.arange(data.shape[1]))
+            if self._X is None or self._X.shape != data.shape:
+                self._X, self._Y = np.meshgrid(np.arange(data.shape[1]),
+                                               np.arange(data.shape[0]))
             self._iso = cntr.Cntr(self._X, self._Y, self._data.astype(float))
 
         if self._clim is None:


### PR DESCRIPTION
* correct rows/cols in IsocurveVisualfor matplotlib isoline tracer
* fix examples to have (200, 100) dimension

closes #1403 