### PR TITLE
Add element-wise rotation to TextVisual

### DIFF
--- a/vispy/visuals/tests/test_text.py
+++ b/vispy/visuals/tests/test_text.py
@@ -19,6 +19,7 @@ def test_text():
         
         text.text = ['foo', 'bar']
         text.pos = [10, 10]  # should auto-replicate
+        text.rotation = [180, 270]
         try:
             text.pos = [10]
         except Exception:

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -482,7 +482,7 @@ class TextVisual(Visual):
 
     @rotation.setter
     def rotation(self, rotation):
-        self._rotation = rotation * np.pi / 180.
+        self._rotation = np.asarray(rotation) * np.pi / 180.
         self.update()
 
     @property
@@ -543,15 +543,17 @@ class TextVisual(Visual):
             if isinstance(_rot, (int, float)):
                 _rot = np.full((pos.shape[0],), self._rotation)
             _rot = np.asarray(_rot)
-            assert len(_rot) == pos.shape[0]
+            if _rot.shape[0] < n_text:
+                _rep = [1] * (len(_rot) - 1) + [n_text - len(_rot) + 1]
+                _rot = np.repeat(_rot, _rep, axis=0)
             _rot = np.repeat(_rot[:n_text], repeats, axis=0)
             self.shared_program['a_rotation'] = _rot.astype(np.float32)
             # Position
             if pos.shape[0] < n_text:
-                pos = np.repeat(pos, [1]*(len(pos)-1) + [n_text-len(pos)+1],
-                                axis=0)
+                _rep = [1] * (len(pos) - 1) + [n_text - len(pos) + 1]
+                pos = np.repeat(pos, _rep, axis=0)
             pos = np.repeat(pos[:n_text], repeats, axis=0)
-            assert pos.shape[0] == self._vertices.size
+            assert pos.shape[0] == self._vertices.size == len(_rot)
             self.shared_program['a_pos'] = pos
             self._pos_changed = False
         transforms = self.transforms


### PR DESCRIPTION
For now, only a unique rotation can be set to `TextVisual`. This PR allows to set an individual rotation to each text element.

```python
import numpy as np

from vispy import scene
from vispy import app

# Camera and scene canvas :
cam = scene.cameras.PanZoomCamera(rect=(-2, -1.5, 4, 3))
sc = scene.SceneCanvas(bgcolor='white')
wc = sc.central_widget.add_view(camera=cam)


n_s = 20
theta = np.linspace(0, 2 * np.pi, n_s, endpoint=False)
text = ['Text_%i' % i for i in range(n_s)]
xy = np.c_[np.cos(theta), np.sin(theta)]

text_v = scene.visuals.Text(text=text, pos=xy, parent=wc.scene,
                            rotation=np.rad2deg(theta[::-1]))

sc.show()
app.run()
```

![image](https://user-images.githubusercontent.com/15892073/48969098-7bd6b880-efc7-11e8-9df7-882768062c49.png)
