### PR TITLE
fix size bug for offscreen.py example

### DIFF
--- a/examples/demo/gloo/offscreen.py
+++ b/examples/demo/gloo/offscreen.py
@@ -103,10 +103,10 @@ class Canvas(app.Canvas):
         app.Canvas.__init__(self, show=False, size=size)
         self._t0 = time()
         # Texture where we render the scene.
-        self._rendertex = gloo.Texture2D(shape=self.size + (4,))
+        self._rendertex = gloo.Texture2D(shape=self.size[::-1] + (4,))
         # FBO.
         self._fbo = gloo.FrameBuffer(self._rendertex,
-                                     gloo.RenderBuffer(self.size))
+                                     gloo.RenderBuffer(self.size[::-1]))
         # Regular program that will be rendered to the FBO.
         self.program = gloo.Program(vertex, fragment)
         self.program["position"] = [(-1, -1), (-1, 1), (1, 1),


### PR DESCRIPTION
In the example/demo/gloo/offscreen.py example, if we change the size to (1200, 600), e.g. the width is not equal to the height, we will get:
![screenshot from 2019-02-09 11-02-40](https://user-images.githubusercontent.com/25207535/52525152-43f02080-2c5a-11e9-8f43-30d12690f709.png)
Where the right half of the image is empty.
I think it is a bug related to the size argument.
In this pull request, I change the order of width/height for Framebuffer and Texture2D, and get the result looks like:
![screenshot from 2019-02-09 11-05-42](https://user-images.githubusercontent.com/25207535/52525179-a77a4e00-2c5a-11e9-8c35-34e897299a08.png)
I'm not sure it is the best solution.