### PR TITLE
Fix Python 3.8 compatibility in Canvas 'keys' update

### DIFF
--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -245,6 +245,7 @@ class Canvas(object):
         if not isinstance(keys, dict):
             raise TypeError('keys must be a dict, str, or None')
         if len(keys) > 0:
+            lower_keys = {}
             # ensure all are callable
             for key, val in keys.items():
                 if isinstance(val, string_types):
@@ -256,9 +257,8 @@ class Canvas(object):
                 if not hasattr(val, '__call__'):
                     raise TypeError('Entry for key %s is not callable' % key)
                 # convert to lower-case representation
-                keys.pop(key)
-                keys[key.lower()] = val
-            self._keys_check = keys
+                lower_keys[key.lower()] = val
+            self._keys_check = lower_keys
 
             def keys_check(event):
                 if event.key is not None:


### PR DESCRIPTION
Fixes #1729. If I understood correctly the `RuntimeError`, an alternative to `keys.pop(key)` should solve this.