### PR TITLE
Fix PySide2 qWait monkey patching

### DIFF
--- a/vispy/app/backends/_pyside2.py
+++ b/vispy/app/backends/_pyside2.py
@@ -44,7 +44,7 @@ else:
             PySide2.QtWidgets.QApplication.processEvents()
             while time.time() < start + msec * 0.001:
                 PySide2.QtWidgets.QApplication.processEvents()
-    QtTest.QTest.qWait = qWait
+        QtTest.QTest.qWait = qWait
 
     which = ('PySide2', PySide2.__version__, QtCore.__version__)
     # Remove _qt module to force an import even if it was already imported


### PR DESCRIPTION
The indention of the line
	QtTest.QTest.qWait = qWait
should be so that it is only executed when the qWait function
needs to be monkey-patched.