### PR TITLE
WIP: Test osmesa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,10 @@ install:
     - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
         git clone git://github.com/glfw/glfw.git;
         cd glfw;
-        cmake -DCMAKE_INSTALL_PREFIX=$HOME -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
+        cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
         make install;
         cd ~;
-        export GLFW_LIBRARY=${HOME}/lib/libglfw.so;
+        export GLFW_LIBRARY=${CONDA_PREFIX}/lib/libglfw.so;
       fi
 
     # Install OSMesa

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
-    - env: PYTHON=2.7 DEPS=full TEST=osmesa
+    - env: PYTHON=3.6 DEPS=full TEST=osmesa
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON=3.6 DEPS=full TEST=osmesa
-      addons:
-        apt:
-          packages:
-            - *full_apt
+    #  addons:
+    #    apt:
+    #      packages:
+    #        - *full_apt
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 # use container-based infrastructure
-sudo : false
 dist: trusty
 
 # liblgfw2 is not whitelisted by Travis, so we don't try using it here (not usable anyway)

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,8 @@ before_script:
     - if [ "${TEST}" == "osmesa" ]; then
         export LD_LIBRARY_PATH=$HOME/osmesa/lib;
         export LIBRARY_PATH=$HOME/osmesa/lib;
-        export VISPY_GL_LIB=$HOME/osmesa/lib/libOSMesa.so
-        export OSMESA_LIBRARY=$HOME/osmesa/lib/libOSMesa.so
+        export VISPY_GL_LIB=$HOME/osmesa/lib/libOSMesa.so;
+        export OSMESA_LIBRARY=$HOME/osmesa/lib/libOSMesa.so;
       fi;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - &mesa_apt [libgl1-mesa-dri]
     - &full_apt [libgl1-mesa-dri, libegl1-mesa, cmake, xorg-dev, libglu1-mesa-dev, mercurial, libdbus-1-dev, libgl1-mesa-dev, libglu1-mesa-dev, libpulse-dev, libx11-dev, libxcursor-dev, libxext-dev, libxi-dev, libxinerama-dev, libxrandr-dev, libxss-dev, libxt-dev, libxv-dev, libxxf86vm-dev, libasound2-dev, libts-dev, libudev-dev, libsdl2-2.0-0]
-
+    - &python_apt [python3-pip, python3-numpy, python3-opengl, python3-scipy, python3-networkx, python3-sdl2, python3-matplotlib, python3-jupyter-client, python3-jupyter-core, python3-jupyter-console, python3-jupyter-notebook, python3-pyqt4, python3-pil, python3-decorator, python3-six, python3-skimage, python3-nose, python3-pytest, cython3, python3-flake8, python3-mock]
 # Size testing can be skipped by adding "[size skip]" within a commit message.
 
 matrix:
@@ -19,26 +19,32 @@ matrix:
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
-    - env: PYTHON=3.6 DEPS=full TEST=osmesa
-    #  addons:
-    #    apt:
-    #      packages:
-    #        - *full_apt
+    - python: 3.6
+      env:
+        - PYTHON=3.6 DEPS=full TEST=osmesa
+      addons:
+        apt:
+          packages:
+            - *full_apt
+            - *python_apt
 
 
 before_install:
-    - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b -p ~/anaconda
-    - export PATH=~/anaconda/bin:$PATH
-    - conda config --add channels conda-forge
-    - conda update --yes --quiet conda
+    #- wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    #- chmod +x miniconda.sh
+    #- ./miniconda.sh -b -p ~/anaconda
+    #- export PATH=~/anaconda/bin:$PATH
+    #- conda config --add channels conda-forge
+    #- conda update --yes --quiet conda
     - SRC_DIR=$(pwd)
 
 install:
     # Install numpy, flake
-    - conda create -n testenv --yes --quiet pip python=$PYTHON pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
-    - source activate testenv;
+    #- conda create -n testenv --yes --quiet pip python=$PYTHON pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
+    #- source activate testenv;
+    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+        pip install numpydoc coveralls pytest-cov pytest-sugar;
+      fi;
 
     # On Python3, install system-wide copies of bundled libraries instead
     # Also install PyQt4, imaging (PIL or pillow), scipy, mpl, egl

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
     - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
         git clone git://github.com/glfw/glfw.git;
         cd glfw;
-        cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_INSTALL_LIBDIR:PATH=$CONDA_PREFIX/lib -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
+        cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_INSTALL_LIBDIR:PATH=$CONDA_PREFIX/lib -DGLFW_CONTEXT_CREATION_API=GLFW_OSMESA_CONTEXT_API -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
         make install;
         cd ~;
         export GLFW_LIBRARY=${CONDA_PREFIX}/lib/libglfw.so;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,38 +15,6 @@ addons:
 
 matrix:
   include:
-    - env: PYTHON=3.6 DEPS=minimal TEST=standard
-      os: osx
-      language: generic
-    - env: PYTHON=3.6 DEPS=full TEST=standard
-      os: osx
-      language: generic
-# Travis Examples are extremely slow for OSX (times out)
-#    - env: PYTHON=3.6 DEPS=full TEST=examples
-#      os: osx
-#      language: generic
-    - env: PYTHON=3.6 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
-      addons:
-        apt:
-          packages:
-    - env: PYTHON=3.6 DEPS=full TEST=standard
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
-            - *full_apt
-    - env: PYTHON=3.6 DEPS=full TEST=examples  # test examples
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
-            - *full_apt
-    - env: PYTHON=2.7 DEPS=full TEST=standard
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
-            - *full_apt
     # OSMesa requires a specific Travis run because since the system also
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause
@@ -59,45 +27,13 @@ matrix:
 
 
 before_install:
-    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-        wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget -q http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-      fi;
-
+    - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -p ~/anaconda
     - export PATH=~/anaconda/bin:$PATH
     - conda config --add channels conda-forge
     - conda update --yes --quiet conda
-
     - SRC_DIR=$(pwd)
-    # file size checks run on minimal build for time
-    - if [ "${DEPS}" == "minimal" ]; then
-        if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-          GIT_TARGET_EXTRA="+refs/heads/${TRAVIS_BRANCH}";
-          GIT_SOURCE_EXTRA="+refs/pull/${TRAVIS_PULL_REQUEST}/merge";
-        else
-          GIT_TARGET_EXTRA="";
-          GIT_SOURCE_EXTRA="";
-        fi;
-        cd ~;
-        mkdir target-size-clone && cd target-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
-        git tag travis-merge-target;
-        git gc --aggressive;
-        TARGET_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
-        git pull origin ${GIT_SOURCE_EXTRA};
-        git gc --aggressive;
-        MERGE_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
-        if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \)`;
-        else
-          SIZE_DIFF=0;
-        fi;
-      fi;
-
 
 install:
     # Install numpy, flake
@@ -121,16 +57,11 @@ install:
     - if [ "${DEPS}" == "full" ]; then
         conda install --yes pyopengl scipy numpy$NUMPY networkx;
         pip install -q numpydoc PySDL2;
-        if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          conda install --yes matplotlib jupyter pyqt=4 pillow decorator six scikit-image;
-          if [ "${PYTHON}" == "3.6" ]; then
-            pip install -q freetype-py husl pypng cassowary imageio;
-            rm -rf ${SRC_DIR}/vispy/ext/_bundled;
-          else
-            pip install -q mock;
-          fi;
+        conda install --yes matplotlib jupyter pyqt=4 pillow decorator six scikit-image;
+        if [ "${PYTHON}" == "3.6" ]; then
+          pip install -q freetype-py husl pypng cassowary imageio;
+          rm -rf ${SRC_DIR}/vispy/ext/_bundled;
         else
-          conda install --yes matplotlib jupyter pyqt=4 scikit-image;
           pip install -q mock;
         fi;
       fi;
@@ -148,11 +79,7 @@ install:
         cmake -DCMAKE_INSTALL_PREFIX=$HOME -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
         make install;
         cd ~;
-        if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          export GLFW_LIBRARY=${HOME}/lib/libglfw.so;
-        else
-          export GLFW_LIBRARY=${HOME}/lib/libglfw.dylib;
-        fi;
+        export GLFW_LIBRARY=${HOME}/lib/libglfw.so;
       fi
 
     # Install OSMesa
@@ -165,49 +92,16 @@ install:
 before_script:
     # We need to create a (fake) display on Travis, let's use a funny resolution
     # For OSX: https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
-    - if [ "${TEST}" != "osmesa" ]; then
-        export DISPLAY=:99.0;
-        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1400x900x24 +render +iglx; echo ok )& fi;
-        if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render;
-        fi;
-      fi;
     - if [ "${TEST}" == "osmesa" ]; then
-        export LD_LIBRARY_PATH=$HOME/osmesa/lib;
-        export LIBRARY_PATH=$HOME/osmesa/lib;
-      fi;
+      export LD_LIBRARY_PATH=$HOME/osmesa/lib;
+      export LIBRARY_PATH=$HOME/osmesa/lib;
+    fi;
+
 
 
 script:
     - cd ${SRC_DIR}
     - python -c "import vispy; print(vispy.sys_info())"
-    - if [ "${TEST}" == "standard" ]; then
-        make unit;
-      fi;
-    - if [ "${TEST}" == "examples" ] || [ "${DEPS}" == "minimal" ]; then
-        make examples;
-      fi;
-    - if [ "${DEPS}" == "minimal" ]; then
-        make extra;
-      fi;
     - if [ "${TEST}" == "osmesa" ]; then
         make osmesa;
-      fi;
-    # Each line must be run in a separate line to ensure exit code accuracy
-    - if [ "${DEPS}" == "minimal" ]; then
-        echo "Size difference ${SIZE_DIFF} kB";
-        if git log --format=%B -n 2 | grep -q "\[size skip\]"; then
-          echo "Skipping size test";
-        else
-          test ${SIZE_DIFF} -lt 100;
-        fi;
-      fi;
-
-
-after_success:
-    # Need to run from source dir to execute appropriate "git" commands
-    - if [ "${TEST}" == "standard" ]; then
-        COVERAGE_FILE=.vispy-coverage coverage combine;
-        mv .vispy-coverage .coverage;
-        coveralls;
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ before_script:
     - if [ "${TEST}" == "osmesa" ]; then
         export LD_LIBRARY_PATH=$HOME/osmesa/lib;
         export LIBRARY_PATH=$HOME/osmesa/lib;
+        export VISPY_GL_LIB=$HOME/osmesa/lib/libOSMesa.so
+        export OSMESA_LIBRARY=$HOME/osmesa/lib/libOSMesa.so
       fi;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
     - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
         git clone git://github.com/glfw/glfw.git;
         cd glfw;
-        cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
+        cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_INSTALL_LIBDIR:PATH=$CONDA_PREFIX/lib -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .;
         make install;
         cd ~;
         export GLFW_LIBRARY=${CONDA_PREFIX}/lib/libglfw.so;

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,11 +93,9 @@ before_script:
     # We need to create a (fake) display on Travis, let's use a funny resolution
     # For OSX: https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
     - if [ "${TEST}" == "osmesa" ]; then
-      export LD_LIBRARY_PATH=$HOME/osmesa/lib;
-      export LIBRARY_PATH=$HOME/osmesa/lib;
-    fi;
-
-
+        export LD_LIBRARY_PATH=$HOME/osmesa/lib;
+        export LIBRARY_PATH=$HOME/osmesa/lib;
+      fi;
 
 script:
     - cd ${SRC_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ install:
     # Install numpy, flake
     - conda create -n testenv --yes --quiet pip python=$PYTHON;
     - source activate testenv;
-    - conda install --yes --quiet numpy$NUMPY nose pytest cython;
-    - pip install -q coveralls pytest-cov pytest-sugar flake8
+    - conda install --yes --quiet pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
 
     # On Python3, install system-wide copies of bundled libraries instead
     # Also install PyQt4, imaging (PIL or pillow), scipy, mpl, egl
@@ -54,17 +53,17 @@ install:
     # WX requires OSMesa (mesa on conda) which has typically been an
     # additional test environment. With llvm=3.3 the combination of
     # EGL and mesa causes segmentation faults. See issue #1401.
-    - if [ "${DEPS}" == "full" ]; then
-        conda install --yes pyopengl scipy numpy$NUMPY networkx;
-        pip install -q numpydoc PySDL2;
-        conda install --yes matplotlib jupyter pyqt=4 pillow decorator six scikit-image;
-        if [ "${PYTHON}" == "3.6" ]; then
-          pip install -q freetype-py husl pypng cassowary imageio;
-          rm -rf ${SRC_DIR}/vispy/ext/_bundled;
-        else
-          pip install -q mock;
-        fi;
-      fi;
+    #- if [ "${DEPS}" == "full" ]; then
+    #    conda install --yes pyopengl scipy numpy$NUMPY networkx;
+    #    pip install -q numpydoc PySDL2;
+    #    conda install --yes matplotlib jupyter pyqt=4 pillow decorator six scikit-image;
+    #    if [ "${PYTHON}" == "3.6" ]; then
+    #      pip install -q freetype-py husl pypng cassowary imageio;
+    #      rm -rf ${SRC_DIR}/vispy/ext/_bundled;
+    #    else
+    #      pip install -q mock;
+    #    fi;
+    #  fi;
 
     # Install vispy
     - cd ${SRC_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     packages:
     - &mesa_apt [libgl1-mesa-dri]
     - &full_apt [libgl1-mesa-dri, libegl1-mesa, cmake, xorg-dev, libglu1-mesa-dev, mercurial, libdbus-1-dev, libgl1-mesa-dev, libglu1-mesa-dev, libpulse-dev, libx11-dev, libxcursor-dev, libxext-dev, libxi-dev, libxinerama-dev, libxrandr-dev, libxss-dev, libxt-dev, libxv-dev, libxxf86vm-dev, libasound2-dev, libts-dev, libudev-dev, libsdl2-2.0-0]
-    - &python_apt [python3-pip, python3-numpy, python3-opengl, python3-scipy, python3-networkx, python3-sdl2, python3-matplotlib, python3-jupyter-client, python3-jupyter-core, python3-jupyter-console, python3-jupyter-notebook, python3-pyqt4, python3-pil, python3-decorator, python3-six, python3-skimage, python3-nose, python3-pytest, cython3, python3-flake8, python3-mock]
+    - &python_apt [python3-pip, python3-numpy, python3-opengl, python3-scipy, python3-networkx, python3-matplotlib, python3-pyqt4, python3-pil, python3-decorator, python3-six, python3-skimage, python3-nose, python3-pytest, cython3, python3-flake8, python3-mock]
 # Size testing can be skipped by adding "[size skip]" within a commit message.
 
 matrix:
@@ -42,7 +42,7 @@ install:
     #- conda create -n testenv --yes --quiet pip python=$PYTHON pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
     #- source activate testenv;
     - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-        pip install numpydoc coveralls pytest-cov pytest-sugar;
+        pip install numpydoc PySDL2 coveralls pytest-cov pytest-sugar;
       fi;
 
     # On Python3, install system-wide copies of bundled libraries instead

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ before_install:
 
 install:
     # Install numpy, flake
-    - conda create -n testenv --yes --quiet pip python=$PYTHON;
+    - conda create -n testenv --yes --quiet pip python=$PYTHON pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
     - source activate testenv;
-    - conda install --yes --quiet pyopengl scipy numpy networkx numpydoc pysdl2 matplotlib jupyter pyqt=4 pillow decorator six scikit-image nose pytest cython coveralls pytest-cov pytest-sugar flake8 mock;
 
     # On Python3, install system-wide copies of bundled libraries instead
     # Also install PyQt4, imaging (PIL or pillow), scipy, mpl, egl

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -251,7 +251,7 @@ class ApplicationBackend(BaseApplicationBackend):
         return app
 
     def _vispy_sleep(self, duration_sec):
-            QtTest.QTest.qWait(duration_sec * 1000)  # in ms
+        QtTest.QTest.qWait(duration_sec * 1000)  # in ms
 
 
 # ------------------------------------------------------------------ canvas ---

--- a/vispy/color/tests/test_color.py
+++ b/vispy/color/tests/test_color.py
@@ -301,7 +301,7 @@ def test_colormap_discrete():
 def test_colormap():
     """Test named colormaps."""
     autumn = get_colormap('autumn')
-    assert autumn.glsl_map is not ""
+    assert autumn.glsl_map != ""
     assert len(autumn[0.]) == 1
     assert len(autumn[0.5]) == 1
     assert len(autumn[1.]) == 1

--- a/vispy/gloo/gl/_pyopengl2.py
+++ b/vispy/gloo/gl/_pyopengl2.py
@@ -11,9 +11,6 @@ from OpenGL import GL
 import OpenGL.GL.framebufferobjects as FBO
 
 
-
-
-
 def glBindAttribLocation(program, index, name):
     name = name.encode('utf-8')
     return GL.glBindAttribLocation(program, index, name)
@@ -88,14 +85,8 @@ def glCreateTexture():
 
 def glGetActiveAttrib(program, index):
     bufsize = 256
-    length = (ctypes.c_int*1)()
-    size = (ctypes.c_int*1)()
-    type = (ctypes.c_uint*1)()
-    name = ctypes.create_string_buffer(bufsize)
-    # pyopengl has a bug, this is a patch
-    GL.glGetActiveAttrib(program, index, bufsize, length, size, type, name)
-    name = name[:length[0]].decode('utf-8')
-    return name, size[0], type[0]
+    name, size, type = GL.glGetActiveAttrib(program, index, bufSize=bufsize)
+    return name.decode('utf-8'), size, type
 
 
 def glGetActiveUniform(program, index):

--- a/vispy/gloo/tests/test_framebuffer.py
+++ b/vispy/gloo/tests/test_framebuffer.py
@@ -19,7 +19,7 @@ def test_renderbuffer():
     # Set both shape and format
     R = RenderBuffer((10, 20), 'color')
     assert R.shape == (10, 20)
-    assert R.format is 'color'
+    assert R.format == 'color'
     #
     glir_cmds = R._glir.clear()
     assert len(glir_cmds) == 2

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -314,9 +314,9 @@ class Grid(Widget):
 
         for (x, xs) in enumerate(widget_grid):
             for(y, widget) in enumerate(xs):
-                    if widget is None:
-                        stretch_widths[y].append((width_grid[y][x], 1))
-                        stretch_heights[x].append((height_grid[x][y], 1))
+                if widget is None:
+                    stretch_widths[y].append((width_grid[y][x], 1))
+                    stretch_heights[x].append((height_grid[x][y], 1))
 
         for sws in stretch_widths:
             if len(sws) <= 1:
@@ -428,7 +428,7 @@ class Grid(Widget):
             Grid._add_gridding_height_constraints(self._solver,
                                                   self._height_grid)
         except RequiredFailure:
-                self._need_solver_recreate = True
+            self._need_solver_recreate = True
 
         # these are WEAK constraints, so these constraints will never fail
         # with a RequiredFailure.

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -337,47 +337,47 @@ class MaxNLocator(object):
     """
     def __init__(self, nbins=10, steps=None, trim=True, integer=False,
                  symmetric=False, prune=None):
-            """
-            Keyword args:
-            *nbins*
-                Maximum number of intervals; one less than max number of ticks.
-            *steps*
-                Sequence of nice numbers starting with 1 and ending with 10;
-                e.g., [1, 2, 4, 5, 10]
-            *integer*
-                If True, ticks will take only integer values.
-            *symmetric*
-                If True, autoscaling will result in a range symmetric
-                about zero.
-            *prune*
-                ['lower' | 'upper' | 'both' | None]
-                Remove edge ticks -- useful for stacked or ganged plots
-                where the upper tick of one axes overlaps with the lower
-                tick of the axes above it.
-                If prune=='lower', the smallest tick will
-                be removed.  If prune=='upper', the largest tick will be
-                removed.  If prune=='both', the largest and smallest ticks
-                will be removed.  If prune==None, no ticks will be removed.
-            """
-            self._nbins = int(nbins)
-            self._trim = trim
-            self._integer = integer
-            self._symmetric = symmetric
-            if prune is not None and prune not in ['upper', 'lower', 'both']:
-                raise ValueError(
-                    "prune must be 'upper', 'lower', 'both', or None")
-            self._prune = prune
-            if steps is None:
-                steps = [1, 2, 2.5, 3, 4, 5, 6, 8, 10]
-            else:
-                if int(steps[-1]) != 10:
-                    steps = list(steps)
-                    steps.append(10)
-            self._steps = steps
-            self._integer = integer
-            if self._integer:
-                self._steps = [n for n in self._steps
-                               if divmod(n, 1)[1] < 0.001]
+        """
+        Keyword args:
+        *nbins*
+            Maximum number of intervals; one less than max number of ticks.
+        *steps*
+            Sequence of nice numbers starting with 1 and ending with 10;
+            e.g., [1, 2, 4, 5, 10]
+        *integer*
+            If True, ticks will take only integer values.
+        *symmetric*
+            If True, autoscaling will result in a range symmetric
+            about zero.
+        *prune*
+            ['lower' | 'upper' | 'both' | None]
+            Remove edge ticks -- useful for stacked or ganged plots
+            where the upper tick of one axes overlaps with the lower
+            tick of the axes above it.
+            If prune=='lower', the smallest tick will
+            be removed.  If prune=='upper', the largest tick will be
+            removed.  If prune=='both', the largest and smallest ticks
+            will be removed.  If prune==None, no ticks will be removed.
+        """
+        self._nbins = int(nbins)
+        self._trim = trim
+        self._integer = integer
+        self._symmetric = symmetric
+        if prune is not None and prune not in ['upper', 'lower', 'both']:
+            raise ValueError(
+                "prune must be 'upper', 'lower', 'both', or None")
+        self._prune = prune
+        if steps is None:
+            steps = [1, 2, 2.5, 3, 4, 5, 6, 8, 10]
+        else:
+            if int(steps[-1]) != 10:
+                steps = list(steps)
+                steps.append(10)
+        self._steps = steps
+        self._integer = integer
+        if self._integer:
+            self._steps = [n for n in self._steps
+                           if divmod(n, 1)[1] < 0.001]
 
     def bin_boundaries(self, vmin, vmax):
         nbins = self._nbins

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -133,11 +133,11 @@ class _CoreColorBarVisual(Visual):
         # test that the given width and height is consistent
         # with the orientation
         if (self._orientation == "bottom" or self._orientation == "top"):
-                if halfw < halfh:
-                    raise ValueError("half-width(%s) < half-height(%s) for"
-                                     "%s orientation,"
-                                     " expected half-width >= half-height" %
-                                     (halfw, halfh, self._orientation, ))
+            if halfw < halfh:
+                raise ValueError("half-width(%s) < half-height(%s) for"
+                                 "%s orientation,"
+                                 " expected half-width >= half-height" %
+                                 (halfw, halfh, self._orientation, ))
         else:  # orientation == left or orientation == right
             if halfw > halfh:
                 raise ValueError("half-width(%s) > half-height(%s) for"
@@ -162,10 +162,10 @@ class _CoreColorBarVisual(Visual):
 
     @staticmethod
     def _get_orientation_error(orientation):
-            return ValueError("orientation must"
-                              " be one of 'top', 'bottom', "
-                              "'left', or 'right', "
-                              "not '%s'" % (orientation, ))
+        return ValueError("orientation must"
+                          " be one of 'top', 'bottom', "
+                          "'left', or 'right', "
+                          "not '%s'" % (orientation, ))
 
     @property
     def pos(self):


### PR DESCRIPTION
This PR extends #1569. It just tests the osmesa handling, so `.travis-yml` is stripped down to only osmesa.

- [x] 1. Test  current approach (not successful, latest commit https://github.com/vispy/vispy/pull/1570/commits/0a28664a14ecc2cb94c655295f0208ecf8881713)
- [x] 2. Test conda-forge only approach (do not use Travis system libs, but depend on conda-forge) (not successful, latest commit https://github.com/vispy/vispy/pull/1570/commits/89c1b319832b692c3ff4440580013fe58911516f)
- [ ] 3. Test Travis only approach (do not use conda-forge)
- [ ] 4. Test osmesa recompilation using 2.
- [ ] 5. Test osmesa recompilation using 3.
- [ ] tbc ?


ToDo/Think about List:
- [x] get glfw into conda-forge, see https://github.com/conda-forge/staged-recipes/issues/4395
- [ ] add mesalib 8bit color channel builds to conda-forge, see https://github.com/conda-forge/mesalib-feedstock/issues/22
- [ ] compile conda-forge `libglu` `--with-osmesa`.
- [ ] tbc
