### PR TITLE
Add pyproject.toml file for better build support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.29.2",
+    "numpy; python_version=='2.7'",
+    "numpy==1.13.3; python_version=='3.5'",
+    "numpy==1.13.3; python_version=='3.6'",
+    "numpy==1.14.5; python_version>='3.7'",
+]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ from setuptools.command.build_py import build_py
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.egg_info import egg_info
 from subprocess import check_call
-import numpy as np
 
 
 try:
@@ -305,7 +304,6 @@ setup(
     },
     packages=find_packages(),
     ext_modules=cythonize(extensions),
-    include_dirs=[np.get_include()],
     package_dir={'vispy': 'vispy'},
     data_files=[
         ('share/jupyter/nbextensions/vispy', [


### PR DESCRIPTION
Closes #1651 

This adds a `pyproject.toml` to match PEP 518 specification so that build dependencies can be handled outside of `setup.py`. I'm hoping that @os-gabe @larsoner @renefritze and @kmuehlbauer could review and maybe test this for me as it is. Mainly, I'm wondering if the numpy/py27 setting is "good enough" for now. We won't be supporting python 2.7 after this next release, but it should at least work (is PEP 518 supported for py27?).

I'd like to add to this later with some changes to how `numpy` is imported in `setup.py` since I don't *think* it is needed the way we have it.

Also, does anyone know if there is a way to optionally require `npm` so that the jupyter widget can be built/compiled?