### PR TITLE
Fix reading depth buffers with read_pixels

### DIFF
--- a/vispy/gloo/framebuffer.py
+++ b/vispy/gloo/framebuffer.py
@@ -250,8 +250,11 @@ class FrameBuffer(GLObject):
         
         """
         _check_valid('mode', mode, ['color', 'depth', 'stencil'])
+        buffer = getattr(self, mode + '_buffer')
+        if buffer is None:
+            raise ValueError("Can't read pixels for buffer {}, "
+                             "buffer does not exist.".format(mode))
         if crop is None:
-            buffer = getattr(self, mode+'_buffer')
             h, w = buffer.shape[:2]
             crop = (0, 0, w, h)
         

--- a/vispy/gloo/framebuffer.py
+++ b/vispy/gloo/framebuffer.py
@@ -257,5 +257,4 @@ class FrameBuffer(GLObject):
         
         # todo: this is ostensibly required, but not available in gloo.gl
         #gl.glReadBuffer(buffer._target)
-        
-        return read_pixels(crop, alpha=alpha)
+        return read_pixels(crop, alpha=alpha, mode=mode)

--- a/vispy/gloo/tests/test_wrappers.py
+++ b/vispy/gloo/tests/test_wrappers.py
@@ -211,13 +211,14 @@ def test_wrappers():
 def test_read_pixels():
     """Test read_pixels to ensure that the image is not flipped"""
     # Create vertices
-    vPosition = np.array([[-1, 1], [0, 1],  # For drawing a square to top left
-                          [-1, 0], [0, 0]], np.float32)
+    vPosition = np.array(
+        [[-1, 1, 0.0], [0, 1, 0.5],  # For drawing a square to top left
+         [-1, 0, 0.0], [0, 0, 0.5]], np.float32)
 
     VERT_SHADER = """ // simple vertex shader
-    attribute vec2 a_position;
+    attribute vec3 a_position;
     void main (void) {
-        gl_Position = vec4(a_position, 0., 1.0);
+        gl_Position = vec4(a_position, 1.0);
     }
     """
 
@@ -231,6 +232,7 @@ def test_read_pixels():
     with Canvas() as c:
         c.set_current()
         gloo.set_viewport(0, 0, *c.size)
+        gloo.set_state(depth_test=True)
         c._program = gloo.Program(VERT_SHADER, FRAG_SHADER)
         c._program['a_position'] = gloo.VertexBuffer(vPosition)
         gloo.clear(color='black')
@@ -246,6 +248,16 @@ def test_read_pixels():
         assert_true(corners == 0)  # Should be all 0
         gloo.flush()
         gloo.finish()
+
+        # Check that we can read the depth buffer
+        img = read_pixels(mode='depth')
+        assert_equal(img.shape[:2], c.size[::-1])
+        assert_equal(img.shape[2], 1)
+        unique_img = np.unique(img)
+        # we should have quite a few different depth values
+        assert unique_img.shape[0] > 50
+        assert unique_img.max() == 255
+        assert unique_img.min() == 128
 
 
 run_tests_if_main()

--- a/vispy/gloo/tests/test_wrappers.py
+++ b/vispy/gloo/tests/test_wrappers.py
@@ -257,7 +257,7 @@ def test_read_pixels():
         # we should have quite a few different depth values
         assert unique_img.shape[0] > 50
         assert unique_img.max() == 255
-        assert unique_img.min() == 128
+        assert unique_img.min() > 0
 
 
 run_tests_if_main()

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -616,7 +616,10 @@ def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte
         the current GL viewport will be queried and used.
     alpha : bool
         If True (default), the returned array has 4 elements (RGBA).
-        If False, it has 3 (RGB).
+        If False, it has 3 (RGB). This only effects the color mode.
+    mode : str
+        Type of buffer data to read. Can be one of 'colors', 'depth',
+        or 'stencil'. See returns for more information.
     out_type : str | dtype
         Can be 'unsigned_byte' or 'float'. Note that this does not
         use casting, but instead determines how values are read from
@@ -627,8 +630,10 @@ def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte
     -------
     pixels : array
         3D array of pixels in np.uint8 or np.float32 format.
-        The array shape is (h, w, 3) or (h, w, 4), with the top-left corner
-        of the framebuffer at index [0, 0] in the returned array.
+        The array shape is (h, w, 3) or (h, w, 4) for colors mode,
+        with the top-left corner of the framebuffer at index [0, 0] in the
+        returned array. If 'mode' is depth or stencil then the last dimension
+        is 1.
     """
     _check_valid('mode', mode, ['color', 'depth', 'stencil'])
 

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -602,7 +602,7 @@ for name in dir(global_gloo_functions):
 ## Functions that do not use the glir queue
 
 
-def read_pixels(viewport=None, alpha=True, out_type='unsigned_byte'):
+def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte'):
     """Read pixels from the currently selected buffer.
 
     Under most circumstances, this function reads from the front buffer.
@@ -630,6 +630,8 @@ def read_pixels(viewport=None, alpha=True, out_type='unsigned_byte'):
         The array shape is (h, w, 3) or (h, w, 4), with the top-left corner
         of the framebuffer at index [0, 0] in the returned array.
     """
+    _check_valid('mode', mode, ['color', 'depth', 'stencil'])
+
     # Check whether the GL context is direct or remote
     context = get_current_canvas().context
     if context.shared.parser.is_remote():
@@ -649,7 +651,18 @@ def read_pixels(viewport=None, alpha=True, out_type='unsigned_byte'):
                          % (viewport,))
     x, y, w, h = viewport
     gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)  # PACK, not UNPACK
-    fmt = gl.GL_RGBA if alpha else gl.GL_RGB
+    if mode == 'depth':
+        fmt = gl.GL_DEPTH_COMPONENT
+        shape = (h, w, 1)
+    elif mode == 'stencil':
+        fmt = gl.GL_STENCIL_INDEX8
+        shape = (h, w, 1)
+    elif alpha:
+        fmt = gl.GL_RGBA
+        shape = (h, w, 4)
+    else:
+        fmt = gl.GL_RGB
+        shape = (h, w, 3)
     im = gl.glReadPixels(x, y, w, h, fmt, type_)
     gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 4)
     # reshape, flip, and return
@@ -657,8 +670,8 @@ def read_pixels(viewport=None, alpha=True, out_type='unsigned_byte'):
         np_dtype = np.uint8 if type_ == gl.GL_UNSIGNED_BYTE else np.float32
         im = np.frombuffer(im, np_dtype)
 
-    im.shape = h, w, (4 if alpha else 3)  # RGBA vs RGB
-    im = im[::-1, :, :]  # flip the image
+    im.shape = shape
+    im = im[::-1, ...]  # flip the image
     return im
 
 


### PR DESCRIPTION
Closes #1250 

This is a simple hack for fixing reading depth buffers. The problem as described in the related issue was that when you asked to read the depth buffer the underlying `read_pixels` function was still asking for an RGB/RGBA array, meaning the color was being read. This PR fixes that by passing a `mode` parameter which can be color/depth/stencil and will use the appropriate GL constant when calling `glReadPixels`.

Questions for the maintainers:

1. Is `mode` the best way to solve this?
2. Should the return value always be 3D even if it is (rows, columns, 1) for depth and stencil?
3. I also realized that `stencil` mode doesn't work with the `crop` logic in frame buffer's `read` because there is no `self.stencil_buffer` attribute. Not sure the best way to fix this.

TODO:

- [ ] Tests
- [ ] Fix docstrings

