### PR TITLE
Fix flake errors

### DIFF
--- a/examples/basics/visuals/text_visual.py
+++ b/examples/basics/visuals/text_visual.py
@@ -55,7 +55,7 @@ class Canvas(app.Canvas):
         big_test_string += '\t-\t\\n\n'
         big_test_string += '\t-\t\\v\n'
         big_test_string += '\t-\t\\t\n'
-        big_test_string += '\t-\t\etc..\v'
+        big_test_string += '\t-\tetc..\v'
         big_test_string += 'So \bif \fthis \rlooks correct, somebody did a \n'
         big_test_string += 'decent job and deserves a beer '
         big_test_string += 'and a digital salute\a! ;)'
@@ -72,7 +72,7 @@ class Canvas(app.Canvas):
             'Hello (scroll/arrows to change text properties)|\\|how are u',
             'Hello (scroll/arrows to change text properties)|\'|how are u',
             'Hello (scroll/arrows to change text properties)|\"|how are u',
-            'Hello (scroll/arrows to change text properties)|\?|how are u',
+            'Hello (scroll/arrows to change text properties)|?|how are u',
             big_test_string,
         ]
         self.str_ind = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 120
+ignore = E226,E241,E265,E266,W291,W293,W503,F999,E305,F405,W504
+exclude =
+    six.py,glfw.py,_proxy.py,_es2.py,_gl2.py,_pyopengl2.py,
+    _constants.py,png.py,decorator.py,ipy_inputhook.py,
+    experimental,wiki,_old,mplexporter.py,cubehelix.py,cassowary
+

--- a/vispy/glsl/build-spatial-filters.py
+++ b/vispy/glsl/build-spatial-filters.py
@@ -92,7 +92,7 @@ class SpatialFilter(object):
             ``x`` : 0 < float < ceil(self.radius)
                 Distance to be used to compute weight.
         '''
-        raise NotImplemented
+        raise NotImplementedError
 
     def kernel(self, size=4*512):
         radius = self.radius

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -156,13 +156,6 @@ def _flake():
         sys.argv[1:] = ['vispy', 'examples', 'make']
     else:
         sys.argv[1:] = [op.basename(import_dir)]
-    sys.argv.append('--ignore=E226,E241,E265,E266,W291,W293,W503,F999,E305,'
-                    'F405')
-    sys.argv.append('--exclude=six.py,glfw.py,'
-                    '_proxy.py,_es2.py,_gl2.py,_pyopengl2.py,'
-                    '_constants.py,png.py,decorator.py,ipy_inputhook.py,'
-                    'experimental,wiki,_old,mplexporter.py,cubehelix.py,'
-                    'cassowary')
     try:
         try:
             from flake8.main import main


### PR DESCRIPTION
This PR fixes flake errors that have been causing travis to fail. As part of this I moved the exclusions and ignored rules to setup.cfg so they are a little less hidden (or at least I think so). I also added W504 to the list of ignored rules which I think is a default ignore in the recent versions of flake8.

This PR also changes a `raise NotImplemented` to a `raise NotImplementedError` to satisfy flake8.

@mkkb There are still errors in `text_visual.py` that you semi-recently made changes to. The main issues are a `\e` and a `\?`. Any idea if those are necessary?