### PR TITLE
More flexible input for PolygonVisual

### DIFF
--- a/vispy/geometry/polygon.py
+++ b/vispy/geometry/polygon.py
@@ -85,6 +85,20 @@ class PolygonData(object):
 
         If no vertices or faces are specified, the function returns None.
         """
+        if self._edges is None:
+            npts = self._vertices.shape[0]
+            if np.any(self._vertices[0] != self._vertices[1]):
+                # start != end, so edges must wrap around to beginning.
+                edges = np.empty((npts, 2), dtype=np.uint32)
+                edges[:, 0] = np.arange(npts)
+                edges[:, 1] = edges[:, 0] + 1
+                edges[-1, 1] = 0
+            else:
+                # start == end; no wrapping required.
+                edges = np.empty((npts-1, 2), dtype=np.uint32)
+                edges[:, 0] = np.arange(npts)
+                edges[:, 1] = edges[:, 0] + 1
+            self._edges = edges
         return self._edges
 
     @edges.setter
@@ -113,20 +127,7 @@ class PolygonData(object):
         Triangulates the set of vertices and stores the triangles in faces and
         the convex hull in convex_hull.
         """
-        npts = self._vertices.shape[0]
-        if np.any(self._vertices[0] != self._vertices[1]):
-            # start != end, so edges must wrap around to beginning.
-            edges = np.empty((npts, 2), dtype=np.uint32)
-            edges[:, 0] = np.arange(npts)
-            edges[:, 1] = edges[:, 0] + 1
-            edges[-1, 1] = 0
-        else:
-            # start == end; no wrapping required.
-            edges = np.empty((npts-1, 2), dtype=np.uint32)
-            edges[:, 0] = np.arange(npts)
-            edges[:, 1] = edges[:, 0] + 1
-
-        tri = Triangulation(self._vertices, edges)
+        tri = Triangulation(self._vertices, self.edges)
         tri.triangulate()
         return tri.pts, tri.tris
 

--- a/vispy/geometry/polygon.py
+++ b/vispy/geometry/polygon.py
@@ -10,7 +10,7 @@ from .triangulation import Triangulation
 
 
 class PolygonData(object):
-    """Class for handling polygon data.
+    """Class for handling 2D polygon data.
     
     Parameters
     ----------
@@ -25,6 +25,7 @@ class PolygonData(object):
     def __init__(self, vertices=None, edges=None, faces=None):
         self._vertices = vertices
         self._edges = edges
+        self._auto_edges = None
         self.triangulation = None
 
     @property
@@ -59,6 +60,7 @@ class PolygonData(object):
         from these vertices and set them.
         """
         self._vertices = v
+        self._auto_edges = None
         self.triangulation = None
 
     @property
@@ -69,7 +71,10 @@ class PolygonData(object):
         If no edges were manually specified, then this property is generated
         by simply connecting the vertices in order to form a loop.
         """
-        if self._edges is None:
+        if self._edges is not None:
+            return self._edges
+        
+        if self._auto_edges is None:
             if self._vertices is None:
                 return None
             npts = self._vertices.shape[0]
@@ -84,13 +89,12 @@ class PolygonData(object):
                 edges = np.empty((npts-1, 2), dtype=np.uint32)
                 edges[:, 0] = np.arange(npts)
                 edges[:, 1] = edges[:, 0] + 1
-            self._edges = edges
-        return self._edges
+            self._auto_edges = edges
+        return self._auto_edges
 
     @edges.setter
-    def edges(self, e):
-        """
-        Ensures that all edges are valid.
-        """
-        self._edges = e
+    def edges(self, edges):
+        self._edges = edges
+        if edges is not None:
+            self._auto_edges = None
         self.triangulation = None

--- a/vispy/visuals/polygon.py
+++ b/vispy/visuals/polygon.py
@@ -75,22 +75,21 @@ class PolygonVisual(CompoundVisual):
         if self._polygon_data is None:
             return
         if not self._color.is_blank and self._triangulate:
-            pts, tris = self._polygon_data.triangulate()
+            pts, tris = self._polygon_data.faces
             set_state(polygon_offset_fill=False)
             self._mesh.set_data(vertices=pts, faces=tris.astype(np.uint32),
                                 color=self._color.rgba)
         elif not self._color.is_blank:
-            self.mesh.set_data(vertices=self._pos,
+            self.mesh.set_data(vertices=self.pos,
                                color=self._color.rgba)
 
         if not self._border_color.is_blank:
-            # Close border if it is not already.
-            border_pos = self.polygon_data.vertices
-            border_connect = self.polygon_data.edges
-            self._border.set_data(pos=border_pos, connect=border_connect,
-                                  color=self._border_color.rgba,
-                                  width=self._border_width)
-
+            self._border.set_data(
+                pos=self.polygon_data.vertices, 
+                connect=self.polygon_data.edges,
+                color=self._border_color.rgba,
+                width=self._border_width
+            )
             self._border.update()
 
     @property


### PR DESCRIPTION
* PolygonVisual can optionally receive PolygonData as its input rather than just an array of positions. This allows more complex edge specification.
* PolygonData makes use of its `edges` property (previously it was ignored).