### PR TITLE
multi-radii tubes

### DIFF
--- a/examples/basics/visuals/tube.py
+++ b/examples/basics/visuals/tube.py
@@ -26,6 +26,10 @@ points3[:, 2] += 30
 points4 = points1.copy()
 points4[:, 0] += 41.
 
+points5 = points1.copy()
+points5[:, 0] += 20.4
+points5[:, 2] += 15
+
 colors = np.linspace(0, 1, len(points1))
 colors = np.array([hsv_to_rgb(c, 1, 1) for c in colors])
 
@@ -56,10 +60,22 @@ l4 = scene.visuals.Tube(points4,
                         tube_points=8,
                         mode='lines')
 
+# generate sine wave radii
+radii = np.sin(2 * np.pi * 440 * np.arange(points5.shape[0]) / 44000)
+radii = (radii + 1.5) / 2
+
+l5 = scene.visuals.Tube(points5,
+                        radius=radii,
+                        color='white',
+                        shading='smooth',
+                        closed=True,
+                        tube_points=8)
+
 view.add(l1)
 view.add(l2)
 view.add(l3)
 view.add(l4)
+view.add(l5)
 view.camera = scene.TurntableCamera()
 # tube does not expose its limits yet
 view.camera.set_range((-20, 20), (-20, 20), (-20, 20))

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -6,6 +6,8 @@ from numpy.linalg import norm
 from ..util.transforms import rotate
 from ..color import ColorArray
 
+import collections
+
 
 class TubeVisual(MeshVisual):
     """Displays a tube around a piecewise-linear path.
@@ -19,8 +21,9 @@ class TubeVisual(MeshVisual):
     points : ndarray
         An array of (x, y, z) points describing the path along which the
         tube will be extruded.
-    radius : float
-        The radius of the tube. Defaults to 1.0.
+    radius : float | ndarray
+        The radius of the tube. Use array of floats as input to set radii of
+        points individually. Defaults to 1.0.
     closed : bool
         Whether the tube should be closed, joining the last point to the
         first. Defaults to False.
@@ -59,18 +62,25 @@ class TubeVisual(MeshVisual):
 
         segments = len(points) - 1
 
+        # if single radius, convert to list of radii
+        if not isinstance(radius, collections.Iterable):
+            radius = [radius] * len(points)
+        elif len(radius) != len(points):
+            raise ValueError('Length of radii list must match points.')
+
         # get the positions of each vertex
         grid = np.zeros((len(points), tube_points, 3))
         for i in range(len(points)):
             pos = points[i]
             normal = normals[i]
             binormal = binormals[i]
+            r = radius[i]
 
             # Add a vertex for each point on the circle
             v = np.arange(tube_points,
                           dtype=np.float) / tube_points * 2 * np.pi
-            cx = -1. * radius * np.cos(v)
-            cy = radius * np.sin(v)
+            cx = -1. * r * np.cos(v)
+            cy = r * np.sin(v)
             grid[i] = (pos + cx[:, np.newaxis]*normal +
                        cy[:, np.newaxis]*binormal)
 

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -56,7 +56,8 @@ class TubeVisual(MeshVisual):
                  face_colors=None,
                  mode='triangles'):
 
-        points = np.array(points)
+        # make sure we are working with floats
+        points = np.array(points).astype(float)
 
         tangents, normals, binormals = _frenet_frames(points, closed)
 


### PR DESCRIPTION
In the current master TubeVisuals can only have a single radius. This PR introduces the option to pass a list of radii to `vispy.scene.visuals.Tube` - one for each point of the tube.

It also forces coordinates into `floats` - otherwise `tangents /= mags[:, np.newaxis]` in [tube.py](https://github.com/vispy/vispy/blob/a6ec64bb7b56739b463e3c16245a31940ca4f5f7/vispy/visuals/tube.py#L123) throws a TypeError.

A minimal example:
```Python
import vispy
import numpy as np

# Create canvas
canvas = vispy.scene.SceneCanvas()
view = canvas.central_widget.add_view()
view.camera = vispy.scene.ArcballCamera()
canvas.show()

# Create tube with 5 points and 5 individual radii
coords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]])
tu = vispy.scene.visuals.Tube(coords, radius=[1, 4, 2, 3, 1])

# Add tube to canvas and set range
view.add(tu)
view.camera.set_range()
```

![tube_w_radii](https://user-images.githubusercontent.com/7161148/45257224-96bb6880-b39a-11e8-8868-52eb86ef1357.png)