### PR TITLE
[MRG] Add TextureCube object and port skybox example from glumpy

### DIFF
--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -4,10 +4,6 @@ from vispy.gloo import gl
 from vispy.io import read_png
 from vispy.util.transforms import perspective, translate, rotate
 
-# DEPRECATED
-# from glumpy import app, gloo, gl, data
-# from glumpy.transforms import Trackball, Position
-
 vertex_shader = """
 attribute vec3 a_position;
 attribute vec3 a_texcoord;
@@ -24,25 +20,12 @@ void main()
 """
 
 fragment_shader = """
-//uniform sampler3D u_tex1;
-//uniform sampler3D u_tex2;
-//uniform sampler3D u_tex3;
-//uniform sampler3D u_tex4;
-//uniform sampler3D u_tex5;
-//uniform sampler3D u_tex6;
+uniform samplerCube texture;
 varying vec3 v_texcoord;
 
 void main()
 {
-    //vec3 clr1 = texture3D(u_tex1, v_texcoord).rgb;
-    //vec3 clr2 = texture3D(u_tex2, v_texcoord).rgb;
-    //vec3 clr3 = texture3D(u_tex3, v_texcoord).rgb;
-    //vec3 clr4 = texture3D(u_tex4, v_texcoord).rgb;
-    //vec3 clr5 = texture3D(u_tex5, v_texcoord).rgb;
-    //vec3 clr6 = texture3D(u_tex6, v_texcoord).rgb;
-    //gl_FragColor.rgb = clr1 + clr2 + clr3 + clr4 + clr5 + clr6;
-    //gl_FragColor.a = 1.0;
-    gl_FragColor = vec4(v_texcoord, 1.0);
+    gl_FragColor = textureCube(texture, v_texcoord);
 }
 """
 
@@ -54,7 +37,6 @@ faces = np.array([vertices[i] for i in [0, 1, 2, 3, 0, 3, 4, 5, 0, 5, 6, 1,
                                         6, 7, 2, 1, 7, 4, 3, 2, 4, 7, 6, 5]])
 indices = np.resize(np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32), 36)
 indices += np.repeat(4 * np.arange(6, dtype=np.uint32), 6)
-# indices = indices.view(gloo.IndexBuffer)
 
 texture = np.zeros((6, 1024, 1024, 3), dtype=np.float32)
 texture[2] = read_png("sky-left.png")/255.
@@ -63,8 +45,6 @@ texture[0] = read_png("sky-front.png")/255.
 texture[1] = read_png("sky-back.png")/255.
 texture[4] = read_png("sky-up.png")/255.
 texture[5] = read_png("sky-down.png")/255.
-# window.attach(program["transform"])
-print("read is finished.")
 
 
 class Canvas(app.Canvas):
@@ -74,20 +54,14 @@ class Canvas(app.Canvas):
         self.program = gloo.Program(vertex_shader, fragment_shader, count=24)
         self.program['a_position'] = faces*10
         self.program['a_texcoord'] = faces
-        #self.program['u_tex1'] = gloo.Texture3D(texture[2], interpolation='linear')
-        #self.program['u_tex2'] = gloo.Texture3D(texture[3], interpolation='linear')
-        #self.program['u_tex3'] = gloo.Texture3D(texture[0], interpolation='linear')
-        #self.program['u_tex4'] = gloo.Texture3D(texture[1], interpolation='linear')
-        #self.program['u_tex5'] = gloo.Texture3D(texture[4], interpolation='linear')
-        #self.program['u_tex6'] = gloo.Texture3D(texture[5], interpolation='linear')
         self.program.bind(gloo.VertexBuffer(faces))
-        #self.program['texture'] = texture
-        #self.program['transform'] = Trackball(Position(), distance=0)
+        self.program['texture'] = gloo.TextureCube(texture, interpolation='linear')
 
-        self.default_view = np.array([[ 8.00000012e-01, 2.00000003e-01, -4.79999989e-01, 0.00000000e+00],
-            [-5.00000000e-01, 3.00000012e-01, -7.79999971e-01, 0.00000000e+00],
-            [-9.99999978e-03, 8.99999976e-01, -3.00000012e-01, 0.00000000e+00],
-            [-3.00000000e-01, -2.15000000e+01, -4.76000001e+01, 1.00000000e+00]],dtype=np.float32)
+        self.default_view = np.array([[8.00000012e-01, 2.00000003e-01, -4.79999989e-01, 0.00000000e+00],
+                                      [-5.00000000e-01, 3.00000012e-01, -7.79999971e-01, 0.00000000e+00],
+                                      [-9.99999978e-03, 8.99999976e-01, -3.00000012e-01, 0.00000000e+00],
+                                      [-3.00000000e-01, -2.15000000e+01, -4.76000001e+01, 1.00000000e+00]],
+                                     dtype=np.float32)
         self.view = self.default_view
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)

--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -87,22 +87,23 @@ class Canvas(app.Canvas):
 
     def __init__(self):
         app.Canvas.__init__(self, size=(1024, 1024), keys='interactive')
-        self.program = gloo.Program(vertex_shader, fragment_shader, count=24)
-        self.program['a_position'] = faces*10
-        self.program['a_texcoord'] = faces
-        self.program['a_texture'] = gloo.TextureCube(texture, interpolation='linear')
 
+        self.cubeSize = 10
         self.pressed = False
-        self.azimuth = pi
-        self.elevation = pi
+        self.azimuth = pi / 2.0
+        self.elevation = pi / 2.0
         self.distanceMin = 1
         self.distanceMax = 50
-        self.distance = self.distanceMax / 2.0
+        self.distance = 30
         self.sensitivity = 5.0
         self.view = getView(self.azimuth, self.elevation, self.distance)
         self.model = np.eye(4, dtype=np.float32)
         self.projection = np.eye(4, dtype=np.float32)
 
+        self.program = gloo.Program(vertex_shader, fragment_shader, count=24)
+        self.program['a_position'] = faces*self.cubeSize
+        self.program['a_texcoord'] = faces
+        self.program['a_texture'] = gloo.TextureCube(texture, interpolation='linear')
         self.program['u_model'] = self.model
         self.program['u_view'] = self.view
         gloo.set_viewport(0, 0, *self.physical_size)
@@ -119,8 +120,7 @@ class Canvas(app.Canvas):
         self.program.draw(gl.GL_TRIANGLES, gloo.IndexBuffer(indices))
 
     def on_mouse_wheel(self, event):
-        deltaDistance = event.delta[1]
-        self.distance = self.distance - deltaDistance
+        self.distance = self.distance - event.delta[1]
         self.distance = min(max(self.distance, self.distanceMin), self.distanceMax)
         self.program['u_view'] = getView(self.azimuth, self.elevation, self.distance)
         self.update()

--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -2,7 +2,7 @@ import numpy as np
 import math
 from vispy import app, gloo
 from vispy.gloo import gl
-from vispy.io import read_png
+from vispy.io import read_png, load_data_file
 from vispy.util.transforms import perspective
 
 
@@ -66,12 +66,12 @@ indices = np.resize(np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32), 36)
 indices += np.repeat(4 * np.arange(6, dtype=np.uint32), 6)
 
 texture = np.zeros((6, 1024, 1024, 3), dtype=np.float32)
-texture[2] = read_png("sky-left.png")/255.
-texture[3] = read_png("sky-right.png")/255.
-texture[0] = read_png("sky-front.png")/255.
-texture[1] = read_png("sky-back.png")/255.
-texture[4] = read_png("sky-up.png")/255.
-texture[5] = read_png("sky-down.png")/255.
+texture[2] = read_png(load_data_file("skybox/sky-left.png"))/255.
+texture[3] = read_png(load_data_file("skybox/sky-right.png"))/255.
+texture[0] = read_png(load_data_file("skybox/sky-front.png"))/255.
+texture[1] = read_png(load_data_file("skybox/sky-back.png"))/255.
+texture[4] = read_png(load_data_file("skybox/sky-up.png"))/255.
+texture[5] = read_png(load_data_file("skybox/sky-down.png"))/255.
 
 
 class Canvas(app.Canvas):

--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -1,0 +1,67 @@
+#Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
+# Distributed under the (new) BSD License.
+# -----------------------------------------------------------------------------
+import numpy as np
+from glumpy import app, gloo, gl, data
+from glumpy.transforms import Trackball, Position
+
+vertex = """
+    attribute vec3 position;
+    attribute vec3 texcoord;
+    varying vec3 v_texcoord;
+    void main()
+    {
+        gl_Position = <transform(position)> * vec4(-1,-1,1,1);
+        v_texcoord = texcoord;
+    }
+"""
+
+fragment = """
+    uniform samplerCube texture;
+    varying vec3 v_texcoord;
+    void main()
+    {
+        gl_FragColor = textureCube(texture, v_texcoord);
+    }
+"""
+
+
+window = app.Window(width=1024, height=1024)
+
+
+@window.event
+def on_draw(dt):
+    window.clear()
+    program.draw(gl.GL_TRIANGLES, indices)
+
+
+@window.event
+def on_init():
+    gl.glEnable(gl.GL_DEPTH_TEST)
+
+
+vertices = np.array([[+1, +1, +1], [-1, +1, +1], [-1, -1, +1], [+1, -1, +1],
+                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]])
+texcoords = np.array([[+1, +1, +1], [-1, +1, +1], [-1, -1, +1], [+1, -1, +1],
+                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]])
+faces = np.array([vertices[i] for i in [0, 1, 2, 3, 0, 3, 4, 5, 0, 5, 6, 1,
+                                        6, 7, 2, 1, 7, 4, 3, 2, 4, 7, 6, 5]])
+indices = np.resize(np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32), 36)
+indices += np.repeat(4 * np.arange(6, dtype=np.uint32), 6)
+indices = indices.view(gloo.IndexBuffer)
+texture = np.zeros((6, 1024, 1024, 3), dtype=np.float32).view(gloo.TextureCube)
+texture.interpolation = gl.GL_LINEAR
+program = gloo.Program(vertex, fragment, count=24)
+program['position'] = faces*10
+program['texcoord'] = faces
+program['texture'] = texture
+program['transform'] = Trackball(Position(), distance=0)
+
+texture[2] = data.get("sky-left.png")/255.
+texture[3] = data.get("sky-right.png")/255.
+texture[0] = data.get("sky-front.png")/255.
+texture[1] = data.get("sky-back.png")/255.
+texture[4] = data.get("sky-up.png")/255.
+texture[5] = data.get("sky-down.png")/255.
+window.attach(program["transform"])
+app.run()

--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -86,7 +86,8 @@ texture[5] = read_png(load_data_file("skybox/sky-down.png"))/255.
 class Canvas(app.Canvas):
 
     def __init__(self):
-        app.Canvas.__init__(self, size=(1024, 1024), keys='interactive')
+        app.Canvas.__init__(self, size=(1024, 1024), title='Skybox example',
+                            keys='interactive')
 
         self.cubeSize = 10
         self.pressed = False

--- a/examples/demo/gloo/skybox.py
+++ b/examples/demo/gloo/skybox.py
@@ -1,67 +1,169 @@
-#Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
-# Distributed under the (new) BSD License.
-# -----------------------------------------------------------------------------
 import numpy as np
-from glumpy import app, gloo, gl, data
-from glumpy.transforms import Trackball, Position
+from vispy import app, gloo
+from vispy.gloo import gl
+from vispy.io import read_png
+from vispy.util.transforms import perspective, translate, rotate
 
-vertex = """
-    attribute vec3 position;
-    attribute vec3 texcoord;
-    varying vec3 v_texcoord;
-    void main()
-    {
-        gl_Position = <transform(position)> * vec4(-1,-1,1,1);
-        v_texcoord = texcoord;
-    }
+# DEPRECATED
+# from glumpy import app, gloo, gl, data
+# from glumpy.transforms import Trackball, Position
+
+vertex_shader = """
+attribute vec3 a_position;
+attribute vec3 a_texcoord;
+varying vec3 v_texcoord;
+uniform   mat4 u_model;
+uniform   mat4 u_view;
+uniform   mat4 u_projection;
+
+void main()
+{
+    v_texcoord = a_texcoord;
+    gl_Position = u_projection * u_view * u_model * vec4(a_position, 1.0);
+}
 """
 
-fragment = """
-    uniform samplerCube texture;
-    varying vec3 v_texcoord;
-    void main()
-    {
-        gl_FragColor = textureCube(texture, v_texcoord);
-    }
+fragment_shader = """
+//uniform sampler3D u_tex1;
+//uniform sampler3D u_tex2;
+//uniform sampler3D u_tex3;
+//uniform sampler3D u_tex4;
+//uniform sampler3D u_tex5;
+//uniform sampler3D u_tex6;
+varying vec3 v_texcoord;
+
+void main()
+{
+    //vec3 clr1 = texture3D(u_tex1, v_texcoord).rgb;
+    //vec3 clr2 = texture3D(u_tex2, v_texcoord).rgb;
+    //vec3 clr3 = texture3D(u_tex3, v_texcoord).rgb;
+    //vec3 clr4 = texture3D(u_tex4, v_texcoord).rgb;
+    //vec3 clr5 = texture3D(u_tex5, v_texcoord).rgb;
+    //vec3 clr6 = texture3D(u_tex6, v_texcoord).rgb;
+    //gl_FragColor.rgb = clr1 + clr2 + clr3 + clr4 + clr5 + clr6;
+    //gl_FragColor.a = 1.0;
+    gl_FragColor = vec4(v_texcoord, 1.0);
+}
 """
-
-
-window = app.Window(width=1024, height=1024)
-
-
-@window.event
-def on_draw(dt):
-    window.clear()
-    program.draw(gl.GL_TRIANGLES, indices)
-
-
-@window.event
-def on_init():
-    gl.glEnable(gl.GL_DEPTH_TEST)
-
 
 vertices = np.array([[+1, +1, +1], [-1, +1, +1], [-1, -1, +1], [+1, -1, +1],
-                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]])
+                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]]).astype(np.float32)
 texcoords = np.array([[+1, +1, +1], [-1, +1, +1], [-1, -1, +1], [+1, -1, +1],
-                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]])
+                     [+1, -1, -1], [+1, +1, -1], [-1, +1, -1], [-1, -1, -1]]).astype(np.float32)
 faces = np.array([vertices[i] for i in [0, 1, 2, 3, 0, 3, 4, 5, 0, 5, 6, 1,
                                         6, 7, 2, 1, 7, 4, 3, 2, 4, 7, 6, 5]])
 indices = np.resize(np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32), 36)
 indices += np.repeat(4 * np.arange(6, dtype=np.uint32), 6)
-indices = indices.view(gloo.IndexBuffer)
-texture = np.zeros((6, 1024, 1024, 3), dtype=np.float32).view(gloo.TextureCube)
-texture.interpolation = gl.GL_LINEAR
-program = gloo.Program(vertex, fragment, count=24)
-program['position'] = faces*10
-program['texcoord'] = faces
-program['texture'] = texture
-program['transform'] = Trackball(Position(), distance=0)
+# indices = indices.view(gloo.IndexBuffer)
 
-texture[2] = data.get("sky-left.png")/255.
-texture[3] = data.get("sky-right.png")/255.
-texture[0] = data.get("sky-front.png")/255.
-texture[1] = data.get("sky-back.png")/255.
-texture[4] = data.get("sky-up.png")/255.
-texture[5] = data.get("sky-down.png")/255.
-window.attach(program["transform"])
-app.run()
+texture = np.zeros((6, 1024, 1024, 3), dtype=np.float32)
+texture[2] = read_png("sky-left.png")/255.
+texture[3] = read_png("sky-right.png")/255.
+texture[0] = read_png("sky-front.png")/255.
+texture[1] = read_png("sky-back.png")/255.
+texture[4] = read_png("sky-up.png")/255.
+texture[5] = read_png("sky-down.png")/255.
+# window.attach(program["transform"])
+print("read is finished.")
+
+
+class Canvas(app.Canvas):
+
+    def __init__(self):
+        app.Canvas.__init__(self, size=(1024, 1024), keys='interactive')
+        self.program = gloo.Program(vertex_shader, fragment_shader, count=24)
+        self.program['a_position'] = faces*10
+        self.program['a_texcoord'] = faces
+        #self.program['u_tex1'] = gloo.Texture3D(texture[2], interpolation='linear')
+        #self.program['u_tex2'] = gloo.Texture3D(texture[3], interpolation='linear')
+        #self.program['u_tex3'] = gloo.Texture3D(texture[0], interpolation='linear')
+        #self.program['u_tex4'] = gloo.Texture3D(texture[1], interpolation='linear')
+        #self.program['u_tex5'] = gloo.Texture3D(texture[4], interpolation='linear')
+        #self.program['u_tex6'] = gloo.Texture3D(texture[5], interpolation='linear')
+        self.program.bind(gloo.VertexBuffer(faces))
+        #self.program['texture'] = texture
+        #self.program['transform'] = Trackball(Position(), distance=0)
+
+        self.default_view = np.array([[ 8.00000012e-01, 2.00000003e-01, -4.79999989e-01, 0.00000000e+00],
+            [-5.00000000e-01, 3.00000012e-01, -7.79999971e-01, 0.00000000e+00],
+            [-9.99999978e-03, 8.99999976e-01, -3.00000012e-01, 0.00000000e+00],
+            [-3.00000000e-01, -2.15000000e+01, -4.76000001e+01, 1.00000000e+00]],dtype=np.float32)
+        self.view = self.default_view
+        self.model = np.eye(4, dtype=np.float32)
+        self.projection = np.eye(4, dtype=np.float32)
+
+        self.translate = [0, 0, 0]
+        self.rotate = [0, 0, 0]
+
+        self.program['u_model'] = self.model
+        self.program['u_view'] = self.view
+
+        gl.glEnable(gl.GL_DEPTH_TEST)
+        gloo.set_clear_color('black')
+        self.show()
+        print("canvas.init()")
+
+    def on_draw(self, event):
+        gloo.clear(color=True, depth=True)
+        self.program.draw(gl.GL_TRIANGLES, gloo.IndexBuffer(indices))
+
+    def on_key_press(self, event):
+        """Controls -
+        q(Q) - move left
+        d(D) - move right
+        z(Z) - move up
+        s(S) - move down
+        j/J - rotate about x-axis cw/anti-cw
+        k/K - rotate about y-axis cw/anti-cw
+        l/L - rotate about z-axis cw/anti-cw
+        space - reset view
+        p(P) - print current view
+        """
+        self.translate = [0, 0, 0]
+        self.rotate = [0, 0, 0]
+
+        if(event.text == 'p' or event.text == 'P'):
+            print(self.view)
+        elif(event.text == 'd' or event.text == 'D'):
+            self.translate[0] = 0.3
+        elif(event.text == 'q' or event.text == 'Q'):
+            self.translate[0] = -0.3
+        elif(event.text == 'z' or event.text == 'Z'):
+            self.translate[1] = 0.3
+        elif(event.text == 's' or event.text == 'S'):
+            self.translate[1] = -0.3
+        elif(event.text == 'j'):
+            self.rotate = [1, 0, 0]
+        elif(event.text == 'J'):
+            self.rotate = [-1, 0, 0]
+        elif(event.text == 'k'):
+            self.rotate = [0, 1, 0]
+        elif(event.text == 'K'):
+            self.rotate = [0, -1, 0]
+        elif(event.text == 'l'):
+            self.rotate = [0, 0, 1]
+        elif(event.text == 'L'):
+            self.rotate = [0, 0, -1]
+        elif(event.text == ' '):
+            self.view = self.default_view
+
+        self.view = self.view.dot(
+            translate(-np.array(self.translate)).dot(
+                rotate(self.rotate[0], (1, 0, 0)).dot(
+                    rotate(self.rotate[1], (0, 1, 0)).dot(
+                        rotate(self.rotate[2], (0, 0, 1))))))
+        self.program['u_view'] = self.view
+        self.update()
+
+    def on_resize(self, event):
+        self.activate_zoom()
+
+    def activate_zoom(self):
+        gloo.set_viewport(0, 0, *self.physical_size)
+        self.projection = perspective(60.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 100.0)
+        self.program['u_projection'] = self.projection
+
+if __name__ == '__main__':
+    c = Canvas()
+    app.run()

--- a/vispy/gloo/__init__.py
+++ b/vispy/gloo/__init__.py
@@ -50,7 +50,7 @@ from .context import (GLContext, get_default_config,  # noqa
                       get_current_canvas)  # noqa
 from .globject import GLObject  # noqa
 from .buffer import VertexBuffer, IndexBuffer  # noqa
-from .texture import Texture1D, Texture2D, TextureAtlas, Texture3D, TextureEmulated3D  # noqa
+from .texture import Texture1D, Texture2D, TextureAtlas, Texture3D, TextureCube, TextureEmulated3D  # noqa
 from .program import Program  # noqa
 from .framebuffer import FrameBuffer, RenderBuffer  # noqa
 from . import util  # noqa

--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from .globject import GLObject
 from .buffer import VertexBuffer, IndexBuffer, DataBuffer
-from .texture import BaseTexture, Texture2D, Texture3D, Texture1D
+from .texture import BaseTexture, Texture2D, Texture3D, Texture1D, TextureCube
 from ..util import logger
 from .util import check_enum
 from ..ext.six import string_types
@@ -89,6 +89,7 @@ class Program(GLObject):
         'sampler1D':    (np.uint32, 1),
         'sampler2D':    (np.uint32, 1),
         'sampler3D':    (np.uint32, 1),
+        'samplerCube':  (np.uint32, 1),
     }
 
     # ---------------------------------
@@ -301,6 +302,8 @@ class Program(GLObject):
                         data = Texture2D(data)
                     elif type_ == 'sampler3D':
                         data = Texture3D(data)
+                    elif type_ == 'samplerCube':
+                        data = TextureCube(data)
                     else:
                         # This should not happen
                         raise RuntimeError('Unknown type %s' % type_)

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -589,6 +589,77 @@ class Texture3D(BaseTexture):
         return 'texture3D'
 
 
+# --------------------------------------------------------- TextureCube class ---
+class TextureCube(BaseTexture):
+    """ Cube dimensional texture
+
+    Parameters
+    ----------
+    data : ndarray | tuple | None
+        Texture data in the form of a numpy array (or something that
+        can be turned into one). A tuple with the shape of the texture
+        can also be given.
+    format : str | enum | None
+        The format of the texture: 'luminance', 'alpha',
+        'luminance_alpha', 'rgb', or 'rgba'. If not given the format
+        is chosen automatically based on the number of channels.
+        When the data has one channel, 'luminance' is assumed.
+    resizable : bool
+        Indicates whether texture can be resized. Default True.
+    interpolation : str | None
+        Interpolation mode, must be one of: 'nearest', 'linear'.
+        Default 'nearest'.
+    wrapping : str | None
+        Wrapping mode, must be one of: 'repeat', 'clamp_to_edge',
+        'mirrored_repeat'. Default 'clamp_to_edge'.
+    shape : tuple | None
+        Optional. A tuple with the shape of the texture. If ``data``
+        is also a tuple, it will override the value of ``shape``.
+    internalformat : str | None
+        Internal format to use.
+    resizeable : None
+        Deprecated version of `resizable`.
+    """
+    _ndim = 3
+    _GLIR_TYPE = 'TextureCube'
+
+    def __init__(self, data=None, format=None, resizable=True,
+                 interpolation=None, wrapping=None, shape=None,
+                 internalformat=None, resizeable=None):
+        BaseTexture.__init__(self, data, format, resizable, interpolation,
+                             wrapping, shape, internalformat, resizeable)
+        if self._shape[0] != 6:
+            print("Texture cube require arrays first dimension to be 6")
+
+    @property
+    def height(self):
+        """ Texture height """
+        return self._shape[1]
+
+    @property
+    def width(self):
+        """ Texture width """
+        return self._shape[2]
+
+    @property
+    def glsl_type(self):
+        """ GLSL declaration strings required for a variable to hold this data.
+        """
+        return 'uniform', 'samplerCube'
+
+    @property
+    def glsl_sampler_type(self):
+        """ GLSL type of the sampler.
+        """
+        return 'samplerCube'
+
+    @property
+    def glsl_sample(self):
+        """ GLSL function that samples the texture.
+        """
+        return 'textureCube'
+
+
 # ------------------------------------------------- TextureEmulated3D class ---
 class TextureEmulated3D(Texture2D):
     """ Two dimensional texture that is emulating a three dimensional texture

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -629,7 +629,8 @@ class TextureCube(BaseTexture):
         BaseTexture.__init__(self, data, format, resizable, interpolation,
                              wrapping, shape, internalformat, resizeable)
         if self._shape[0] != 6:
-            print("Texture cube require arrays first dimension to be 6")
+            raise ValueError("Texture cube require arrays first dimension to be 6 :"
+                             " {} was given.".format(self._shape[0]))
 
     @property
     def height(self):

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -591,7 +591,7 @@ class Texture3D(BaseTexture):
 
 # --------------------------------------------------------- TextureCube class ---
 class TextureCube(BaseTexture):
-    """ Cube dimensional texture
+    """ Texture Cube
 
     Parameters
     ----------
@@ -641,6 +641,11 @@ class TextureCube(BaseTexture):
     def width(self):
         """ Texture width """
         return self._shape[2]
+
+    @property
+    def depth(self):
+        """ Texture depth """
+        return self._shape[0]
 
     @property
     def glsl_type(self):


### PR DESCRIPTION
**What does this implement/fix?**
Port skybox example from Glumpy #818 

**Additional information**
1) I fixed the `offset` tuple in the `set_data()` method of the `GlirTextureCube` class in `vispy/gloo/glir.py` because I wasn't sure about what it exactly does.

2) I did not find any alternatives for `trackball` so I used another way to interact from:
`examples/demo/gloo/terrain.py`. Most likely there is a more practical way.

3) I stored the images on my machine and tested locally but I guess they can be uploaded in `vispy/demo-data`.

4) I am not sure about the location of `skybox.py`, I put it in `examples/demo/gloo` by default.

It is still a work in progress but here is a rendering:
![skybox](https://user-images.githubusercontent.com/18143289/53818180-f8364b80-3f67-11e9-913e-01d5786eab4e.png)
