### PR TITLE
Fix setuptools_scm_git_archive usage

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
This was a small thing I missed from #1706. I added the `setuptools_scm_git_archive` package so that if someone installs from a release from github it will include the necessary information to determine what the version number should be. However, I forgot to actually do the part where it includes that information :smile:

This PR fixes that by following the installation instructions described [here](https://github.com/Changaco/setuptools_scm_git_archive/).