### PR TITLE
Fix Azure Linux builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,9 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets; pip uninstall -y typing"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; ; pip uninstall -y typing; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,12 +8,13 @@ trigger:
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-*"
-  CIBW_TEST_REQUIRES: "'pytest<5.2' pytest-sugar nose"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_MANYLINUX1_X86_64_IMAGE: "quay.io/pypa/manylinux1_x86_64@sha256:fa5e2e059ccfd296cdaa12cea534fa3130c695dbf3dc7c9e4b5f6000f719713d"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,8 +22,9 @@ jobs:
     - bash: |
         git submodule update --init --recursive
         python -m pip install --upgrade pip
-        pip install 'cibuildwheel<0.12' twine numpy Cython jupyter ipywidgets
-        python setup.py sdist -d wheelhouse
+        pip install cibuildwheel
+        #pip install 'cibuildwheel<0.12' twine numpy Cython jupyter ipywidgets
+        #python setup.py sdist -d wheelhouse
         cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "pip install -U pip setuptools"
+  CIBW_BEFORE_BUILD_LINUX: "pip install -U pip setuptools; python -c 'from typing import Optional; print(Optional.__file__)'"
 #  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
   #CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
-  #CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
@@ -23,9 +22,8 @@ jobs:
     - bash: |
         git submodule update --init --recursive
         python -m pip install --upgrade pip
-        pip install cibuildwheel
-        #pip install cibuildwheel twine numpy Cython jupyterlab ipywidgets
-        #python setup.py sdist -d wheelhouse
+        pip install cibuildwheel twine numpy Cython jupyterlab ipywidgets
+        python setup.py sdist -d wheelhouse
         cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
+  CIBW_TEST_REQUIRES: "'pytest<5.2' pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
@@ -23,7 +23,7 @@ jobs:
         git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel
-        #pip install 'cibuildwheel<0.12' twine numpy Cython jupyter ipywidgets
+        #pip install 'cibuildwheel<0.12' twine numpy Cython jupyterlab ipywidgets
         #python setup.py sdist -d wheelhouse
         cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "pip install -U pip setuptools; python -c 'from typing import Optional; print(Optional.__file__)'"
-#  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
   #CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
 jobs:
 - job: linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; ; pip uninstall -y typing; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; pip uninstall -y typing; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,9 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets; pip uninstall -y typing"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
-  CIBW_MANYLINUX1_X86_64_IMAGE: "quay.io/pypa/manylinux1_x86_64@sha256:fa5e2e059ccfd296cdaa12cea534fa3130c695dbf3dc7c9e4b5f6000f719713d"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
@@ -24,7 +23,7 @@ jobs:
         git submodule update --init --recursive
         python -m pip install --upgrade pip
         pip install cibuildwheel
-        #pip install 'cibuildwheel<0.12' twine numpy Cython jupyterlab ipywidgets
+        #pip install cibuildwheel twine numpy Cython jupyterlab ipywidgets
         #python setup.py sdist -d wheelhouse
         cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,9 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
+  CIBW_BEFORE_BUILD_LINUX: "pip install -U pip setuptools"
+#  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  #CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
     - bash: |
         git submodule update --init --recursive
         python -m pip install --upgrade pip
-        pip install cibuildwheel twine numpy Cython jupyter ipywidgets
+        pip install 'cibuildwheel<0.12' twine numpy Cython jupyter ipywidgets
         python setup.py sdist -d wheelhouse
         cibuildwheel --output-dir wheelhouse .
     - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyterlab ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; pip uninstall -y typing; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi; pip uninstall -y typing"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -18,7 +18,6 @@ For more information, see http://vispy.org.
 """
 
 from __future__ import division
-from typing import Optional
 from pkg_resources import get_distribution, DistributionNotFound
 
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -17,6 +17,7 @@ For more information, see http://vispy.org.
 
 """
 
+from typing import Optional
 from __future__ import division
 from pkg_resources import get_distribution, DistributionNotFound
 

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -17,8 +17,8 @@ For more information, see http://vispy.org.
 
 """
 
-from typing import Optional
 from __future__ import division
+from typing import Optional
 from pkg_resources import get_distribution, DistributionNotFound
 
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']


### PR DESCRIPTION
Noticed in #1724 our tests on the linux container on Azure is failing. It fails with an AttributeError related to the `typing` module. Looking at the paths involved it seems `site-packages/typing.py` is being used instead of the built in typing in CPython.

All of the environments are generally the same except for Linux include installing extra dependencies so we can build the `sdist` tarball of vispy (iirc it uses the extension .so's built from the wheel generation). The easiest logical leap is that these extra dependencies are for some reason installing the third-party typing package. Otherwise, it is an issue with the cibuildwheel linux which could also be because none of these dependencies have been recently updated.

This PR is me trying to figure this out...yay.