### PR TITLE
FIX: Memory leak in LinePlot.set_data (#1407)

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -590,16 +590,16 @@ class MarkersVisual(Visual):
     def symbol(self, symbol):
         if symbol == self._symbol:
             return
-        if symbol is not None:
+        if (symbol is not None and self._symbol is None and
+                self._data is not None):
             # Allow user to configure symbol after a set_data call with
             # symbol=None. This can break down if the user does a consecutive
             # marker.symbol = 'disc'
             # marker.symbol = None
             # without drawing. At this point the memory leaking ensues
             # but this case is unlikely/makes no sense.
-            if self._symbol is None and self._data is not None:
-                self._vbo.set_data(self._data)
-                self.shared_program.bind(self._vbo)
+            self._vbo.set_data(self._data)
+            self.shared_program.bind(self._vbo)
         self._symbol = symbol
         if symbol is None:
             self._marker_fun = None

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -590,6 +590,16 @@ class MarkersVisual(Visual):
     def symbol(self, symbol):
         if symbol == self._symbol:
             return
+        if symbol is not None:
+            # Allow user to configure symbol after a set_data call with
+            # symbol=None. This can break down if the user does a consecutive
+            # marker.symbol = 'disc'
+            # marker.symbol = None
+            # without drawing. At this point the memory leaking ensues
+            # but this case is unlikely/makes no sense.
+            if self._symbol is None and self._data is not None:
+                self._vbo.set_data(self._data)
+                self.shared_program.bind(self._vbo)
         self._symbol = symbol
         if symbol is None:
             self._marker_fun = None

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -572,8 +572,14 @@ class MarkersVisual(Visual):
         data['a_size'] = size
         self.shared_program['u_antialias'] = self.antialias  # XXX make prop
         self._data = data
-        self._vbo.set_data(data)
-        self.shared_program.bind(self._vbo)
+        if self._symbol is not None:
+            # If we have no symbol set, we skip drawing (_prepare_draw
+            # returns False). This causes the GLIR queue to not flush,
+            # and thus the GLIR queue fills with VBO DATA commands, resulting
+            # in a "memory leak". Thus only set the VertexBuffer data if we
+            # are actually going to draw.
+            self._vbo.set_data(data)
+            self.shared_program.bind(self._vbo)
         self.update()
 
     @property


### PR DESCRIPTION
Fix memory leak in LinePlot (#1407) when no markers are to be rendered.