### PR TITLE
Use proper exception NotImplementedError

### DIFF
--- a/vispy/glsl/build-spatial-filters.py
+++ b/vispy/glsl/build-spatial-filters.py
@@ -92,7 +92,7 @@ class SpatialFilter(object):
             ``x`` : 0 < float < ceil(self.radius)
                 Distance to be used to compute weight.
         '''
-        raise NotImplemented
+        raise NotImplementedError
 
     def kernel(self, size=4*512):
         radius = self.radius


### PR DESCRIPTION
I think NotImplementedError was intended.

See:
https://docs.python.org/3.7/library/exceptions.html#NotImplementedError
https://docs.python.org/3.7/library/constants.html#NotImplemented