### PR TITLE
Update azure PyPI token to match new standards

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,6 @@ jobs:
         cd $(Pipeline.Workspace)
         python -m pip install --upgrade pip
         pip install twine
-        twine upload -u "@token" --skip-existing vispyDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
+        twine upload -u "__token__" --skip-existing vispyDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
       env:
-        TWINE_PASSWORD: $(pypiToken)
+        TWINE_PASSWORD: $(pypiToken2)


### PR DESCRIPTION
PyPI tokens are still in beta and in a recent update they've changed how they would like upload tokens to be provided and used.

```
    username:       @token                          =>      __token__
    password/token: pypi:<base64 token body>        =>      pypi-<base64 token body>
```

Because I made the Variable on Azure secret I couldn't simply modify the value of it so I had to make a whole new token under my account on PyPI. The token is now updated on Azure and this PR makes vispy use the new token.