### PR TITLE
ImageVisual and masked array

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -233,7 +233,7 @@ class ImageVisual(Visual):
         image : array-like
             The image data.
         """
-        data = np.asarray(image)
+        data = image if np.ma.is_masked(image) else np.asarray(image)
         if self._data is None or self._data.shape != data.shape:
             self._need_vertex_update = True
         self._data = data
@@ -400,6 +400,11 @@ class ImageVisual(Visual):
             # deal with clim on CPU b/c of texture depth limits :(
             # can eventually do this by simulating 32-bit float... maybe
             clim = self._clim
+            # deal with masked_array
+            if np.ma.is_masked(data):
+                mask = data.mask
+                data = np.array(data)
+                data[mask] = np.nan
             is_num = np.isfinite(data)
             if isinstance(clim, string_types) and clim == 'auto':
                 clim = np.min(data[is_num]), np.max(data[is_num])

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -400,8 +400,9 @@ class ImageVisual(Visual):
             # deal with clim on CPU b/c of texture depth limits :(
             # can eventually do this by simulating 32-bit float... maybe
             clim = self._clim
+            is_num = np.isfinite(data)
             if isinstance(clim, string_types) and clim == 'auto':
-                clim = np.min(data), np.max(data)
+                clim = np.min(data[is_num]), np.max(data[is_num])
             clim = np.asarray(clim, dtype=np.float32)
             data = data - clim[0]  # not inplace so we don't modify orig data
             if clim[1] - clim[0] > 0:


### PR DESCRIPTION
Hi @djhoese 

This is not a fully working pull request. Right now :
1. It fix `ImageVisual` if there's a `np.nan` in the 2D image (beacause of the `clim = np.min(data), np.max(data)`)
2. If a masked_array is passed, masked values are set to `np.nan`

IMO the intended behavior would to to discard nan pixels (as discussed in #1509 ). For now, nan pixels are set to 0. (somewhere... I can't figure it out). Do you have an idea how to discard those pixels?

(Note : OpenGL seems to have a [isnan](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/isnan.xhtml) function but it's not working for me. [Here](https://github.com/metsci/glimpse/blob/ec72fae680de6334bdf64aea5cc950f3c245e304/core/src/main/resources/shaders/colormap/tagged_colorscale_shader.fs#L68) they said that `x != x` could be used instead)

```py
import numpy as np

from vispy import scene
from vispy.scene.cameras import PanZoomCamera

n = 10

# data = np.random.rand(10, 10)
data = np.arange(100).reshape(10, 10).astype(np.float32)
y, x = np.ogrid[-n / 2:n / 2, -n / 2:n / 2]
mask = x**2 + y**2 >= (n / 2)**2
data = np.ma.masked_array(data, mask=mask)

# Vispy :
cam = PanZoomCamera(rect=(0, 0, n, n))
sc = scene.SceneCanvas(bgcolor='black', show=True)
wc = sc.central_widget.add_view(camera=cam)
im_vispy = scene.visuals.Image(data, parent=wc.scene)
sc.app.run()
```
![image](https://user-images.githubusercontent.com/15892073/44428367-258a5180-a562-11e8-9be9-674933adf2e7.png)

closes #1509 