### PR TITLE
Volume visual has unset variable texture2D_LUT

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -547,6 +547,8 @@ class VolumeVisual(Visual):
         self.shared_program.frag['sampler_type'] = self._tex.glsl_sampler_type
         self.shared_program.frag['sample'] = self._tex.glsl_sample
         self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        self.shared_program['texture2D_LUT'] = self.cmap.texture_lut() \
+            if (hasattr(self.cmap, 'texture_lut')) else None
         self.update()
     
     @property


### PR DESCRIPTION
When I try to use my own colormap using 
```python
n_colors = 256
t = np.linspace(0., 1., n_colors)
color = np.c_[t, t, t, t*0.05]
cmap = Colormap(color)
```
instead of the one from `examples/basics/scene/volume.py`
```python
class TransGrays(BaseColormap):
    glsl_map = """
    vec4 translucent_grays(float t) {
        return vec4(t, t, t, t*0.05);
    }
    """
```
it keeps showing 

> Program has unset variables: {'texture2D_LUT'}  

with a blank screen.

Not sure if this is the best way to do it, after comparing how `cmap` is configured in `visuals.Image`, `visuals.Mesh`, `visuals.Colorbar` and `visuals.Line`, I think `texture2D_LUT` is missing.
