### PR TITLE
Fix MarkerVisual scaling when rotating in 3D space

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -619,9 +619,9 @@ class MarkersVisual(Visual):
             return False
         view.view_program['u_px_scale'] = view.transforms.pixel_scale
         if self.scaling:
-            tr = view.transforms.get_transform('visual', 'document')
+            tr = view.transforms.get_transform('visual', 'document').simplified
             mat = tr.map(np.eye(3)) - tr.map(np.zeros((3, 3)))
-            scale = np.linalg.norm(mat)
+            scale = np.linalg.norm(mat[:, :3])
             view.view_program['u_scale'] = scale
         else:
             view.view_program['u_scale'] = 1

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -619,8 +619,9 @@ class MarkersVisual(Visual):
             return False
         view.view_program['u_px_scale'] = view.transforms.pixel_scale
         if self.scaling:
-            tr = view.transforms.get_transform('visual', 'document').simplified
-            scale = np.linalg.norm((tr.map([1, 0]) - tr.map([0, 0]))[:2])
+            tr = view.transforms.get_transform('visual', 'document')
+            mat = tr.map(np.eye(3)) - tr.map(np.zeros((3, 3)))
+            scale = np.linalg.norm(mat)
             view.view_program['u_scale'] = scale
         else:
             view.view_program['u_scale'] = 1


### PR DESCRIPTION
This PR fixes #1166 where the scale was not working properly for markers when they were being rotated.

Please see that issue for a detailed discussion of the problem and proposed solution, including example code to reproduce the bug and gifs of the behavior before and after the fix.