### PR TITLE
Add TextureFilter for adding textures to MeshVisuals

### DIFF
--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -1,0 +1,53 @@
+import argparse
+
+import numpy as np
+from vispy import app, scene
+from vispy.io import imread, read_mesh
+from vispy.scene.visuals import Mesh
+from vispy.visuals.filters import TextureFilter
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('mesh')
+parser.add_argument('--shading', default='smooth',
+                    choices=['none', 'flat', 'smooth'])
+args = parser.parse_args()
+
+vertices, faces, normals, texcoords = read_mesh(args.mesh)
+texture = np.flipud(imread(args.mesh.replace(".obj", ".png")))
+
+canvas = scene.SceneCanvas(keys='interactive', bgcolor='white',
+                           size=(800, 600))
+view = canvas.central_widget.add_view()
+
+view.camera = 'arcball'
+# Adapt the depth to the scale of the mesh to avoid rendering artefacts.
+view.camera.depth_value = 10 * (vertices.max() - vertices.min())
+
+shading = None if args.shading == 'none' else args.shading
+mesh = Mesh(vertices, faces, shading=shading, color='lightgreen')
+mesh.shininess = 1e-3
+view.add(mesh)
+
+texture_filter = TextureFilter(texture, texcoords)
+mesh.attach(texture_filter)
+
+
+def attach_headlight(mesh, view, canvas):
+    mesh.light_dir = (0, -1, 0)
+    initial_light_dir = view.camera.transform.imap(mesh.light_dir)
+    initial_light_dir[3] = 0
+
+    @canvas.events.mouse_move.connect
+    def on_mouse_move(event):
+        transform = view.camera.transform
+        mesh.light_dir = transform.map(initial_light_dir)[:3]
+
+
+attach_headlight(mesh, view, canvas)
+
+
+canvas.show()
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -27,7 +27,7 @@ view.camera = 'arcball'
 view.camera.depth_value = 10 * (vertices.max() - vertices.min())
 
 shading = None if args.shading == 'none' else args.shading
-mesh = Mesh(vertices, faces, shading=shading, color='lightgreen')
+mesh = Mesh(vertices, faces, shading=shading, color='white')
 mesh.shininess = 1e-3
 view.add(mesh)
 

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -48,8 +48,8 @@ def attach_headlight(mesh, view, canvas):
     initial_light_dir = view.camera.transform.imap(light_dir)
     initial_light_dir[3] = 0
 
-    @canvas.events.mouse_move.connect
-    def on_mouse_move(event):
+    @view.scene.transform.changed.connect
+    def on_transform_change(event):
         transform = view.camera.transform
         mesh.light_dir = transform.map(initial_light_dir)[:3]
 

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -43,8 +43,9 @@ def on_key_press(event):
 
 
 def attach_headlight(mesh, view, canvas):
-    mesh.light_dir = (0, -1, 0)
-    initial_light_dir = view.camera.transform.imap(mesh.light_dir)
+    light_dir = (0, -1, 0, 0)
+    mesh.light_dir = light_dir[:3]
+    initial_light_dir = view.camera.transform.imap(light_dir)
     initial_light_dir[3] = 0
 
     @canvas.events.mouse_move.connect

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -46,7 +46,6 @@ def attach_headlight(mesh, view, canvas):
     light_dir = (0, -1, 0, 0)
     mesh.light_dir = light_dir[:3]
     initial_light_dir = view.camera.transform.imap(light_dir)
-    initial_light_dir[3] = 0
 
     @view.scene.transform.changed.connect
     def on_transform_change(event):

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -2,19 +2,21 @@ import argparse
 
 import numpy as np
 from vispy import app, scene
-from vispy.io import imread, read_mesh
+from vispy.io import imread, load_data_file, read_mesh
 from vispy.scene.visuals import Mesh
 from vispy.visuals.filters import TextureFilter
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('mesh')
 parser.add_argument('--shading', default='smooth',
-                    choices=['none', 'flat', 'smooth'])
+                    choices=['none', 'flat', 'smooth'],
+                    help="shading mode")
 args = parser.parse_args()
 
-vertices, faces, normals, texcoords = read_mesh(args.mesh)
-texture = np.flipud(imread(args.mesh.replace(".obj", ".png")))
+mesh_path = load_data_file('spot/spot.obj.gz')
+texture_path = load_data_file('spot/spot.png')
+vertices, faces, normals, texcoords = read_mesh(mesh_path)
+texture = np.flipud(imread(texture_path))
 
 canvas = scene.SceneCanvas(keys='interactive', bgcolor='white',
                            size=(800, 600))

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -35,6 +35,13 @@ texture_filter = TextureFilter(texture, texcoords)
 mesh.attach(texture_filter)
 
 
+@canvas.events.key_press.connect
+def on_key_press(event):
+    if event.key == "t":
+        texture_filter.enabled = not texture_filter.enabled
+        mesh.update()
+
+
 def attach_headlight(mesh, view, canvas):
     mesh.light_dir = (0, -1, 0)
     initial_light_dir = view.camera.transform.imap(mesh.light_dir)

--- a/vispy/visuals/filters/__init__.py
+++ b/vispy/visuals/filters/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
+from .base_filter import Filter  # noqa
 from .clipper import Clipper  # noqa
 from .color import Alpha, ColorFilter, IsolineFilter, ZColormapFilter  # noqa
 from .picking import PickingFilter  # noqa

--- a/vispy/visuals/filters/__init__.py
+++ b/vispy/visuals/filters/__init__.py
@@ -5,3 +5,4 @@
 from .clipper import Clipper  # noqa
 from .color import Alpha, ColorFilter, IsolineFilter, ZColormapFilter  # noqa
 from .picking import PickingFilter  # noqa
+from .mesh import TextureFilter  # noqa

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -1,0 +1,45 @@
+from vispy.gloo import Texture2D, VertexBuffer
+from vispy.visuals.shaders import Function, Varying
+import numpy as np
+
+
+class TextureFilter(object):
+
+    def __init__(self, texture, texcoords):
+        self.texture = texture
+        self.texcoords = texcoords
+        self._texcoords = VertexBuffer(np.zeros((0, 2), dtype=np.float32))
+        self._texcoord_varying = Varying('v_texcoord', 'vec2')
+        self.apply_coords = Function("""
+            void apply_coords() {
+                $v_texcoords = $texcoords;
+            }
+        """)
+
+        self.apply_texture = Function("""
+            void apply_texture() {
+                gl_FragColor *= texture2D($u_texture, $texcoord);
+            }
+        """)
+
+        self.coords_expr = self.apply_coords()
+        self.texture_expr = self.apply_texture()
+
+    def _attach(self, visual):
+        # vertex shader
+        vert_pre = visual._get_hook('vert', 'pre')
+        vert_pre.add(self.coords_expr)
+        tc = self.texcoords[visual.mesh_data.get_faces()]
+        self._texcoords.set_data(tc, convert=True)
+        self.apply_coords['texcoords'] = self._texcoords
+        self.apply_coords['v_texcoords'] = self._texcoord_varying
+
+        # fragment shader
+        frag_post = visual._get_hook('frag', 'post')
+        frag_post.add(self.texture_expr)
+        self.apply_texture['texcoord'] = self._texcoord_varying
+        self.apply_texture['u_texture'] = Texture2D(self.texture)
+
+    def _detach(self, visual):
+        visual._get_hook('vert', 'pre').remove(self.coords_expr)
+        visual._get_hook('frag', 'post').remove(self.texture_expr)

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -1,45 +1,112 @@
+import numpy as np
 from vispy.gloo import Texture2D, VertexBuffer
 from vispy.visuals.shaders import Function, Varying
-import numpy as np
 
 
 class TextureFilter(object):
 
-    def __init__(self, texture, texcoords):
-        self.texture = texture
-        self.texcoords = texcoords
-        self._texcoords = VertexBuffer(np.zeros((0, 2), dtype=np.float32))
-        self._texcoord_varying = Varying('v_texcoord', 'vec2')
-        self.apply_coords = Function("""
-            void apply_coords() {
+    def __init__(self, texture, texcoords, enabled=True):
+        """Apply a texture on a mesh.
+
+        Parameters
+        ----------
+        texture : (M, N) or (M, N, C) array
+            The 2D texture image.
+        texcoords : (N, 2) array
+            The texture coordinates.
+        enabled : bool
+            Whether the display of the texture is enabled.
+        """
+        self.pass_coords = Function("""
+            void pass_coords() {
                 $v_texcoords = $texcoords;
             }
         """)
-
         self.apply_texture = Function("""
             void apply_texture() {
-                gl_FragColor *= texture2D($u_texture, $texcoord);
+                if ($enabled == 1) {
+                    gl_FragColor *= texture2D($u_texture, $texcoords);
+                }
             }
         """)
-
-        self.coords_expr = self.apply_coords()
+        self._texcoord_varying = Varying('v_texcoord', 'vec2')
+        self.pass_coords['v_texcoords'] = self._texcoord_varying
+        self.apply_texture['texcoords'] = self._texcoord_varying
+        self._texcoords_buffer = VertexBuffer(
+            np.zeros((0, 2), dtype=np.float32)
+        )
+        self.pass_coords['texcoords'] = self._texcoords_buffer
+        self.coords_expr = self.pass_coords()
         self.texture_expr = self.apply_texture()
 
+        self._attached = False
+        self._visual = None
+
+        self.enabled = enabled
+        self.texture = texture
+        self.texcoords = texcoords
+
+    @property
+    def enabled(self):
+        """True to display the texture, False to disable."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+        self.apply_texture['enabled'] = 1 if enabled else 0
+
+    @property
+    def texture(self):
+        """The texture image."""
+        return self._texture
+
+    @texture.setter
+    def texture(self, texture):
+        self._texture = texture
+        self.apply_texture['u_texture'] = Texture2D(texture)
+
+    @property
+    def texcoords(self):
+        """The texture coordinates as an (N, 2) array of floats."""
+        return self._texcoords
+
+    @texcoords.setter
+    def texcoords(self, texcoords):
+        self._texcoords = texcoords
+        self._update_texcoords_buffer(texcoords)
+
+    def _update_texcoords_buffer(self, texcoords):
+        if not self._attached or self._visual is None:
+            return
+
+        # FIXME: Indices for texture coordinates might be different than face
+        # indices, although in some cases they are the same. Currently,
+        # vispy.io.read_mesh assumes face indices and texture coordinates are
+        # the same.
+        # TODO:
+        # 1. Add reading and returning of texture coordinate indices in
+        #    read_mesh.
+        # 2. Add texture coordinate indices in MeshData from
+        #    vispy.geometry.meshdata
+        # 3. Use mesh_data.get_texcoords_indices() here below.
+        tc = texcoords[self._visual.mesh_data.get_faces()]
+        self._texcoords_buffer.set_data(tc, convert=True)
+
     def _attach(self, visual):
-        # vertex shader
         vert_pre = visual._get_hook('vert', 'pre')
         vert_pre.add(self.coords_expr)
-        tc = self.texcoords[visual.mesh_data.get_faces()]
-        self._texcoords.set_data(tc, convert=True)
-        self.apply_coords['texcoords'] = self._texcoords
-        self.apply_coords['v_texcoords'] = self._texcoord_varying
 
-        # fragment shader
         frag_post = visual._get_hook('frag', 'post')
         frag_post.add(self.texture_expr)
-        self.apply_texture['texcoord'] = self._texcoord_varying
-        self.apply_texture['u_texture'] = Texture2D(self.texture)
+
+        self._attached = True
+        self._visual = visual
+
+        self._update_texcoords_buffer(self._texcoords)
 
     def _detach(self, visual):
         visual._get_hook('vert', 'pre').remove(self.coords_expr)
         visual._get_hook('frag', 'post').remove(self.texture_expr)
+        self._attached = False
+        self._visual = None

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -8,7 +8,15 @@ from vispy.visuals.filters import Filter
 
 
 class TextureFilter(Filter):
-    """Filter to apply a texture to a mesh."""
+    """Filter to apply a texture to a mesh.
+
+    Note the texture is applied by multiplying the texture color by the
+    Visual's produced color. By specifying `color="white"` when creating
+    a `MeshVisual` the result will be the unaltered texture value. Any
+    other color, including the default, will result in a blending of that
+    color and the color of the texture.
+
+    """
 
     def __init__(self, texture, texcoords, enabled=True):
         """Apply a texture on a mesh.


### PR DESCRIPTION
This PR implements texture support for MeshVisual as a filter.
Addresses #748 

- [x] Extend the MeshVisual vertex shader with a hook for passing the texture coordinates
- [x] Extend the MeshVisual fragment shader with a hook for applying the texture
- [x] Add a flag to toggle the texture
- [x] Add setters for texture coordinates and texture
- [x] Add a demo program
- [X] Add demo data to https://github.com/vispy/demo-data/
- [X] Use demo data from vispy/demo-data

Edit(2018-11-05): Update following #1462 enforcing unindexed buffers for meshes.