### PR TITLE
Fix IsocurveVisual to use scikit-image instead of matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ install:
         conda install --yes pyopengl scipy numpy$NUMPY networkx;
         pip install -q numpydoc PySDL2;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          conda install --yes matplotlib jupyter pyqt=4 pillow decorator six;
+          conda install --yes matplotlib jupyter pyqt=4 pillow decorator six scikit-image;
           if [ "${PYTHON}" == "3.6" ]; then
             pip install -q freetype-py husl pypng cassowary imageio;
             rm -rf ${SRC_DIR}/vispy/ext/_bundled;
@@ -130,7 +130,7 @@ install:
             pip install -q mock;
           fi;
         else
-          conda install --yes matplotlib jupyter pyqt=4;
+          conda install --yes matplotlib jupyter pyqt=4 scikit-image;
           pip install -q mock;
         fi;
       fi;

--- a/vispy/testing/__init__.py
+++ b/vispy/testing/__init__.py
@@ -43,7 +43,7 @@ to determine what automatic tests are run.
 from ._testing import (SkipTest, requires_application, requires_ipython,  # noqa
                       requires_img_lib,  # noqa
                       has_backend, requires_pyopengl,  # noqa
-                      requires_scipy, has_matplotlib,  # noqa
+                      requires_scipy, has_matplotlib, has_skimage,  # noqa
                       save_testing_image, TestingCanvas, has_pyopengl,  # noqa
                       run_tests_if_main,
                       assert_is, assert_in, assert_not_in, assert_equal,

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -294,6 +294,16 @@ def has_matplotlib(version='1.2'):
     return has_mpl
 
 
+def has_skimage(version='0.11'):
+    """Determine if scikit-image is a usable version"""
+    try:
+        import skimage
+    except ImportError:
+        return False
+    sk_version = LooseVersion(skimage.__version__)
+    return sk_version >= LooseVersion(version)
+
+
 ###############################################################################
 # Visuals stuff
 

--- a/vispy/visuals/isocurve.py
+++ b/vispy/visuals/isocurve.py
@@ -18,7 +18,6 @@ _HAS_SKI = has_skimage()
 if _HAS_SKI:
     try:
         from skimage.measure import find_contours
-        _HAS_SKI = False
     except ImportError:
         _HAS_SKI = False
         find_contours = None

--- a/vispy/visuals/isocurve.py
+++ b/vispy/visuals/isocurve.py
@@ -10,10 +10,9 @@ from .line import LineVisual
 from ..color import ColorArray
 from ..color.colormap import _normalize, get_colormap
 from ..geometry.isocurve import isocurve
-from ..testing import has_skimage, has_matplotlib
+from ..testing import has_skimage
 
-# checking for matplotlib
-_HAS_MPL = has_matplotlib()
+# checking for scikit-image
 _HAS_SKI = has_skimage()
 if _HAS_SKI:
     try:
@@ -21,15 +20,6 @@ if _HAS_SKI:
     except ImportError:
         _HAS_SKI = False
         find_contours = None
-
-if _HAS_MPL:
-    try:
-        from matplotlib import _cntr as cntr
-    except ImportError:
-        import warnings
-        warnings.warn("VisPy is not yet compatible with matplotlib 2.2+")
-        _HAS_MPL = False
-        cntr = None
 
 
 class IsocurveVisual(LineVisual):
@@ -63,9 +53,6 @@ class IsocurveVisual(LineVisual):
         self._need_color_update = True
         self._need_level_update = True
         self._need_recompute = True
-        self._X = None
-        self._Y = None
-        self._iso = None
         self._level_min = None
         self._data_is_uniform = False
         self._lc = None
@@ -114,18 +101,6 @@ class IsocurveVisual(LineVisual):
             all locations in the scalar field equal to ``self.levels``.
         """
         self._data = data
-
-        # if using matplotlib isoline algorithm we have to check for meshgrid
-        # and we can setup the tracer object here
-        if _HAS_SKI:
-            if self._X is None or self._X.shape != data.shape:
-                self._X, self._Y = np.meshgrid(np.arange(data.shape[1]),
-                                               np.arange(data.shape[0]))
-        elif _HAS_MPL:
-            if self._X is None or self._X.shape != data.shape:
-                self._X, self._Y = np.meshgrid(np.arange(data.shape[1]),
-                                               np.arange(data.shape[0]))
-            self._iso = cntr.Cntr(self._X, self._Y, self._data.astype(float))
 
         if self._clim is None:
             self._clim = (data.min(), data.max())
@@ -177,11 +152,6 @@ class IsocurveVisual(LineVisual):
                 v, c = self._get_verts_and_connect(contours)
                 # swap row, column to column, row (x, y)
                 v[:, [0, 1]] = v[:, [1, 0]]
-                v += np.array([0.5, 0.5])
-            elif _HAS_MPL:
-                nlist = self._iso.trace(level, level, 0)
-                paths = nlist[:len(nlist)//2]
-                v, c = self._get_verts_and_connect(paths)
                 v += np.array([0.5, 0.5])
             else:
                 paths = isocurve(self._data.astype(float).T, level,


### PR DESCRIPTION
Fixes #1437 

I separated out the commits so if we want to temporarily support both MPL and skimage we can go back to the previous commit.