### PR TITLE
Enable EGL backend for headless rendering

### DIFF
--- a/vispy/app/backends/_egl.py
+++ b/vispy/app/backends/_egl.py
@@ -128,12 +128,6 @@ class ApplicationBackend(BaseApplicationBackend):
 
 # ------------------------------------------------------------------ canvas ---
 
-COMMON_ATTRIB_LIST = [egl.EGL_RED_SIZE, 8,
-                      egl.EGL_BLUE_SIZE, 8,
-                      egl.EGL_GREEN_SIZE, 8,
-                      egl.EGL_ALPHA_SIZE, 8,
-                      egl.EGL_COLOR_BUFFER_TYPE, egl.EGL_RGB_BUFFER,
-                      egl.EGL_SURFACE_TYPE, egl.EGL_PBUFFER_BIT]
 
 
 class CanvasBackend(BaseCanvasBackend):
@@ -150,7 +144,12 @@ class CanvasBackend(BaseCanvasBackend):
         p.context.shared.add_ref('egl', self)
         if p.context.shared.ref is self:
             # Store context information
-            attribs = COMMON_ATTRIB_LIST
+            attribs = [egl.EGL_RED_SIZE, 8,
+                       egl.EGL_BLUE_SIZE, 8,
+                       egl.EGL_GREEN_SIZE, 8,
+                       egl.EGL_ALPHA_SIZE, 8,
+                       egl.EGL_COLOR_BUFFER_TYPE, egl.EGL_RGB_BUFFER,
+                       egl.EGL_SURFACE_TYPE, egl.EGL_PBUFFER_BIT]
             api = None
             if 'es' in config['gl_backend']:
                 attribs.extend([egl.EGL_RENDERABLE_TYPE,

--- a/vispy/app/backends/_egl.py
+++ b/vispy/app/backends/_egl.py
@@ -135,6 +135,7 @@ COMMON_ATTRIB_LIST = [egl.EGL_RED_SIZE, 8,
                       egl.EGL_COLOR_BUFFER_TYPE, egl.EGL_RGB_BUFFER,
                       egl.EGL_SURFACE_TYPE, egl.EGL_PBUFFER_BIT]
 
+
 class CanvasBackend(BaseCanvasBackend):
 
     """ EGL backend for Canvas abstract class."""
@@ -152,7 +153,8 @@ class CanvasBackend(BaseCanvasBackend):
             attribs = COMMON_ATTRIB_LIST
             api = None
             if 'es' in config['gl_backend']:
-                attribs.extend([egl.EGL_RENDERABLE_TYPE, egl.EGL_OPENGL_ES2_BIT])
+                attribs.extend([egl.EGL_RENDERABLE_TYPE,
+                                egl.EGL_OPENGL_ES2_BIT])
                 api = egl.EGL_OPENGL_ES_API
             else:
                 attribs.extend([egl.EGL_RENDERABLE_TYPE, egl.EGL_OPENGL_BIT])

--- a/vispy/app/backends/_egl.py
+++ b/vispy/app/backends/_egl.py
@@ -129,7 +129,6 @@ class ApplicationBackend(BaseApplicationBackend):
 # ------------------------------------------------------------------ canvas ---
 
 
-
 class CanvasBackend(BaseCanvasBackend):
 
     """ EGL backend for Canvas abstract class."""

--- a/vispy/ext/egl.py
+++ b/vispy/ext/egl.py
@@ -218,6 +218,7 @@ _lib.eglCreateWindowSurface.argtypes = (c_void_p, c_void_p,
 _lib.eglCreatePbufferSurface.argtypes = (c_void_p, c_void_p, _POINTER(_c_int))
 _lib.eglCreateContext.argtypes = c_void_p, c_void_p, c_void_p, _POINTER(_c_int)
 _lib.eglMakeCurrent.argtypes = (c_void_p,) * 4
+_lib.eglBindAPI.argtypes = _c_int,
 _lib.eglSwapBuffers.argtypes = (c_void_p,) * 2
 _lib.eglDestroySurface.argtypes = (c_void_p,) * 2
 _lib.eglQueryString.argtypes = (c_void_p, _c_int)
@@ -355,6 +356,15 @@ def eglMakeCurrent(display, draw, read, context):
     res = _lib.eglMakeCurrent(display, draw, read, context)
     if res == EGL_FALSE:
         raise RuntimeError('Could not make the context current.')
+
+
+def eglBindAPI(api):
+    """ Set the current rendering API (OpenGL, OpenGL ES or OpenVG)
+    """
+    res = _lib.eglBindAPI(api)
+    if res == EGL_FALSE:
+        raise RuntimeError('Could not bind API %d' % api)
+    return res
 
 
 def eglSwapBuffers(display, surface):

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -497,7 +497,14 @@ class GlirParser(BaseGlirParser):
             self.capabilities['gl_version'] = gl.glGetParameter(gl.GL_VERSION)
             self.capabilities['max_texture_size'] = \
                 gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
-            this_version = self.capabilities['gl_version'].split(' ')[0]
+            this_version = self.capabilities['gl_version'].split(' ')
+            if this_version[0] == "OpenGL":
+                # For OpenGL ES, the version string has the format:
+                # "OpenGL ES <version number> <vendor-specific information>"
+                this_version = this_version[2]
+            else:
+                this_version = this_version[0]
+
             this_version = LooseVersion(this_version)
             if this_version < '2.1':
                 if os.getenv('VISPY_IGNORE_OLD_VERSION', '').lower() != 'true':


### PR DESCRIPTION
Hi,

Here's a few changes that re-enables the EGL backend and makes it usable for accelerated off-screen rendering. This makes my application, as well as vispy/examples/demo/gloo/offscreen.py able to utilize truly headless rendering using EGL, using both standard OpenGL and OpenGL ES. Only tested with recent NVIDIA drivers.