### PR TITLE
Use matplotlib colormaps (if installed)

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -452,7 +452,10 @@ class MatplotlibColormap(Colormap):
 
     def __init__(self, name):
         assert has_matplotlib()
-        from matplotlib.cm import ScalarMappable
+        from matplotlib.cm import ScalarMappable, cmap_d
+        if name not in sorted(cmap_d):
+            raise KeyError("Possible values for Matplotlib colormaps are"
+                           " %s" % ', '.join(sorted(cmap_d)))
 
         vec = ScalarMappable(cmap=name).to_rgba(np.arange(LUT_len))
         Colormap.__init__(self, vec)

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1113,10 +1113,10 @@ def get_colormap(name, *args, **kwargs):
             raise TypeError('colormap must be a Colormap or string name')
         if name in _colormaps:  # vispy cmap
             cmap = _colormaps[name]
-        else:
-            if has_matplotlib:  # matplotlib colormap
+        else:  # matplotlib colormap
+            try:
                 cmap = MatplotlibColormap(name)
-            else:
+            except:
                 raise KeyError('colormap name %s not found' % name)
 
         if inspect.isclass(cmap):

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -451,9 +451,7 @@ class MatplotlibColormap(Colormap):
     """
 
     def __init__(self, name):
-        from matplotlib.cm import ScalarMappable, cmap_d
-        assert has_matplotlib()
-        assert name in cmap_d
+        from matplotlib.cm import ScalarMappable
 
         vec = ScalarMappable(cmap=name).to_rgba(np.arange(LUT_len))
         Colormap.__init__(self, vec)

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -451,11 +451,9 @@ class MatplotlibColormap(Colormap):
     """
 
     def __init__(self, name):
-        assert has_matplotlib()
         from matplotlib.cm import ScalarMappable, cmap_d
-        if name not in sorted(cmap_d):
-            raise KeyError("Possible values for Matplotlib colormaps are"
-                           " %s" % ', '.join(sorted(cmap_d)))
+        assert has_matplotlib()
+        assert name in cmap_d
 
         vec = ScalarMappable(cmap=name).to_rgba(np.arange(LUT_len))
         Colormap.__init__(self, vec)

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -11,6 +11,7 @@ from .color_array import ColorArray
 from ..ext.six import string_types
 from ..ext.cubehelix import cubehelix
 from ..ext.husl import husl_to_rgb
+from ..testing import has_matplotlib
 import vispy.gloo
 
 ###############################################################################
@@ -438,6 +439,23 @@ class Colormap(BaseColormap):
         else:
             texture_LUT = None
         return texture_LUT
+
+
+class MatplotlibColormap(Colormap):
+    """Use matplotlib colormaps if installed.
+
+    Parameters
+    ----------
+    name : string
+        Name of the colormap.
+    """
+
+    def __init__(self, name):
+        assert has_matplotlib()
+        from matplotlib.cm import ScalarMappable
+
+        vec = ScalarMappable(cmap=name).to_rgba(np.arange(LUT_len))
+        Colormap.__init__(self, vec)
 
 
 class CubeHelixColormap(Colormap):

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1110,9 +1110,13 @@ def get_colormap(name, *args, **kwargs):
     else:
         if not isinstance(name, string_types):
             raise TypeError('colormap must be a Colormap or string name')
-        if name not in _colormaps:
-            raise KeyError('colormap name %s not found' % name)
-        cmap = _colormaps[name]
+        if name in _colormaps:  # vispy cmap
+            cmap = _colormaps[name]
+        else:
+            if has_matplotlib:  # matplotlib colormap
+                cmap = MatplotlibColormap(name)
+            else:
+                raise KeyError('colormap name %s not found' % name)
 
         if inspect.isclass(cmap):
             cmap = cmap(*args, **kwargs)

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1112,7 +1112,10 @@ def get_colormap(name, *args, **kwargs):
         if name in _colormaps:  # vispy cmap
             cmap = _colormaps[name]
         elif has_matplotlib():  # matplotlib cmap
-            cmap = MatplotlibColormap(name)
+            try:
+                cmap = MatplotlibColormap(name)
+            except ValueError:
+                raise KeyError('colormap name %s not found' % name)
         else:
             raise KeyError('colormap name %s not found' % name)
 

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1111,11 +1111,10 @@ def get_colormap(name, *args, **kwargs):
             raise TypeError('colormap must be a Colormap or string name')
         if name in _colormaps:  # vispy cmap
             cmap = _colormaps[name]
-        else:  # matplotlib colormap
-            try:
-                cmap = MatplotlibColormap(name)
-            except:
-                raise KeyError('colormap name %s not found' % name)
+        elif has_matplotlib():  # matplotlib cmap
+            cmap = MatplotlibColormap(name)
+        else:
+            raise KeyError('colormap name %s not found' % name)
 
         if inspect.isclass(cmap):
             cmap = cmap(*args, **kwargs)


### PR DESCRIPTION
Note that in [line.py](https://github.com/vispy/vispy/blob/master/vispy/visuals/line/line.py#L231) there's a `try/except` which is used to switch between colormaps and unique color. So I add a `KeyError` inside the `MatplotlibColormap` class but there's probably a better way to handle `KeyError`.

Small script to test it :
```python
import numpy as np

from vispy import scene
from vispy import app
from vispy.scene.cameras import PanZoomCamera

cam = PanZoomCamera(rect=(0, 0, 20, 10))
sc = scene.SceneCanvas(bgcolor='black', show=True)
wc = sc.central_widget.add_view(camera=cam)

data = np.arange(200).reshape(10, 20).astype(float)
im_red = scene.visuals.Image(data, parent=wc.scene, cmap='tab20b')

app.run()

```
![image](https://user-images.githubusercontent.com/15892073/42059384-414663b4-7af1-11e8-8cdc-d9b6ec48365e.png)
