### PR TITLE
Fail gracefully if OpenGL version can't be determined

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -839,6 +839,12 @@ class GlirParser(BaseGlirParser):
             self.capabilities['gl_version'] = gl.glGetParameter(gl.GL_VERSION)
             self.capabilities['max_texture_size'] = \
                 gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+
+            if self.capabilities['gl_version'] == '':
+                logger.warning('Could not determine OpenGL version. Some '
+                               'functionality may fail.')
+                return
+
             this_version = self.capabilities['gl_version'].split(' ')
             if this_version[0] == "OpenGL":
                 # For OpenGL ES, the version string has the format:


### PR DESCRIPTION
I ran into issues on Azure Pipelines where ``self.capabilities['gl_version']`` is an empty string which causes the version comparison below to crash. This PR adds a workaround to show a warning and not crash.