### PR TITLE
Remove extra space between # and ! in shebangs.

### DIFF
--- a/examples/basics/gloo/animate_shape.py
+++ b/examples/basics/gloo/animate_shape.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 3
 

--- a/examples/basics/gloo/display_lines.py
+++ b/examples/basics/gloo/display_lines.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 2
 """ Show a bunch of lines.

--- a/examples/basics/gloo/display_points.py
+++ b/examples/basics/gloo/display_points.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 2
 """ Simple example plotting 2D points.

--- a/examples/basics/gloo/display_shape.py
+++ b/examples/basics/gloo/display_shape.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 2
 

--- a/examples/basics/gloo/hello_fbo.py
+++ b/examples/basics/gloo/hello_fbo.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 3
 

--- a/examples/basics/gloo/multi_texture.py
+++ b/examples/basics/gloo/multi_texture.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """Example demonstrating (and testing) multi-texturing.

--- a/examples/basics/gloo/start.py
+++ b/examples/basics/gloo/start.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """ Probably the simplest vispy example
 """

--- a/examples/basics/plotting/scatter_histogram.py
+++ b/examples/basics/plotting/scatter_histogram.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 30
 

--- a/examples/demo/gloo/boids.py
+++ b/examples/demo/gloo/boids.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 30
 

--- a/examples/demo/gloo/cloud.py
+++ b/examples/demo/gloo/cloud.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vispy: gallery 1
 


### PR DESCRIPTION
The extra space makes the shebang not work, e.g.:
```shell
vispy/examples/demo/gloo$ ./cloud.py 
./cloud.py: line 7: $'\nDemonstrating a cloud of points.\n': command not found
```