### PR TITLE
Fix mesh indexing mode

### DIFF
--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -198,8 +198,6 @@ class MeshVisual(Visual):
 
         # Define buffers
         self._vertices = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
-        self._normals = None
-        self._faces = IndexBuffer()
         self._normals = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
         self._ambient_light_color = Color((0.3, 0.3, 0.3, 1.0))
         self._light_dir = (10, 5, -5)
@@ -364,7 +362,6 @@ class MeshVisual(Visual):
             self._normals.set_data(normals, convert=True)
         else:
             self._normals.set_data(np.zeros((0, 3), dtype=np.float32))
-        self._index_buffer = None
         if md.has_vertex_color():
             colors = md.get_vertex_colors(indexed='faces')
             colors = colors.astype(np.float32)

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from .visual import Visual
 from .shaders import Function, FunctionChain
-from ..gloo import VertexBuffer, IndexBuffer
+from ..gloo import VertexBuffer
 from ..geometry import MeshData
 from ..color import Color, get_colormap
 from ..ext.six import string_types


### PR DESCRIPTION
MeshVisual currently seems to always reindex the vertex array as face-indexed vertices. This should rather be the decision of the caller for practical and perfomance reasons (e.g., glDrawEelements vs glDrawArrays).

This PR changes the behavior of MeshVisual to use whatever indexing was provided by the caller.

This allows the implementation of texture filters (#1444) and coming-up shading filters without workarounds.
