### PR TITLE
Add .pytest_cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ vispy.egg-info
 *.swp
 .ipynb_checkpoints
 .cache/
-
+.pytest_cache/


### PR DESCRIPTION
When I run the test suite with `make tests`, I find that the generated `.pytest_cache/` shows up in git.