### PR TITLE
Fix setup.py to install vispy even if javascript compilation fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,12 +98,17 @@ developers to use the development version on Github (master branch). You need
 to clone the repository and install VisPy with
 ``python setup.py install``.
 
-As a one-liner, assuming `git` is installed ::
+As a one-liner, assuming `git` is installed::
 
-    git clone https://github.com/vispy/vispy.git && cd vispy && python setup.py install --user
+    git clone --recurse-submodules https://github.com/vispy/vispy.git && cd vispy && python setup.py install --user
 
 This will automatically install the latest version of vispy.
 
+If you already have vispy cloned, you may need to update the git submodules
+to make sure you have the newest code::
+
+    git pull
+    git submodule update --init --recursive
 
 Structure of VisPy
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,14 @@ def js_prerelease(command, strict=False):
                     log.warn('rebuilding js and css failed')
                     if missing:
                         log.error('missing files: %s' % missing)
-                    raise e
+                    # HACK: Allow users who can't build the JS to still install vispy
+                    if not is_repo:
+                        raise e
+                    log.warn('WARNING: continuing installation WITHOUT nbextension javascript')
+                    # remove JS files from data_files so setuptools doesn't try to copy
+                    # non-existent files
+                    self.distribution.data_files = [x for x in self.distribution.data_files
+                                                    if 'jupyter' not in x[0]]
                 else:
                     log.warn('rebuilding js and css failed (not a problem)')
                     log.warn(str(e))
@@ -284,8 +291,8 @@ setup(
     install_requires=['numpy'],
     extras_require={
         'ipython-static': ['ipython'],
-        'ipython-vnc': ['ipython>=3'],
-        'ipython-webgl': ['ipywidgets>=7.0', 'ipython>=3', 'tornado'],
+        'ipython-vnc': ['ipython>=7'],
+        'ipython-webgl': ['ipywidgets>=7.0', 'ipython>=7', 'tornado'],
         'pyglet': ['pyglet>=1.2'],
         # 'pyqt4': [],  # Why is this on PyPI, but without downloads?
         # 'pyqt5': [],  # Ditto.


### PR DESCRIPTION
In #1610 I fixed setup.py to match the [ipywidgets cookiecutter](https://github.com/jupyter-widgets/widget-cookiecutter) for a notebook/jlab extension. As part of this PR I had removed the `vispy/static/*.js` files which are the bundled output of the javascript build process. Given the rest of the traditional ipywidgets installation process this meant that `setup.py` was now **requiring** that the javascript files be built before installing the rest of vispy. Obviously for a package like vispy this can't be a requirement (a notebook is only one possible backend/use case for our users). This issue is discussed further in #1619 where some users may not have `npm` installed or may have an older version that is unable to build the extensions for whatever reason.

I saw two possible solutions (and asked for more on https://github.com/jupyter-widgets/widget-cookiecutter/issues/49):

1. Add the static javascript files to the git repository so users always have at least one version of the static files. This is not great for file sizes in the git history where each update to the JS likely means a new ~1.5MB (see below). It could also make it harder to tell if `sdist` packages are including the "old" JS builds or are building them new when preparing a package for PyPI.

```bash
$ du -hs vispy/static/
1.5M	vispy/static/
```

2. Modifying the `setup.py` code to allow for JS building to fail. This is what I ended up going with. This puts more work on the maintainers (@kmuehlbauer @larsoner ) to make sure that released PyPI sdists have the javascript files. I updated the [releasing instructions](https://github.com/vispy/vispy/wiki/Releasing-new-version-of-VisPy-python-package#generate-pypi-release-bundles
) already. This choice felt the cleanest to me in the long run and seems less likely that I'll screw it up when building an sdist.

The main difficulty here is that in `setuptools/distutils` there is no difference between the `sdist` that `pip` and `python setup.py install` do and the `sdist` we use when building a release tarball (`python setup.py sdist`). I could make a custom command that we use for building the tarball that makes the javascript build required, but that becomes yet another hack and customization in the vispy build workflow on top of all of the existing complex `doc` and other build processes.

@deciph and @os-gabe could you test this on your own systems by doing:

```bash
pip install git+https://github.com/djhoese/vispy.git@bugfix-setuppy-js
```

Does it install on your systems?