### PR TITLE
Add lines_adjacency and line_strip_adjacency OpenGL primitives.

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -182,8 +182,9 @@ DRAW
 Applies to: Program
 
 This command is used to draw the program. It has a ``mode`` argument
-which can be 'points', 'lines', 'line_strip', 'line_loop', 'triangles',
-'triangle_strip', or 'triangle_fan' (case insensitive).
+which can be 'points', 'lines', 'line_strip', 'line_loop', 'lines_adjacency',
+'line_strip_adjacency', 'triangles', 'triangle_strip', or 'triangle_fan'
+(case insensitive).
 
 If the ``selection`` argument has two elements, it contains two integers
 ``(start, count)``. If it has three elements, it contains
@@ -999,7 +1000,8 @@ class GlirGeometryShader(GlirShader):
 
     def __init__(self, *args, **kwargs):
         if not hasattr(gl, 'GL_GEOMETRY_SHADER'):
-            raise RuntimeError("GL2 backend does not support geometry shaders."
+            raise RuntimeError(gl.current_backend.__name__ +
+                               " backend does not support geometry shaders."
                                " Try gloo.gl.use_gl('gl+').")
         GlirGeometryShader._target = gl.GL_GEOMETRY_SHADER
         GlirShader.__init__(self, *args, **kwargs)
@@ -1320,7 +1322,16 @@ class GlirProgram(GlirObject):
             raise RuntimeError('Cannot draw program if code has not been set')
         # Init
         gl.check_error('Check before draw')
-        mode = as_enum(mode)
+        try:
+            mode = as_enum(mode)
+        except ValueError:
+            if mode == 'lines_adjacency' or mode == 'line_strip_adjacency':
+                raise RuntimeError(gl.current_backend.__name__ +
+                                   " backend does not support lines_adjacency"
+                                   " and line_strip_adjacency primitives."
+                                   " Try gloo.gl.use_gl('gl+').")
+            raise
+
         # Draw
         if len(selection) == 3:
             # Selection based on indices

--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -128,7 +128,7 @@ class Program(GLObject):
 
         # Init source code for vertex and fragment shader
         self._shaders = None, None
-        
+
         # Init description of variables obtained from source code
         self._code_variables = {}  # name -> (kind, type_, name)
         # Init user-defined data for attributes and uniforms
@@ -188,7 +188,7 @@ class Program(GLObject):
         for shader in shaders:
             self.glir.associate(shader.glir)
             self._glir.command('ATTACH', self._id, shader.id)
-        
+
         # Store source code, send it to glir, parse the code for variables
         self._shaders = shaders
 
@@ -207,7 +207,7 @@ class Program(GLObject):
         self._user_variables = {}
         # Parse code (and process pending variables)
         self._parse_variables_from_code(update_variables=update_variables)
-    
+
     @property
     def shaders(self):
         """ All currently attached shaders
@@ -230,7 +230,7 @@ class Program(GLObject):
         # Note that internally the variables are stored as a dict
         # that maps names -> tuples, for easy looking up by name.
         return [x[:3] for x in self._code_variables.values()]
-   
+
     def _parse_variables_from_code(self, update_variables=True):
         """ Parse uniforms, attributes and varyings from the source code.
         """
@@ -238,7 +238,7 @@ class Program(GLObject):
         # Get one string of code with comments removed
         code = '\n\n'.join([sh.code for sh in self._shaders])
         code = re.sub(r'(.*)(//.*)', r'\1', code, re.M)
-        
+
         # Regexp to look for variable names
         var_regexp = (r"\s*VARIABLE\s+"  # kind of variable
                       r"((highp|mediump|lowp)\s+)?"  # Precision (optional)
@@ -469,8 +469,9 @@ class Program(GLObject):
         Parameters
         ----------
         mode : str | GL_ENUM
-            'points', 'lines', 'line_strip', 'line_loop', 'triangles',
-            'triangle_strip', or 'triangle_fan'.
+            'points', 'lines', 'line_strip', 'line_loop', 'lines_adjacency',
+            'line_strip_adjacency', 'triangles', 'triangle_strip', or
+            'triangle_fan'.
         indices : array
             Array of indices to draw.
         check_error:
@@ -484,7 +485,8 @@ class Program(GLObject):
         # Check if mode is valid
         mode = check_enum(mode)
         if mode not in ['points', 'lines', 'line_strip', 'line_loop',
-                        'triangles', 'triangle_strip', 'triangle_fan']:
+                        'lines_adjacency', 'line_strip_adjacency', 'triangles',
+                        'triangle_strip', 'triangle_fan']:
             raise ValueError('Invalid draw mode: %r' % mode)
 
         # Check leftover variables, warn, discard them


### PR DESCRIPTION
I added lines_adjacency and line_strip_adjacency OpenGL primitives, so I can emulate quads with geometry shader.
[https://github.com/proto3/vispy/blob/quad-gif/quad.gif](https://github.com/proto3/vispy/blob/quad-gif/quad.gif)

It worked immediately with GL+ backend, but it won't with GL2 so it raise an explicit error advising to use GL+ with these primitives.
In the mean time, I updated the geometry shader support error message, so it won't blame 'GL2' all the time but gl.current_backend.__name__