### PR TITLE
Update vispy.js to not include package-lock.json

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ variables:
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
-  SETUPTOOLS_SCM_PRETEND_VERSION: 0.6.2
-  CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=0.6.2"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}


### PR DESCRIPTION
See https://github.com/vispy/vispy.js/pull/26 for details.

Basically for the 0.6.2 release I had to hardcode the version number so setuptools_scm would be happy. I have now updated the vispy.js repository so it doesn't include the `package-lock.json` file which was being updated during setup.py building and causing issues with the version number that `setuptools_scm` ended up generating.