### PR TITLE
Changed vispy.plot.Fig.__init__() to allow passing 'keys' argument

### DIFF
--- a/vispy/plot/fig.py
+++ b/vispy/plot/fig.py
@@ -36,10 +36,11 @@ class Fig(SceneCanvas):
     PlotWidget : the axis widget for plotting
     SceneCanvas : the super class
     """
-    def __init__(self, bgcolor='w', size=(800, 600), show=True, **kwargs):
+    def __init__(self, bgcolor='w', size=(800, 600), show=True,
+                 keys='interactive', **kwargs):
         self._plot_widgets = []
         self._grid = None  # initialize before the freeze occurs
-        super(Fig, self).__init__(bgcolor=bgcolor, keys='interactive',
+        super(Fig, self).__init__(bgcolor=bgcolor, keys=keys,
                                   show=show, size=size, **kwargs)
         self._grid = self.central_widget.add_grid()
         self._grid._default_class = PlotWidget


### PR DESCRIPTION
(previously forced to 'interactive' in call to super().__init__()).

I couldn't figure out how else to pass key events up to a PyQt5 QMainWindow.