### PR TITLE
Fixed a bug in linking two flycameras

### DIFF
--- a/vispy/scene/cameras/fly.py
+++ b/vispy/scene/cameras/fly.py
@@ -52,8 +52,8 @@ class FlyCamera(PerspectiveCamera):
 
     """
 
-    # Linking this camera likely not to work very well
-    _state_props = PerspectiveCamera._state_props + ('rotation', )
+    # Using _rotation1 and _rotation2 for camera states instead of _rotation
+    _state_props = PerspectiveCamera._state_props + ('rotation1', 'rotation2')
 
     def __init__(self, fov=60, rotation=None, **kwargs):
 
@@ -73,7 +73,7 @@ class FlyCamera(PerspectiveCamera):
         PerspectiveCamera.__init__(self, fov=fov, **kwargs)
 
         # Set camera attributes
-        self.rotation = rotation if (rotation is not None) else Quaternion()
+        self.rotation1 = rotation.normalize() if (rotation is not None) else Quaternion()
 
         # To store data at start of interaction
         self._event_value = None
@@ -112,8 +112,31 @@ class FlyCamera(PerspectiveCamera):
 
     @rotation.setter
     def rotation(self, value):
+        print("rotation.setter called, use rotation1.setter instead")
+
+    @property
+    def rotation1(self):
+        """
+        rotation1 records confirmed camera rotation
+        """
+        return self._rotation1
+    
+    @rotation1.setter
+    def rotation1(self, value):
         assert isinstance(value, Quaternion)
-        self._rotation1 = value
+        self._rotation1 = value.normalize()
+
+    @property
+    def rotation2(self):
+        """
+        rotation2 records on going camera rotation.
+        """
+        return self._rotation2
+    
+    @rotation2.setter
+    def rotation2(self, value):
+        assert isinstance(value, Quaternion)
+        self._rotation2 = value.normalize()
 
     @property
     def auto_roll(self):

--- a/vispy/scene/cameras/fly.py
+++ b/vispy/scene/cameras/fly.py
@@ -378,6 +378,7 @@ class FlyCamera(PerspectiveCamera):
             for dim in val_dims[1:]:
                 factor = 1.0
                 vec[dim-1] = val * factor
+            event.handled = True
 
     def viewbox_mouse_event(self, event):
         """ViewBox mouse event handler
@@ -412,6 +413,7 @@ class FlyCamera(PerspectiveCamera):
             # Apply rotation
             self._rotation1 = (self._rotation2 * self._rotation1).normalize()
             self._rotation2 = Quaternion()
+            event.handled = True
         elif not self._timer.running:
             # Ensure the timer runs
             self._timer.start()
@@ -444,6 +446,7 @@ class FlyCamera(PerspectiveCamera):
 
                 # Apply to global quaternion
                 self._rotation2 = (q_el.normalize() * q_az).normalize()
+                event.handled = True
 
             elif 2 in event.buttons and keys.CONTROL in modifiers:
                 # zoom --> fov
@@ -456,6 +459,7 @@ class FlyCamera(PerspectiveCamera):
                 d = p2c - p1c
                 fov = self._event_value * math.exp(-0.01*d[1])
                 self._fov = min(90.0, max(10, fov))
+                event.handled = True
 
         # Make transform be updated on the next timer tick.
         # By doing it at timer tick, we avoid shaky behavior


### PR DESCRIPTION
See issue #1554. The bug is fixed as discussed.
- Replaced actual `rotation.setter` function by a warning of using `rotation1.setter instead`
- Added property `rotation1` and `rotation1.setter`
- Added property `rotation2` and `rotation2.setter`
- Normalizes Quaternion before assigning.