### PR TITLE
BUGFIX: Properly update opacity in `VisualNode`s

### DIFF
--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -17,7 +17,7 @@ import weakref
 
 from .. import visuals
 from .node import Node
-from ..visuals.filters import ColorFilter, PickingFilter
+from ..visuals.filters import Alpha, PickingFilter
 
 
 class VisualNode(Node):
@@ -28,7 +28,7 @@ class VisualNode(Node):
         Node.__init__(self, parent=parent, name=name,
                       transforms=self.transforms)
         self.interactive = False
-        self._opacity_filter = ColorFilter()
+        self._opacity_filter = Alpha()
         self.attach(self._opacity_filter)
 
         self._id = VisualNode._next_id
@@ -38,7 +38,7 @@ class VisualNode(Node):
         self.attach(self._picking_filter)
 
     def _update_opacity(self):
-        self._opacity_filter.filter = (1, 1, 1, self._opacity)
+        self._opacity_filter.alpha = self._opacity
         self.update()
 
     def _set_clipper(self, node, clipper):

--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -38,7 +38,8 @@ class VisualNode(Node):
         self.attach(self._picking_filter)
 
     def _update_opacity(self):
-        self._opacity_filter.color = (1, 1, 1, self._opacity)
+        self._opacity_filter.filter = (1, 1, 1, self._opacity)
+        self.update()
 
     def _set_clipper(self, node, clipper):
         """Assign a clipper that is inherited from a parent node.


### PR DESCRIPTION
# Description
Fixes a bug in `VisualNode`'s `_update_opacity` function wherein opacity was being updated by setting a `ColorFilter`'s `color` property when the correct property to set was `filter`. Additionally calls the visual's `update` method upon filter change.

Since opacity only affects the `alpha` channel, additionally opts to replace the overly explicit `ColorFilter` with an `Alpha` filter. This prevents tampering with the RGB channels in the private filter.