### PR TITLE
Remove forced sdl2 version in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ install:
     # EGL and mesa causes segmentation faults. See issue #1401.
     # can remove the github numpydoc install once >0.8.0 is released and get it from conda
     - if [ "${DEPS}" == "full" ]; then
-        conda install --yes pyopengl networkx pysdl2 sdl2=2.0.8;
+        conda install --yes pyopengl networkx pysdl2;
         pip install git+https://github.com/numpy/numpydoc;
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
           conda install --yes matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw;


### PR DESCRIPTION
See https://github.com/conda-forge/sdl2-feedstock/issues/13