### PR TITLE
Fix ValueError exception from ambiguous truth value in PanZoomCamera

### DIFF
--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -86,7 +86,7 @@ class PanZoomCamera(BaseCamera):
             current center.
         """
         # Init some variables
-        center = center or self.center
+        center = center if (center is not None) else self.center
         assert len(center) in (2, 3, 4)
         # Get scale factor, take scale ratio into account
         if np.isscalar(factor):


### PR DESCRIPTION
When zooming with the PanZoomCamera, I get a ValueError: The truth value of an array with more than one element is ambiguous. Here is a fix that works when center is none using a line that was changed in commit a8ee4f45a56ff9509546cade6439cdda841b7a04.

I stumbled upon this by running vispy/examples/demo/scene/picking.py using python3.7.2 and numpy 1.16.2.