### PR TITLE
Add ability to pass webGL context arguments for notebook backend canvas initialization

### DIFF
--- a/vispy/app/backends/_ipynb_webgl.py
+++ b/vispy/app/backends/_ipynb_webgl.py
@@ -103,6 +103,8 @@ class CanvasBackend(BaseCanvasBackend):
         BaseCanvasBackend.__init__(self, *args)
         self._widget = None
 
+        self.webgl_config = {}
+
         p = self._process_backend_kwargs(kwargs)
         self._context = p.context
 
@@ -188,6 +190,7 @@ class CanvasBackend(BaseCanvasBackend):
             return
         if self._widget is None:
             self._widget = VispyWidget()
+            self._widget.webgl_config = self.webgl_config
             self._widget.set_canvas(self._vispy_canvas)
         display(self._widget)
 

--- a/vispy/app/backends/_ipynb_webgl.py
+++ b/vispy/app/backends/_ipynb_webgl.py
@@ -103,8 +103,7 @@ class CanvasBackend(BaseCanvasBackend):
         BaseCanvasBackend.__init__(self, *args)
         self._widget = None
 
-        self.webgl_config = {}
-
+        self._webgl_config = {}
         p = self._process_backend_kwargs(kwargs)
         self._context = p.context
 
@@ -129,6 +128,11 @@ class CanvasBackend(BaseCanvasBackend):
     def _init_glir(self):
         context = self._vispy_canvas.context
         context.shared.parser = WebGLGlirParser()
+
+    def _process_backend_kwargs(self, kwargs):
+        if 'webgl' in kwargs:
+            self._webgl_config = kwargs.pop('webgl')
+        return super()._process_backend_kwargs(kwargs)
 
     def _reinit_widget(self):
         self._vispy_canvas.set_current()
@@ -190,7 +194,7 @@ class CanvasBackend(BaseCanvasBackend):
             return
         if self._widget is None:
             self._widget = VispyWidget()
-            self._widget.webgl_config = self.webgl_config
+            self._widget.webgl_config = self._webgl_config
             self._widget.set_canvas(self._vispy_canvas)
         display(self._widget)
 

--- a/vispy/app/backends/ipython/_widget.py
+++ b/vispy/app/backends/ipython/_widget.py
@@ -4,7 +4,7 @@
 
 try:
     from ipywidgets.widgets import DOMWidget, register
-    from traitlets import Unicode, Int, Bool
+    from traitlets import Unicode, Int, Bool, Dict
 except Exception as exp:
     # Init dummy objects needed to import this module without errors.
     # These are all overwritten with imports from IPython (on success)
@@ -59,6 +59,7 @@ class VispyWidget(DOMWidget):
     width = Int().tag(sync=True)
     height = Int().tag(sync=True)
     resizable = Bool(value=True).tag(sync=True)
+    webgl_config = Dict(value={}).tag(sync=True)
 
     def __init__(self, **kwargs):
         if DOMWidget is object:

--- a/vispy/app/backends/ipython/_widget.py
+++ b/vispy/app/backends/ipython/_widget.py
@@ -22,7 +22,7 @@ except Exception as exp:
         def tag(self, *args, **kwargs):
             pass
 
-    Unicode = Int = Float = Bool = _MockTraitlet
+    Unicode = Int = Float = Bool = Dict = _MockTraitlet
     available, testable, why_not, which = False, False, str(exp), None
 else:
     available, testable, why_not, which = True, False, None, None

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -108,6 +108,12 @@ class Canvas(object):
     backends, they are detected manually with a fixed time delay.
     This can cause problems with accessibility, as increasing the OS detection
     time or using a dedicated double-click button will not be respected.
+
+    Backend-specific arguments can be given through the `backend_kwargs`
+    argument. Currently this can be used to control the webGL context
+    requested by the `ipynb_webgl` backend, for example::
+
+        canvas = Canvas(backend_kwargs={'webgl': dict(preserveDrawingBuffer=True)})
     """
 
     def __init__(self, title='VisPy canvas', size=(800, 600), position=None,

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -81,8 +81,8 @@ class Canvas(object):
         A scale factor to apply between logical and physical pixels in addition
         to the actual scale factor determined by the backend. This option
         allows the scale factor to be adjusted for testing.
-    **kwargs : dict
-        Keyword arguments specific to the backend canvas object.
+    backend_kwargs : dict
+        Keyword arguments to be supplied to the backend canvas object.
 
     Notes
     -----
@@ -114,7 +114,7 @@ class Canvas(object):
                  show=False, autoswap=True, app=None, create_native=True,
                  vsync=False, resizable=True, decorate=True, fullscreen=False,
                  config=None, shared=None, keys=None, parent=None, dpi=None,
-                 always_on_top=False, px_scale=1, **kwargs):
+                 always_on_top=False, px_scale=1, backend_kwargs=None):
 
         size = tuple(int(s) * px_scale for s in size)
         if len(size) != 2:
@@ -200,8 +200,9 @@ class Canvas(object):
             title=title, size=size, position=position, show=show,
             vsync=vsync, resizable=resizable, decorate=decorate,
             fullscreen=fullscreen, context=self._context,
-            parent=parent, always_on_top=always_on_top,
-            **kwargs)
+            parent=parent, always_on_top=always_on_top)
+        if backend_kwargs is not None:
+            self._backend_kwargs.update(**backend_kwargs)
 
         # Create widget now (always do this *last*, after all err checks)
         if create_native:

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -81,6 +81,8 @@ class Canvas(object):
         A scale factor to apply between logical and physical pixels in addition
         to the actual scale factor determined by the backend. This option
         allows the scale factor to be adjusted for testing.
+    **kwargs : dict
+        Keyword arguments specific to the backend canvas object.
 
     Notes
     -----
@@ -112,7 +114,7 @@ class Canvas(object):
                  show=False, autoswap=True, app=None, create_native=True,
                  vsync=False, resizable=True, decorate=True, fullscreen=False,
                  config=None, shared=None, keys=None, parent=None, dpi=None,
-                 always_on_top=False, px_scale=1):
+                 always_on_top=False, px_scale=1, **kwargs):
 
         size = tuple(int(s) * px_scale for s in size)
         if len(size) != 2:
@@ -194,11 +196,12 @@ class Canvas(object):
         self._set_keys(keys)
 
         # store arguments that get set on Canvas init
-        kwargs = dict(title=title, size=size, position=position, show=show,
-                      vsync=vsync, resizable=resizable, decorate=decorate,
-                      fullscreen=fullscreen, context=self._context,
-                      parent=parent, always_on_top=always_on_top)
-        self._backend_kwargs = kwargs
+        self._backend_kwargs = dict(
+            title=title, size=size, position=position, show=show,
+            vsync=vsync, resizable=resizable, decorate=decorate,
+            fullscreen=fullscreen, context=self._context,
+            parent=parent, always_on_top=always_on_top,
+            **kwargs)
 
         # Create widget now (always do this *last*, after all err checks)
         if create_native:


### PR DESCRIPTION
This PR adds the ability to pass arguments into the webGL context creation function by setting an attribute of the `VispyWidget` before showing the `Canvas`. I'm interested in doing this (or something like this) to be able to set `preserveDrawingBuffer` of the created contexts, so I can "freeze" vispy notebook widgets as static images that can be saved in the notebook itself (see [vispy_toDataUrl.ipynb.txt](https://github.com/vispy/vispy/files/3498482/vispy_toDataUrl.ipynb.txt) for an example). The easy solution would be to just always set `preserveDrawingBuffer` in vispy-created contexts, but I have read that it can carry a performance penalty of around 50% on some very weak hardware (like phones). 

I'm not terribly familiar with vispy's internals, but I imagine there is a better way to achieve what I'm looking for than this method. I'm submitting this PR to begin the discussion!

