### PR TITLE
Make events only propagate to callbacks that were present when the event was emitted

### DIFF
--- a/vispy/util/event.py
+++ b/vispy/util/event.py
@@ -439,7 +439,7 @@ class EventEmitter(object):
                 return event
 
             rem = []
-            for cb in self._callbacks:
+            for cb in self._callbacks[:]:
                 if isinstance(cb, tuple):
                     obj = cb[0]()
                     if obj is None:


### PR DESCRIPTION
Fixes the "nasty" bug described in #1033, which was caused by an event callback changing the list of callbacks.