### PR TITLE
Add automatic PyPI deployment through Azure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,3 +38,4 @@ exclude stdeb.cfg
 exclude .spyderproject
 recursive-exclude vispy *.c
 recursive-exclude js *
+recursive-exclude make *

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_8.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
@@ -16,8 +16,8 @@ jobs:
         git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel twine numpy Cython jupyter ipywidgets
-        cibuildwheel --output-dir wheelhouse .
         python setup.py sdist -d wheelhouse
+        cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "wget https://archives.fedoraproject.org/pub/archive/epel/5/x86_64/epel-release-5-4.noarch.rpm; rpm -Uhv epel-release-5-4.noarch.rpm; yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "curl -O https://archives.fedoraproject.org/pub/archive/epel/5/x86_64/epel-release-5-4.noarch.rpm; rpm -Uhv epel-release-5-4.noarch.rpm; yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,10 @@
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose numpy Cython jupyter ipywidgets"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
+  CIBW_BUILD_VERBOSITY: "2"
+  CIBW_BEFORE_BUILD: "pip install numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
@@ -11,7 +13,7 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel twine
+        pip install cibuildwheel twine numpy Cython jupyter ipywidgets
         cibuildwheel --output-dir wheelhouse .
         python setup.py sdist -d wheelhouse
     - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel twine
+        pip install cibuildwheel twine numpy
         cibuildwheel --output-dir wheelhouse .
         python setup.py sdist -d wheelhouse
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,10 +58,10 @@ jobs:
     - task: UsePythonVersion@0
     - task: DownloadPipelineArtifact@2
       inputs:
-        patterns:
-          - vispyDeployLinux/*
-          - vispyDeployMacOS/*.whl
-          - vispyDeployWindows/*.whl
+        patterns: |
+          vispyDeployLinux/*
+          vispyDeployMacOS/*.whl
+          vispyDeployWindows/*.whl
     - bash: |
         python -m pip install --upgrade pip
         pip install twine

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,8 +57,8 @@ jobs:
   steps:
     - task: UsePythonVersion@0
     - task: DownloadPipelineArtifact@2
-        inputs:
-          artifact: vispyDeploy
+      inputs:
+        artifact: vispyDeploy
     - bash: |
         python -m pip install --upgrade pip
         pip install twine

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,9 @@ jobs:
     - windows
   steps:
     - task: UsePythonVersion@0
-    - env:
-        TWINE_PASSWORD: $(pypiToken)
     - bash: |
         python -m pip install --upgrade pip
         pip install twine
         twine upload -u "@token" --skip-existing wheelhouse/*
+      env:
+        TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     - task: PublishPipelineArtifact@1
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
-        artifact: vispyDeploy
+        artifact: vispyDeployLinux
 - job: macos
   pool: {vmImage: 'macOS-10.13'}
   steps:
@@ -29,7 +29,7 @@ jobs:
     - task: PublishPipelineArtifact@1
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
-        artifact: vispyDeploy
+        artifact: vispyDeployMacOS
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
   steps:
@@ -46,22 +46,23 @@ jobs:
     - task: PublishPipelineArtifact@1
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
-        artifact: vispyDeploy
-- job: deploy
+        artifact: vispyDeployWindows
+- deployment: DeployPyPI
+  displayName: Deploy PyPI
   pool: {vmImage: 'Ubuntu-16.04'}
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
   dependsOn:
     - linux
     - macos
     - windows
-  steps:
-    - task: UsePythonVersion@0
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifact: vispyDeploy
-    - bash: |
-        python -m pip install --upgrade pip
-        pip install twine
-        twine upload -u "@token" --skip-existing vispyDeploy/*
-      env:
-        TWINE_PASSWORD: $(pypiToken)
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+          - task: UsePythonVersion@0
+          - bash: |
+              python -m pip install --upgrade pip
+              pip install twine
+              twine upload -u "@token" --skip-existing vispyDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
+            env:
+              TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,23 +47,24 @@ jobs:
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: vispyDeployWindows
-- deployment: DeployPyPI
-  displayName: Deploy PyPI
-  environment: 'vispy.deploypypi'
+- job: deployPyPI
   pool: {vmImage: 'Ubuntu-16.04'}
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
   dependsOn:
     - linux
     - macos
     - windows
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-          - task: UsePythonVersion@0
-          - bash: |
-              python -m pip install --upgrade pip
-              pip install twine
-              twine upload -u "@token" --skip-existing vispyDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
-            env:
-              TWINE_PASSWORD: $(pypiToken)
+  steps:
+    - task: UsePythonVersion@0
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        patterns:
+          - vispyDeployLinux/*
+          - vispyDeployMacOS/*.whl
+          - vispyDeployWindows/*.whl
+    - bash: |
+        python -m pip install --upgrade pip
+        pip install twine
+        twine upload -u "@token" --skip-existing vispyDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
+      env:
+        TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_9.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_8.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose numpy Cython jupyter ipywidgets"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
@@ -11,7 +11,7 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel twine numpy Cython
+        pip install cibuildwheel twine
         cibuildwheel --output-dir wheelhouse .
         python setup.py sdist -d wheelhouse
     - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,9 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install numpy Cython jupyter ipywidgets"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD: "pip install -U pip setuptools; pip install -U numpy Cython jupyter ipywidgets"
+  CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb npm; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,9 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel
+        pip install cibuildwheel twine
         cibuildwheel --output-dir wheelhouse .
+        python setup.py sdist -d wheelhouse
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
 - job: macos
@@ -21,7 +22,6 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
@@ -36,7 +36,21 @@ jobs:
     - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
+- job: deploy
+  pool: {vmImage: 'Ubuntu-16.04'}
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
+  dependsOn:
+    - linux
+    - macos
+    - windows
+  steps:
+    - task: UsePythonVersion@0
+    - env:
+        TWINE_PASSWORD: $(pypiToken)
+    - bash: |
+        python -m pip install --upgrade pip
+        pip install twine
+        twine upload -u "@token" --skip-existing wheelhouse/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ jobs:
         artifact: vispyDeployWindows
 - deployment: DeployPyPI
   displayName: Deploy PyPI
+  environment: 'vispy.deploypypi'
   pool: {vmImage: 'Ubuntu-16.04'}
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
   dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "wget https://archives.fedoraproject.org/pub/archive/epel/5/x86_64/epel-release-5-4.noarch.rpm; rpm -Uhv epel-release-5-4.noarch.rpm; yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,16 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U pip setuptools; pip install -U numpy Cython jupyter ipywidgets"
-  CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb npm; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
+  CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
   steps:
     - task: UsePythonVersion@0
     - bash: |
+        git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel twine numpy Cython jupyter ipywidgets
         cibuildwheel --output-dir wheelhouse .
@@ -26,6 +27,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
     - bash: |
+        git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
@@ -43,6 +45,7 @@ jobs:
     - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
     - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
     - bash: |
+        git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,13 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
-        pip install cibuildwheel twine numpy
+        pip install cibuildwheel twine numpy Cython
         cibuildwheel --output-dir wheelhouse .
         python setup.py sdist -d wheelhouse
-    - task: PublishBuildArtifacts@1
-      inputs: {pathtoPublish: 'wheelhouse'}
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: vispyDeploy
 - job: macos
   pool: {vmImage: 'macOS-10.13'}
   steps:
@@ -24,8 +26,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
-    - task: PublishBuildArtifacts@1
-      inputs: {pathtoPublish: 'wheelhouse'}
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: vispyDeploy
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
   steps:
@@ -39,8 +43,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
-    - task: PublishBuildArtifacts@1
-      inputs: {pathtoPublish: 'wheelhouse'}
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: vispyDeploy
 - job: deploy
   pool: {vmImage: 'Ubuntu-16.04'}
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
@@ -50,9 +56,12 @@ jobs:
     - windows
   steps:
     - task: UsePythonVersion@0
+    - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: vispyDeploy
     - bash: |
         python -m pip install --upgrade pip
         pip install twine
-        twine upload -u "@token" --skip-existing wheelhouse/*
+        twine upload -u "@token" --skip-existing vispyDeploy/*
       env:
         TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_10.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_9.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "curl -O https://archives.fedoraproject.org/pub/archive/epel/5/x86_64/epel-release-5-4.noarch.rpm; rpm -Uhv epel-release-5-4.noarch.rpm; yum install -y fontconfig xvfb npm; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "curl -sL https://rpm.nodesource.com/setup_10.x | bash -; yum install -y fontconfig xvfb nodejs; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
     - task: UsePythonVersion@0
     - bash: |
         python -m pip install --upgrade pip
+        pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
@@ -36,6 +37,7 @@ jobs:
     - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
     - bash: |
         python -m pip install --upgrade pip
+        pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ class NPM(Command):
             log.info("Installing build dependencies with npm.  This may take "
                      "a while...")
             npmName = self.get_npm_name();
-            check_call([npmName, 'install'], cwd=node_root,
+            check_call([npmName, 'install', '--verbose'], cwd=node_root,
                        stdout=sys.stdout, stderr=sys.stderr)
             os.utime(self.node_modules, None)
 

--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,7 @@ setup(
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=['numpy', 'freetype-py'],
-    build_requires=['numpy', 'cython'],
+    setup_requires=['numpy', 'cython'],
     extras_require={
         'ipython-static': ['ipython'],
         'ipython-vnc': ['ipython>=7'],

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -22,7 +22,7 @@ from __future__ import division
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']
 
 # Definition of the version number
-version_info = 0, 6, 0  # 'dev0'  # major, minor, patch, extra
+version_info = 0, 6, 1, 'dev0'  # major, minor, patch, extra
 
 # Nice string for the version (mimic how IPython composes its version str)
 __version__ = '-'.join(map(str, version_info)).replace('-', '.').strip('-')


### PR DESCRIPTION
This PR updates the azure configuration to:

1. Add sdist generation
2. Upload the sdist and all wheels to PyPI

This works by setting a special variable in the Azure web UI with a PyPI API token under my account. This token only has access to upload to the vispy project on PyPI, will do it as me, and the secret variable can only be seen by people who have permission on the azure vispy project. By setting the environment variable `TWINE_PASSWORD to this value `twine` should pick it up and use it to upload the packages.

The main thing I think I have wrong is that all the wheels and the sdist file are uploaded to the "wheelhouse" artifacts storage, but I don't think I can access that as a simple directory in a separate job (see the `twine upload` call). If there is no way to do that then I can do the upload in each job separately.