### PR TITLE
FIX: set `conda config --set channel_priority strict` in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ before_install:
     - export PATH=~/anaconda/bin:$PATH
     - conda config --add channels conda-forge
     - conda update --yes --quiet conda
-    # remove defaults, depend only on conda-forge
-    - conda config --remove channels defaults
+    # Set strict channel priority
+    conda config --set channel_priority strict
 
 
     - SRC_DIR=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
     - conda config --add channels conda-forge
     - conda update --yes --quiet conda
     # Set strict channel priority
-    conda config --set channel_priority strict
+    - conda config --set channel_priority strict
 
 
     - SRC_DIR=$(pwd)


### PR DESCRIPTION
So this adds the recent conda strict `channel_priority`. This means, that if a package is not available on conda-forge it will be fetched from defaults without touching other depending packages.