### PR TITLE
Fix qt5 based backends when moving window from one monitor to another

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -361,7 +361,6 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         self.resize(w, h)
 
     def _vispy_set_physical_size(self, w, h):
-        print("Setting physical size to: ", w, h)
         self._physical_size = (w, h)
 
     def _vispy_get_physical_size(self):


### PR DESCRIPTION
This is similar to https://github.com/matplotlib/matplotlib/issues/8061 for matplotlib. I work on a macbook with a HiDPI retina display. My external monitor at work is not HiDPI. If I open a PyQt5 canvas on one monitor and drag it to another it gets in to a bad state. This is caused by the two displays having different device pixel ratios. This is the ratio of logical pixels to physical screen pixels. On HiDPI displays this is usually 2 and for regular displays it is 1.

PyQt5 allows you to know this ratio (`self.devicePixelRatio()`) and vispy already uses it to adjust physical versus logic pixel calculations. However, vispy only does this when first creating the window and on resize events. This means that if you get in to the bad state mentioned above you can resize the window and everything goes back to normal...until you move the window to another monitor. This PR moves the check of `self.devicePixelRatio()` to the getter of `physical_size`. This likely has some performance penalty but it should be relatively small if PyQt5 is optimizing things correctly.

This PR fixes this issue 99.9% of the way. There is still an issue if you move the window and don't interact with the canvas (cause a redraw). As far as I know there is no signal in PyQt5 to say "we've moved to a different display" that I have access to. Although, PyQt5 seems to be displaying things just fine since text and window sizes are kept proportional.