### PR TITLE
Bug fixes related to AxisVisual

### DIFF
--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -171,7 +171,9 @@ class AxisVisual(CompoundVisual):
             # TODO: make sure we only call get_transform if the transform for
             # the line is updated
             tr = self._line.get_transform(map_from='visual', map_to='canvas')
-            x1, y1, x2, y2 = tr.map(self.pos)[:, :2].ravel()
+            trpos = tr.map(self.pos)
+            trpos /= trpos[:, 3:]
+            x1, y1, x2, y2 = trpos[:, :2].ravel()
             if x1 > x2:
                 x1, y1, x2, y2 = x2, y2, x1, y1
             self._axis_label.rotation = math.degrees(math.atan2(y2-y1, x2-x1))

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -505,6 +505,10 @@ def _get_ticks_talbot(dmin, dmax, n_inches, density=1.):
     # the density function converts this back to a density in data units
     # (not inches)
     n_inches = max(n_inches, 2.0)  # Set minimum otherwise code can crash :(
+
+    if dmin == dmax:
+        return np.array([dmin, dmax])
+
     m = density * n_inches + 1.0
     only_inside = False  # we cull values outside ourselves
     Q = [1, 5, 2, 2.5, 4, 3]

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -168,17 +168,25 @@ class AxisVisual(CompoundVisual):
         if self._pos is None:
             return False
         if self.axis_label is not None:
-            # TODO: make sure we only call get_transform if the transform for
-            # the line is updated
-            tr = self._line.get_transform(map_from='visual', map_to='canvas')
-            trpos = tr.map(self.pos)
-            trpos /= trpos[:, 3:]
-            x1, y1, x2, y2 = trpos[:, :2].ravel()
-            if x1 > x2:
-                x1, y1, x2, y2 = x2, y2, x1, y1
-            self._axis_label.rotation = math.degrees(math.atan2(y2-y1, x2-x1))
+            self._axis_label.rotation = self._rotation_angle
         if self._need_update:
             self._update_subvisuals()
+
+    @property
+    def _rotation_angle(self):
+        """
+        Determine the rotation angle of the axis as projected onto the canvas.
+        """
+        # TODO: make sure we only call get_transform if the transform for
+        # the line is updated
+        tr = self._line.get_transform(map_from='visual', map_to='canvas')
+        trpos = tr.map(self.pos)
+        # Normalize homogeneous coordinates
+        # trpos /= trpos[:, 3:]
+        x1, y1, x2, y2 = trpos[:, :2].ravel()
+        if x1 > x2:
+            x1, y1, x2, y2 = x2, y2, x1, y1
+        return math.degrees(math.atan2(y2-y1, x2-x1))
 
     def _compute_bounds(self, axis, view):
         if axis == 2:

--- a/vispy/visuals/tests/test_axis.py
+++ b/vispy/visuals/tests/test_axis.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for AxisVisual
+"""
+
+from vispy import scene
+from vispy.scene import visuals
+from vispy.testing import (requires_application, TestingCanvas,
+                           run_tests_if_main)
+
+
+@requires_application()
+def test_axis():
+    with TestingCanvas() as c:
+        axis = visuals.Axis(pos=[[-1.0, 0], [1.0, 0]], parent=c.scene)
+        c.draw_visual(axis)
+
+
+@requires_application()
+def test_axis_zero_domain():
+    # Regression test for a bug that caused an overflow error when the domain
+    # min was same as max
+    with TestingCanvas() as c:
+        axis = visuals.Axis(pos=[[-1.0, 0], [1.0, 0]], domain=(0.5, 0.5), parent=c.scene)
+        c.draw_visual(axis)
+
+
+run_tests_if_main()

--- a/vispy/visuals/tests/test_axis.py
+++ b/vispy/visuals/tests/test_axis.py
@@ -8,6 +8,9 @@
 Tests for AxisVisual
 """
 
+from numpy.testing import assert_allclose
+
+from vispy import scene
 from vispy.scene import visuals
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
@@ -27,6 +30,39 @@ def test_axis_zero_domain():
     with TestingCanvas() as c:
         axis = visuals.Axis(pos=[[-1.0, 0], [1.0, 0]], domain=(0.5, 0.5), parent=c.scene)
         c.draw_visual(axis)
+
+
+@requires_application()
+def test_rotation_angle():
+
+    # Make sure the rotation angle calculation is correct
+
+    canvas = scene.SceneCanvas(keys=None, size=(800, 600), show=True)
+    view = canvas.central_widget.add_view()
+    view.camera = scene.cameras.TurntableCamera(parent=view.scene,
+                                                fov=0., distance=4.0,
+                                                elevation=0, azimuth=0, roll=0.)
+
+    axis1 = visuals.Axis(pos=[[-1.0, 0], [1.0, 0]], parent=view.scene)
+    assert_allclose(axis1._rotation_angle, 0)
+
+    axis2 = visuals.Axis(pos=[[-3**0.5/2., -0.5], [3**0.5/2., 0.5]], parent=view.scene)
+    assert_allclose(axis2._rotation_angle, 0.)
+
+    view.camera.elevation = 90.
+
+    assert_allclose(axis1._rotation_angle, 0)
+    assert_allclose(axis2._rotation_angle, -30)
+
+    view.camera.elevation = 45.
+
+    assert_allclose(axis1._rotation_angle, 0)
+    assert_allclose(axis2._rotation_angle, -22.207653)
+
+    view.camera.fov = 20.
+
+    assert_allclose(axis1._rotation_angle, 0)
+    assert_allclose(axis2._rotation_angle, -17.056795)
 
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_axis.py
+++ b/vispy/visuals/tests/test_axis.py
@@ -4,7 +4,6 @@
 Tests for AxisVisual
 """
 
-from vispy import scene
 from vispy.scene import visuals
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)

--- a/vispy/visuals/tests/test_axis.py
+++ b/vispy/visuals/tests/test_axis.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
 
 """
 Tests for AxisVisual

--- a/vispy/visuals/tests/test_text.py
+++ b/vispy/visuals/tests/test_text.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+
+import numpy as np
+from numpy.testing import assert_allclose
+
 from vispy.scene.visuals import Text
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
@@ -16,7 +20,7 @@ def test_text():
                     parent=c.scene)
         # Test image created in Illustrator CS5, 1"x1" output @ 92 DPI
         assert_image_approved(c.render(), 'visuals/text1.png')
-        
+
         text.text = ['foo', 'bar']
         text.pos = [10, 10]  # should auto-replicate
         text.rotation = [180, 270]
@@ -32,6 +36,23 @@ def test_text():
         text.text = 'foobar'
         c.update()
         c.app.process_events()
+
+
+@requires_application()
+def test_text_rotation_update():
+
+    # Regression test for a bug that caused text labels to not be redrawn
+    # if the rotation angle was updated
+
+    with TestingCanvas() as c:
+        text = Text('testing', pos=(100, 100), parent=c.scene)
+        c.update()
+        c.app.process_events()
+        assert_allclose(text.shared_program['a_rotation'], 0.)
+        text.rotation = 30.
+        c.update()
+        c.app.process_events()
+        assert_allclose(text.shared_program['a_rotation'], np.radians(30.))
 
 
 run_tests_if_main()

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -490,6 +490,7 @@ class TextVisual(Visual):
     @rotation.setter
     def rotation(self, rotation):
         self._rotation = np.asarray(rotation) * np.pi / 180.
+        self._pos_changed = True
         self.update()
 
     @property


### PR DESCRIPTION
This fixes a few bugs I ran into while using ``AxisVisual``:

* Changing the ``.rotation`` on a ``TextVisual`` didn't previously update the actual shader attribute for rotation. This became apparent when rotating the axes in 3-d, as the labels didn't follow the rotation.
* The calculation of the angle for the axis label didn't quite work when projection is present
* Warnings were emitted when the min/max for axes were the same

It's not clear to me how to properly test the first two but I think I could add a test for the last one if needed.