### PR TITLE
Fix read_pixels when there are multiple contexts

### DIFF
--- a/vispy/gloo/util.py
+++ b/vispy/gloo/util.py
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 
 from ..ext.six import string_types
-from .wrappers import read_pixels
+from .wrappers import read_pixels, get_current_canvas
 
 
 def _screenshot(viewport=None, alpha=True):
@@ -27,6 +27,8 @@ def _screenshot(viewport=None, alpha=True):
         3D array of pixels in np.uint8 format
     """
     # gl.glReadBuffer(gl.GL_BACK)  Not avaliable in ES 2.0
+    # Need to set current canvas so context is current
+    get_current_canvas().set_current()
     return read_pixels(viewport, alpha)
 
 

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -638,10 +638,7 @@ def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte
     _check_valid('mode', mode, ['color', 'depth', 'stencil'])
 
     # Check whether the GL context is direct or remote
-    canvas = get_current_canvas()
-    context = canvas.context
-    # Need to set current canvas so context is current
-    canvas.set_current()
+    context = get_current_canvas().context
     if context.shared.parser.is_remote():
         raise RuntimeError('Cannot use read_pixels() with remote GLIR parser')
 

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -638,7 +638,10 @@ def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte
     _check_valid('mode', mode, ['color', 'depth', 'stencil'])
 
     # Check whether the GL context is direct or remote
-    context = get_current_canvas().context
+    canvas = get_current_canvas()
+    context = canvas.context
+    # Need to set current canvas so context is current
+    canvas.set_current()
     if context.shared.parser.is_remote():
         raise RuntimeError('Cannot use read_pixels() with remote GLIR parser')
 


### PR DESCRIPTION
Closes #1695.

I discovered that the behavior of the semi-hidden `_screenshot` utility function has unexpected results when used as part of a PyQt5 application. Best I can understand is that vispy and pyqt5 are both using OpenGL to draw things to the screen. At any given time the Qt5 GL context could be active. If you ask for any properties of the "current context" when then you may be accidentally getting that information from the Qt context instead of the vispy context. I think that's what was happening with `_screenshot` and `read_pixels`. This PR adds a "set_current" operation to `read_pixels` so the vispy canvas is current when we then ask for the current viewport (`gl.glGetParameter(gl.GL_VIEWPORT)`).

I could see another option being to get the viewport from the actual canvas (which keeps that information cached) and only use the context for checking if it is remote.

@rougier @larsoner Thoughts?