### PR TITLE
Utilize the cmap.setter

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -407,7 +407,7 @@ class VolumeVisual(Visual):
         self._need_vertex_update = True
 
         # Set the colormap
-        self._cmap = get_colormap(cmap)
+        self.cmap = cmap
 
         # Create gloo objects
         self._vertices = VertexBuffer()
@@ -545,7 +545,6 @@ class VolumeVisual(Visual):
         self.shared_program.frag = frag_dict[method]
         self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
         self.shared_program.frag['sample'] = self._tex.glsl_sample
-        self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
         self.update()
     
     @property


### PR DESCRIPTION
When trying to modify `vispy.visuals.volume.Volume` to integrate with multi-color volume, I figured that `cmap.setter` might be better utilized - instead of setting it independently in `__init__` and `method.setter`, which can also potentially alleviate `self._cmap` and `frag['cmap']` being mistmatch.