### PR TITLE
Fix numpy 1.17 deprecation warnings about dtype creation

### DIFF
--- a/vispy/visuals/line/arrow.py
+++ b/vispy/visuals/line/arrow.py
@@ -50,11 +50,11 @@ class _ArrowHeadVisual(Visual):
     ARROWHEAD_FRAGMENT_SHADER = glsl.get('arrowheads/arrowheads.frag')
 
     _arrow_vtype = np.dtype([
-        ('v1', np.float32, 4),
-        ('v2', np.float32, 4),
-        ('size', np.float32, 1),
-        ('color', np.float32, 4),
-        ('linewidth', np.float32, 1)
+        ('v1', np.float32, (4,)),
+        ('v2', np.float32, (4,)),
+        ('size', np.float32),
+        ('color', np.float32, (4,)),
+        ('linewidth', np.float32)
     ])
 
     def __init__(self, parent):

--- a/vispy/visuals/line/line.py
+++ b/vispy/visuals/line/line.py
@@ -390,13 +390,13 @@ class _GLLineVisual(Visual):
 
 
 class _AggLineVisual(Visual):
-    _agg_vtype = np.dtype([('a_position', np.float32, 2),
-                           ('a_tangents', np.float32, 4),
-                           ('a_segment',  np.float32, 2),
-                           ('a_angles',   np.float32, 2),
-                           ('a_texcoord', np.float32, 2),
-                           ('alength', np.float32, 1),
-                           ('color', np.float32, 4)])
+    _agg_vtype = np.dtype([('a_position', np.float32, (2,)),
+                           ('a_tangents', np.float32, (4,)),
+                           ('a_segment', np.float32, (2,)),
+                           ('a_angles', np.float32, (2,)),
+                           ('a_texcoord', np.float32, (2,)),
+                           ('alength', np.float32),
+                           ('color', np.float32, (4,))])
 
     VERTEX_SHADER = glsl.get('lines/agg.vert')
     FRAGMENT_SHADER = glsl.get('lines/agg.frag')


### PR DESCRIPTION
See https://github.com/napari/napari/issues/404

Talked with @seberg in person and now understand what the deprecation warnings in the above issue are talking about. This PR should fix the warnings from popping up and retain the current behavior.