### PR TITLE
Fix _glsl_step reversing discrete colormaps

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -183,7 +183,7 @@ def _glsl_step(controls=None, colors=None, texture_map_data=None):
 
     # Perform element-wise comparison to find
     # control points for all LUT colors.
-    bn = np.sum(controls.transpose() >= t2, axis=1)
+    bn = np.sum(controls.transpose() <= t2, axis=1)
 
     j = np.clip(bn-1, 0, ncolors-1)
 

--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -376,7 +376,7 @@ def get_test_data_repo():
     # This tag marks the test-data commit that this version of vispy should
     # be tested against. When adding or changing test images, create
     # and push a new tag and update this variable.
-    test_data_tag = 'test-data-9'
+    test_data_tag = 'test-data-10'
 
     data_path = config['test_data_path']
     git_path = 'http://github.com/vispy/test-data'


### PR DESCRIPTION
The texture-based `_glsl_step` (https://github.com/vispy/vispy/pull/1457) results in reversed colormaps when viewing non-interpolated colormaps (e.g. `Colormap(..., interpolation='zero'`).

Flipping the comparison here assigns the correct LUT entry. (e.g., the first control point should return 1 here, not N.)