### PR TITLE
Fix event loop detection triggering on blocked events

### DIFF
--- a/vispy/util/event.py
+++ b/vispy/util/event.py
@@ -194,7 +194,7 @@ class EventEmitter(object):
         self._blocked = {None: 0}
 
         # used to detect emitter loops
-        self._emitting = False
+        self._emitting = 0
         self.source = source
         self.default_args = {}
         if type is not None:
@@ -424,8 +424,6 @@ class EventEmitter(object):
         """
         # This is a VERY highly used method; must be fast!
         blocked = self._blocked
-        if self._emitting:
-            raise RuntimeError('EventEmitter loop detected!')
 
         # create / massage event as needed
         event = self._prepare_event(*args, **kwargs)
@@ -433,7 +431,7 @@ class EventEmitter(object):
         # Add our source to the event; remove it after all callbacks have been
         # invoked.
         event._push_source(self.source)
-        self._emitting = True
+        self._emitting += 1
         try:
             if blocked.get(None, 0) > 0:  # this is the same as self.blocked()
                 return event
@@ -451,6 +449,9 @@ class EventEmitter(object):
 
                 if blocked.get(cb, 0) > 0:
                     continue
+                
+                if self._emitting > 1:
+                    raise RuntimeError('EventEmitter loop detected!')
 
                 self._invoke_callback(cb, event)
                 if event.blocked:
@@ -460,7 +461,7 @@ class EventEmitter(object):
             for cb in rem:
                 self.disconnect(cb)
         finally:
-            self._emitting = False
+            self._emitting -= 1
             if event._pop_source() != self.source:
                 raise RuntimeError("Event source-stack mismatch.")
 

--- a/vispy/util/event.py
+++ b/vispy/util/event.py
@@ -449,7 +449,7 @@ class EventEmitter(object):
 
                 if blocked.get(cb, 0) > 0:
                     continue
-                
+
                 if self._emitting > 1:
                     raise RuntimeError('EventEmitter loop detected!')
 

--- a/vispy/util/tests/test_event_emitter.py
+++ b/vispy/util/tests/test_event_emitter.py
@@ -663,4 +663,81 @@ def test_emitter_block():
     assert_state(True, True)
 
 
+def test_emitter_reentrance_allowed_when_blocked1():
+    # Minimal re-entrance example
+
+    e = EventEmitter(source=None, type='test')
+    count = 0
+
+    @e.connect
+    def foo(x):
+        nonlocal count
+        count += 1
+        with e.blocker():
+            e()
+
+    e()
+    assert count == 1
+
+
+def test_emitter_reentrance_allowed_when_blocked2():
+    # More realistic re-entrance example
+    # The real world case for this might be a longer chain of events
+    # where event1's callback knows that what it's doing will trigger
+    # the same event so it blocks it. So event1 -> foo -> event2
+    # -> bar -> event1 -> (ignored bc blocked).
+
+    e1 = EventEmitter(source=None, type='test1')
+    e2 = EventEmitter(source=None, type='test2')
+    count = 0
+
+    @e1.connect
+    def foo(x):
+        nonlocal count
+        count += 1
+        with e1.blocker():
+            e2()
+
+    @e2.connect
+    def bar(x):
+        nonlocal count
+        count += 10
+        e1()
+
+    e1()
+    assert count == 11
+
+
+def test_emitter_reentrance_allowed_when_blocked3():
+    # Like the previous, but blocking callbacks instead of the event itself.
+    # Allows more fine-grained control. To some extent anyway - all callbacks
+    # of the event must be blocked to prevent raising the emitter loop error.
+
+    e1 = EventEmitter(source=None, type='test1')
+    e2 = EventEmitter(source=None, type='test2')
+    count = 0
+
+    @e1.connect
+    def foo(x):
+        nonlocal count
+        count += 1
+        with e1.blocker(foo):
+            e2()
+
+    @e2.connect
+    def bar(x):
+        nonlocal count
+        count += 10
+        e1()
+
+    @e2.connect
+    def eggs(x):
+        nonlocal count
+        count += 100
+        e1()
+
+    e1()
+    assert count == 2111
+
+
 run_tests_if_main()

--- a/vispy/util/tests/test_event_emitter.py
+++ b/vispy/util/tests/test_event_emitter.py
@@ -543,25 +543,25 @@ def test_event_connect_order():
 
 def test_emitter_block():
     state = [False, False]
-    
+
     def a(ev):
         state[0] = True
-        
+
     def b(ev):
         state[1] = True
-        
+
     e = EventEmitter(source=None, type='event')
     e.connect(a)
     e.connect(b)
-    
+
     def assert_state(a, b):
         assert state == [a, b]
         state[0] = False
         state[1] = False
-    
+
     e()
     assert_state(True, True)
-    
+
     # test global blocking
     e.block()
     e()
@@ -569,7 +569,7 @@ def test_emitter_block():
     e.block()
     e()
     assert_state(False, False)
-    
+
     # test global unlock, multiple depth
     e.unblock()
     e()
@@ -577,23 +577,23 @@ def test_emitter_block():
     e.unblock()
     e()
     assert_state(True, True)
-    
+
     # test unblock failure
     try:
         e.unblock()
         raise Exception("Expected RuntimeError")
     except RuntimeError:
         pass
-    
+
     # test single block
     e.block(a)
     e()
     assert_state(False, True)
-    
+
     e.block(b)
     e()
     assert_state(False, False)
-    
+
     e.block(b)
     e()
     assert_state(False, False)
@@ -602,15 +602,15 @@ def test_emitter_block():
     e.unblock(a)
     e()
     assert_state(True, False)
-    
+
     e.unblock(b)
     e()
     assert_state(True, False)
-    
+
     e.unblock(b)
     e()
     assert_state(True, True)
-    
+
     # Test single unblock failure
     try:
         e.unblock(a)
@@ -622,12 +622,12 @@ def test_emitter_block():
     with e.blocker():
         e()
         assert_state(False, False)
-        
+
         # test nested blocker
         with e.blocker():
             e()
             assert_state(False, False)
-        
+
         e()
         assert_state(False, False)
 
@@ -638,7 +638,7 @@ def test_emitter_block():
     with e.blocker(a):
         e()
         assert_state(False, True)
-        
+
         # test nested gloabel blocker
         with e.blocker():
             e()
@@ -684,8 +684,8 @@ def test_emitter_reentrance_allowed_when_blocked2():
     # More realistic re-entrance example
     # The real world case for this might be a longer chain of events
     # where event1's callback knows that what it's doing will trigger
-    # the same event so it blocks it. So event1 -> foo -> event2
-    # -> bar -> event1 -> (ignored bc blocked).
+    # the same event so it blocks it:
+    # event1 -> foo -> event2 -> bar -> event1 -> (ignored bc blocked).
 
     e1 = EventEmitter(source=None, type='test1')
     e2 = EventEmitter(source=None, type='test2')
@@ -737,7 +737,7 @@ def test_emitter_reentrance_allowed_when_blocked3():
         e1()
 
     e1()
-    assert count == 2111
+    assert count == 111
 
 
 run_tests_if_main()


### PR DESCRIPTION
Delay checking if stuck in an event loop until after checking if the event emitter is being blocked. This allows callback cycling. 

Toy example:
```python
e = EventEmitter(source=None, type='test')

def foo(x):
    print('foo')
    with e.blocker():
        e()

e.connect(foo)
e()
```

However, this check can be erroneously triggered during asynchronous operations. IMO if there is no real good reason for the check (since the loop will automatically trigger a `RecursionError` anyways), I'd like to just flat-out remove it.