### PR TITLE
Fix AGG line artifacts from transparent colors

### DIFF
--- a/vispy/glsl/lines/agg.vert
+++ b/vispy/glsl/lines/agg.vert
@@ -100,11 +100,11 @@ void main()
     v_linewidth = max(v_linewidth, 1.0);
 
     // If color is fully transparent we just will discard the fragment anyway
-    if( v_color.a <= 0.0 )
-    {
-        gl_Position = vec4(0.0,0.0,0.0,1.0);
-        return;
-    }
+//    if( v_color.a <= 0.0 )
+//    {
+//        gl_Position = vec4(0.0,0.0,0.0,1.0);
+//        return;
+//    }
 
     // This is the actual half width of the line
     // TODO: take care of logical - physical pixel difference here.


### PR DESCRIPTION
This is a partial fix of #588. See the issue for screenshots and further discussion.

In general, my understanding of the issue is that the if statement commented out by this PR in `agg.vert` is/was causing the vertex shader to be exited too early; short-circuiting the logic that feeds the fragment shader for angles and other parameters to determine proper AGG line color and look.

As mentioned in the related issue, there still seems to be a non-alpha related issue where certain line joins show up as brighter parts of the line. Those will have to be fixed in a later PR.