### PR TITLE
Add CONDA_CHANNELS environment variable to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       PYTHON_ARCH: "64"
+      CONDA_CHANNELS: "conda-forge"
 
   matrix:
       - PYTHON_VERSION: "2.7"


### PR DESCRIPTION
Windows builds have started failing recently. Let's see if we can fix them.