### PR TITLE
Fix memory leak caused by keeping weak references to callbacks around.

### DIFF
--- a/vispy/visuals/transforms/base_transform.py
+++ b/vispy/visuals/transforms/base_transform.py
@@ -194,6 +194,10 @@ class BaseTransform(object):
     def __repr__(self):
         return "<%s at 0x%x>" % (self.__class__.__name__, id(self))
 
+    def __del__(self):
+        # we can remove ourselves from *all* events in this situation.
+        self.changed.disconnect()
+
 
 class InverseTransform(BaseTransform):
     def __init__(self, transform):

--- a/vispy/visuals/transforms/chain.py
+++ b/vispy/visuals/transforms/chain.py
@@ -240,6 +240,14 @@ class ChainTransform(BaseTransform):
         tr = ",\n                 ".join(map(repr, self.transforms))
         return "<ChainTransform [%s] at 0x%x>" % (tr, id(self))
 
+    def __del__(self):
+        # remove all the children transforms from our callback, since we are
+        # being deleted.  (But we do *not* want to remove children from other
+        # callbacks)
+        for t in self._transforms:
+            t.changed.disconnect(self._subtr_changed)
+        self.changed.disconnect()
+
 
 class SimplifiedChainTransform(ChainTransform):
     def __init__(self, chain):


### PR DESCRIPTION
The list of callbacks gets iterated over very often, so it's important
to make sure there aren't useless entries laying around.  Plus the
memory can grow without bound without correcting this.