### PR TITLE
Add 'python_requires' to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ install:
     # EGL and mesa causes segmentation faults. See issue #1401.
     # can remove the github numpydoc install once >0.8.0 is released and get it from conda
     - if [ "${DEPS}" == "full" ]; then
-        conda install --yes pyopengl networkx pysdl2;
+        conda install --yes pyopengl networkx pysdl2 sdl2=2.0.8;
         pip install git+https://github.com/numpy/numpydoc;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
           conda install --yes matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw;

--- a/setup.py
+++ b/setup.py
@@ -288,6 +288,7 @@ setup(
         'jsdeps': NPM,
         'build_ext': build_ext,
     },
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=['numpy'],
     extras_require={
         'ipython-static': ['ipython'],


### PR DESCRIPTION
Adding `python_requires` to the `setup.py` tells PyPI what client versions can download certain packages. By releasing the next version (0.6) with this and supporting python 2.7, this *should* make it the last version that python 2.7 clients are able to download automatically. It should avoid 2.7 clients downloading versions that are no longer python 2.7 compatible in the future.

Also looks like SDL2 on conda-forge is now causing issues on travis.