### PR TITLE
Switch to setuptools_scm for automatic version numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ vispy.egg-info
 *.swp
 .ipynb_checkpoints
 .cache/
+.eggs/
 examples/basics/scene/animation.gif
 .pytest_cache/
 js/node_modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools>=30.3.0",
+    "setuptools_scm",
+    "setuptools_scm_git_archive",
     "Cython>=0.29.2",
     "numpy; python_version=='2.7'",
     "numpy==1.13.3; python_version=='3.5'",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
-
-""" Vispy setup script.
+"""Vispy setup script.
 
 Steps to do a new release:
 
@@ -10,25 +9,16 @@ Preparations:
   * Test on Windows, Linux, Mac
   * Make release notes
   * Update API documentation and other docs that need updating.
-  * Install 'twine' package for uploading to PyPI
 
-Define the version:
-  * update __version__ in __init__.py
-  * tag the tip changeset as version x.x.x; `git tag -a 'vX.Y.Z'`
-
-Test installation:
-  * clear the build and dist dir (if they exist)
-  * python setup.py sdist
-  * twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-  * pip install -i https://testpypi.python.org/pypi vispy
-
-Generate and upload package
-  * python setup.py sdist
-  * twine upload dist/*
+Define the version and release:
+  * tag the tip changeset as version x.x.x; `git tag -a 'vX.Y.Z' -m "Version X.Y.Z"`
+  * push tag to github
+  * verify that azure pipelines complete
+  * verify that `.tar.gz` sdist and binary wheels are available on PyPI
 
 Announcing:
   * It can be worth waiting a day for eager users to report critical bugs
-  * Announce in scipy-user, vispy mailing list, G+
+  * Announce in scipy-user, vispy mailing list, twitter (@vispyproject)
 
 """
 
@@ -52,25 +42,6 @@ log.info('$PATH=%s' % os.environ['PATH'])
 
 name = 'vispy'
 description = 'Interactive visualization in Python'
-
-
-# Get version and docstring
-__version__ = None
-__doc__ = ''
-docStatus = 0  # Not started, in progress, done
-initFile = os.path.join(os.path.dirname(__file__), 'vispy', '__init__.py')
-for line in open(initFile).readlines():
-    if line.startswith('version_info') or line.startswith('__version__'):
-        exec(line.strip())
-    elif line.startswith('"""'):
-        if docStatus == 0:
-            docStatus = 1
-            line = line.lstrip('"')
-        elif docStatus == 1:
-            docStatus = 2
-    if docStatus == 1:
-        __doc__ += line
-
 
 # Special commands for building jupyter notebook extension
 here = os.path.dirname(os.path.abspath(__file__))
@@ -207,7 +178,7 @@ extensions = [Extension('vispy.visuals.text._sdf_cpu',
 readme = open('README.rst', 'r').read()
 setup(
     name=name,
-    version=__version__,
+    use_scm_version=True,
     author='Vispy contributors',
     author_email='vispy@googlegroups.com',
     license='(new) BSD',
@@ -239,7 +210,7 @@ setup(
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=['numpy', 'freetype-py'],
-    setup_requires=['numpy', 'cython'],
+    setup_requires=['numpy', 'cython', 'setuptools_scm', 'setuptools_scm_git_archive'],
     extras_require={
         'ipython-static': ['ipython'],
         'ipython-vnc': ['ipython>=7'],

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -18,14 +18,15 @@ For more information, see http://vispy.org.
 """
 
 from __future__ import division
+from pkg_resources import get_distribution, DistributionNotFound
 
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']
 
-# Definition of the version number
-version_info = 0, 6, 2, 'dev0'  # major, minor, patch, extra
-
-# Nice string for the version (mimic how IPython composes its version str)
-__version__ = '-'.join(map(str, version_info)).replace('-', '.').strip('-')
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
 
 from .util import config, set_log_level, keys, sys_info  # noqa
 from .util.wrappers import use  # noqa

--- a/vispy/util/tests/test_import.py
+++ b/vispy/util/tests/test_import.py
@@ -41,7 +41,8 @@ def loaded_vispy_modules(import_module, depth=None, all_modules=False):
     # Get only vispy modules at the given depth
     vispy_modules = set()
     for m in loaded_modules:
-        if m.startswith('vispy') and '__future__' not in m:
+        # pkg_resources from vispy/__init__.py shows up as vispy.pkg_resources in python 2.7
+        if m.startswith('vispy') and '__future__' not in m and 'pkg_resources' not in m:
             if depth:
                 parts = m.split('.')
                 m = '.'.join(parts[:depth])


### PR DESCRIPTION
This updates vispy's version number handling to be automatic based on git tags instead of having to manually edit the value in `vispy/__init__.py`. The one major change to this is that `setup.py` no longer updates the `__doc__` attribute of `setup.py`, but I don't see the point of this anyway. This is even less useful now that `pip install` (and variants) is the preferred method of installing python packages instead of `python setup.py ...`.

More info on setuptools_scm: https://pypi.org/project/setuptools-scm/
Requires https://github.com/vispy/vispy-website/pull/26

Note: In previous non-github conversations I had mentioned "caching" the version number in something like a `vispy/version.py` file. I was going to try this with my Satpy library but one of the other maintainers didn't like it. I'm doing the same thing here that I did with Satpy which is asking setuptools_scm to get the version from git every time it is imported. This has a slight performance penalty but nothing noticeable in my opinion.