### PR TITLE
Fix VolumeVisual modifying user provided data in-place

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -57,4 +57,25 @@ def test_volume_draw():
         assert_image_approved(c.render(), 'visuals/volume.png')
 
 
+@requires_pyopengl()
+def test_set_data_does_not_change_input():
+    # Create volume
+    V = scene.visuals.Volume(np.zeros((20, 20, 20)))
+
+    # calling Volume.set_data() should NOT alter the values of the input array
+    # regardless of data type
+    vol = np.random.randint(0, 200, (20, 20, 20))
+    for dtype in ['uint8', 'int16', 'uint16', 'float32', 'float64']:
+        vol_copy = np.array(vol, dtype=dtype, copy=True)
+        # setting clim so that normalization would otherwise change the data
+        V.set_data(vol_copy, clim=(0, 200))
+        assert np.allclose(vol, vol_copy)
+
+    # for those using float32 who want to avoid the copy operation,
+    # using set_data() with `copy=False` should be expected to alter the data.
+    vol2 = np.array(vol, dtype='float32', copy=True)
+    assert np.allclose(vol, vol2)
+    V.set_data(vol2, clim=(0, 200), copy=False)
+    assert not np.allclose(vol, vol2)
+
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -78,4 +78,5 @@ def test_set_data_does_not_change_input():
     V.set_data(vol2, clim=(0, 200), copy=False)
     assert not np.allclose(vol, vol2)
 
+
 run_tests_if_main()

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -457,6 +457,8 @@ class VolumeVisual(Visual):
             The 3D volume.
         clim : tuple | None
             Colormap limits to use. None will use the min and max values.
+        copy : bool | True
+            Whether to copy the input volume prior to applying clim normalization.
         """
         # Check volume
         if not isinstance(vol, np.ndarray):

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -448,7 +448,7 @@ class VolumeVisual(Visual):
         self.threshold = threshold if (threshold is not None) else vol.mean()
         self.freeze()
     
-    def set_data(self, vol, clim=None):
+    def set_data(self, vol, clim=None, copy=True):
         """ Set the volume data. 
 
         Parameters
@@ -473,8 +473,8 @@ class VolumeVisual(Visual):
         if self._clim is None:
             self._clim = vol.min(), vol.max()
         
-        # Apply clim
-        vol = np.array(vol, dtype='float32', copy=False)
+        # Apply clim (copy data by default... see issue #1727)
+        vol = np.array(vol, dtype='float32', copy=copy)
         if self._clim[1] == self._clim[0]:
             if self._clim[0] != 0.:
                 vol *= 1.0 / self._clim[0]


### PR DESCRIPTION
This PR copies data by default in `VolumeVisual.set_data`, and adds a copy parameter to the method for those who want to maintain the existing behavior (wherein float32 data is not copied).
see #1727 for full discussion.