### PR TITLE
Fix numpy futurewarning in dtype creation

### DIFF
--- a/examples/demo/gloo/boids.py
+++ b/examples/demo/gloo/boids.py
@@ -54,12 +54,13 @@ class Canvas(app.Canvas):
 
         # Create boids
         n = 1000
+        size_type = ('size', 'f4', 1*ps) if ps > 1 else ('size', 'f4')
         self.particles = np.zeros(2 + n, [('position', 'f4', 3),
                                           ('position_1', 'f4', 3),
                                           ('position_2', 'f4', 3),
                                           ('velocity', 'f4', 3),
                                           ('color', 'f4', 4),
-                                          ('size', 'f4', 1*ps)])
+                                          size_type])
         self.boids = self.particles[2:]
         self.target = self.particles[0]
         self.predator = self.particles[1]

--- a/examples/demo/gloo/cloud.py
+++ b/examples/demo/gloo/cloud.py
@@ -223,7 +223,7 @@ class Canvas(app.Canvas):
         data = np.zeros(n, [('a_position', np.float32, 3),
                             ('a_bg_color', np.float32, 4),
                             ('a_fg_color', np.float32, 4),
-                            ('a_size', np.float32, 1)])
+                            ('a_size', np.float32)])
         data['a_position'] = 0.45 * np.random.randn(n, 3)
         data['a_bg_color'] = np.random.uniform(0.85, 1.00, (n, 4))
         data['a_fg_color'] = 0, 0, 0, 1

--- a/examples/demo/gloo/donut.py
+++ b/examples/demo/gloo/donut.py
@@ -112,7 +112,7 @@ class Canvas(app.Canvas):
         data = np.zeros(p * n, [('a_position', np.float32, 2),
                                 ('a_bg_color', np.float32, 4),
                                 ('a_fg_color', np.float32, 4),
-                                ('a_size',     np.float32, 1)])
+                                ('a_size',     np.float32)])
         data['a_position'][:, 0] = np.resize(np.linspace(
                                              0, 2 * np.pi, n), p * n)
         data['a_position'][:, 1] = np.repeat(np.linspace(0, 2 * np.pi, p), n)

--- a/examples/demo/gloo/fireworks.py
+++ b/examples/demo/gloo/fireworks.py
@@ -34,7 +34,7 @@ im1 *= np.array((X ** 2 + Y ** 2) <= radius * radius, dtype='float32')
 N = 10000
 
 # Create vertex data container
-data = np.zeros(N, [('a_lifetime', np.float32, 1),
+data = np.zeros(N, [('a_lifetime', np.float32),
                     ('a_startPosition', np.float32, 3),
                     ('a_endPosition', np.float32, 3)])
 

--- a/examples/demo/gloo/galaxy.py
+++ b/examples/demo/gloo/galaxy.py
@@ -120,8 +120,8 @@ class Canvas(app.Canvas):
         self.title = "A very fake galaxy [mouse scroll to zoom]"
 
         data = np.zeros(n, [('a_position', np.float32, 3),
-                        ('a_size', np.float32, 1),
-                        ('a_dist', np.float32, 1)])
+                        ('a_size', np.float32),
+                        ('a_dist', np.float32)])
 
         for i in range(3):
             P, S, D = make_arm(p, i * 2 * np.pi / 3)

--- a/examples/demo/gloo/galaxy/galaxy.py
+++ b/examples/demo/gloo/galaxy/galaxy.py
@@ -155,11 +155,11 @@ class Canvas(app.Canvas):
 
     def __create_galaxy_vertex_data(self):
         data = np.zeros(len(galaxy),
-                        dtype=[('a_size', np.float32, 1),
+                        dtype=[('a_size', np.float32),
                                ('a_position', np.float32, 2),
-                               ('a_color_index', np.float32, 1),
-                               ('a_brightness', np.float32, 1),
-                               ('a_type', np.float32, 1)])
+                               ('a_color_index', np.float32),
+                               ('a_brightness', np.float32),
+                               ('a_type', np.float32)])
 
         # see shader for parameter explanations
         pw, ph = self.physical_size

--- a/examples/demo/gloo/galaxy/galaxy_simulation.py
+++ b/examples/demo/gloo/galaxy/galaxy_simulation.py
@@ -63,15 +63,15 @@ class Galaxy(object):
         self._h2_count = 200
 
         # Particles
-        dtype = [('theta',       np.float32, 1),
-                 ('velocity',    np.float32, 1),
-                 ('angle',       np.float32, 1),
-                 ('m_a',         np.float32, 1),
-                 ('m_b',         np.float32, 1),
-                 ('size',        np.float32, 1),
-                 ('type',        np.float32, 1),
-                 ('temperature', np.float32, 1),
-                 ('brightness',  np.float32, 1),
+        dtype = [('theta',       np.float32),
+                 ('velocity',    np.float32),
+                 ('angle',       np.float32),
+                 ('m_a',         np.float32),
+                 ('m_b',         np.float32),
+                 ('size',        np.float32),
+                 ('type',        np.float32),
+                 ('temperature', np.float32),
+                 ('brightness',  np.float32),
                  ('position',    np.float32, 2)]
         n = self._stars_count + self._dust_count + 2*self._h2_count
         self._particles = np.zeros(n, dtype=dtype)

--- a/examples/demo/gloo/graph.py
+++ b/examples/demo/gloo/graph.py
@@ -139,8 +139,8 @@ class Canvas(app.Canvas):
         data = np.zeros(n, dtype=[('a_position', np.float32, 3),
                                   ('a_fg_color', np.float32, 4),
                                   ('a_bg_color', np.float32, 4),
-                                  ('a_size', np.float32, 1),
-                                  ('a_linewidth', np.float32, 1),
+                                  ('a_size', np.float32),
+                                  ('a_linewidth', np.float32),
                                   ])
         edges = np.random.randint(size=(ne, 2), low=0,
                                   high=n).astype(np.uint32)

--- a/examples/demo/gloo/molecular_viewer.py
+++ b/examples/demo/gloo/molecular_viewer.py
@@ -138,7 +138,7 @@ class Canvas(app.Canvas):
 
         data = np.zeros(n, [('a_position', np.float32, 3),
                             ('a_color', np.float32, 3),
-                            ('a_radius', np.float32, 1)])
+                            ('a_radius', np.float32)])
 
         data['a_position'] = self.coords
         data['a_color'] = self.atomsColours

--- a/examples/demo/gloo/quiver.py
+++ b/examples/demo/gloo/quiver.py
@@ -78,6 +78,7 @@ def on_mouse_move(event):
 program = gloo.Program(vertex, fragment, count=4)
 dx, dy = 1, 1
 program['position'] = (-dx, -dy), (-dx, +dy), (+dx, -dy), (+dx, +dy)
+program["iResolution"] = (2 * 512, 2 * 512)
 program["iMouse"] = (0., 0.)
 
 if __name__ == '__main__':

--- a/examples/demo/gloo/rain.py
+++ b/examples/demo/gloo/rain.py
@@ -95,7 +95,7 @@ class Canvas(app.Canvas):
         n = 500
         self.data = np.zeros(n, [('a_position', np.float32, 2),
                                  ('a_fg_color', np.float32, 4),
-                                 ('a_size',     np.float32, 1)])
+                                 ('a_size',     np.float32)])
         self.index = 0
         self.program = Program(vertex, fragment)
         self.vdata = VertexBuffer(self.data)

--- a/examples/demo/gloo/signals.py
+++ b/examples/demo/gloo/signals.py
@@ -22,7 +22,7 @@ y += np.arange(m).reshape((-1, 1))
 data = np.zeros(n*m, dtype=[
     ('a_position', np.float32, 2),
     ('a_color', np.float32, 3),
-    ('a_index', np.float32, 1),
+    ('a_index', np.float32),
 ])
 
 data['a_position'] = np.zeros((n*m, 2), dtype=np.float32)

--- a/examples/tutorial/gl/fireworks.py
+++ b/examples/tutorial/gl/fireworks.py
@@ -83,7 +83,7 @@ class Canvas(app.Canvas):
 
         # Build vertex buffer
         n = 10000
-        self.data = np.zeros(n, dtype=[('lifetime', np.float32, 1),
+        self.data = np.zeros(n, dtype=[('lifetime', np.float32),
                                        ('start',    np.float32, 3),
                                        ('end',      np.float32, 3)])
         vbuffer = gl.glCreateBuffer()

--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -451,7 +451,11 @@ class VertexBuffer(DataBuffer):
             if self._last_dim and c != self._last_dim:
                 raise ValueError('Last dimension should be %s not %s'
                                  % (self._last_dim, c))
-            data = data.view(dtype=[('f0', data.dtype.base, c)])
+            dtype_def = ('f0', data.dtype.base)
+            if c > 1:
+                # numpy dtypes with size 1 are ambiguous, only add size if it is greater than 1
+                dtype_def += (c,)
+            data = data.view(dtype=[dtype_def])
             self._last_dim = c
         return data
 

--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -452,7 +452,7 @@ class VertexBuffer(DataBuffer):
                 raise ValueError('Last dimension should be %s not %s'
                                  % (self._last_dim, c))
             dtype_def = ('f0', data.dtype.base)
-            if c > 1:
+            if c != 1:
                 # numpy dtypes with size 1 are ambiguous, only add size if it is greater than 1
                 dtype_def += (c,)
             data = data.view(dtype=[dtype_def])

--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -158,7 +158,7 @@ class Program(GLObject):
             for kind, type_, name, size in self._code_variables.values():
                 if kind == 'attribute':
                     dt, numel = self._gtypes[type_]
-                    dtype.append((name, dt, numel))
+                    dtype.append((name, dt, numel) if numel != 1 else (name, dt))
             self._buffer = np.zeros(self._count, dtype=dtype)
             self.bind(VertexBuffer(self._buffer))
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -560,8 +560,8 @@ class MarkersVisual(Visual):
         data = np.zeros(n, dtype=[('a_position', np.float32, 3),
                                   ('a_fg_color', np.float32, 4),
                                   ('a_bg_color', np.float32, 4),
-                                  ('a_size', np.float32, 1),
-                                  ('a_edgewidth', np.float32, 1)])
+                                  ('a_size', np.float32),
+                                  ('a_edgewidth', np.float32)])
         data['a_fg_color'] = edge_color
         data['a_bg_color'] = face_color
         if edge_width is not None:

--- a/vispy/visuals/windbarb.py
+++ b/vispy/visuals/windbarb.py
@@ -253,8 +253,8 @@ class WindbarbVisual(Visual):
                                   ('a_trig', np.float32, 0),
                                   ('a_fg_color', np.float32, 4),
                                   ('a_bg_color', np.float32, 4),
-                                  ('a_size', np.float32, 1),
-                                  ('a_edgewidth', np.float32, 1)])
+                                  ('a_size', np.float32),
+                                  ('a_edgewidth', np.float32)])
         data['a_fg_color'] = edge_color
         data['a_bg_color'] = face_color
         data['a_edgewidth'] = edge_width


### PR DESCRIPTION
In future versions of numpy defining a dtype as `('name', np.float32, 1)` will be interpreted differently. You currently get this warning:

```
/home/travis/build/vispy/vispy/vispy/visuals/markers.py:564: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  ('a_edgewidth', np.float32, 1)])
```

I fixed a couple of these after it was pointed out by some napari developers, but these should be all the rest now that travis can complain about them.

If I remember correctly vispy is currently using `, 1)` as "scalar" and in the future this will be treated as a length 1 array. But now I don't remember what `, 0)` means.