### PR TITLE
Fix xaxis labels being wrong initially in PlotWidget

### DIFF
--- a/vispy/plot/plotwidget.py
+++ b/vispy/plot/plotwidget.py
@@ -142,7 +142,7 @@ class PlotWidget(scene.Widget):
         self.cbar_bottom = self.grid.add_widget(None, row=5, col=4)
         self.cbar_bottom.height_max = 1
 
-        # This needs to be added to the grid last (to fix #1743)
+        # This needs to be added to the grid last (to fix #1742)
         self.view = self.grid.add_view(row=2, col=4,
                                        border_color='grey', bgcolor="#efefef")
         self.view.camera = 'panzoom'

--- a/vispy/plot/plotwidget.py
+++ b/vispy/plot/plotwidget.py
@@ -122,6 +122,14 @@ class PlotWidget(scene.Widget):
         yaxis_widget = self.grid.add_widget(self.yaxis, row=2, col=3)
         yaxis_widget.width_max = 40
 
+        # row 3
+        # xaxis - column 4
+        # This needs to be added to the grid before the viewbox (to fix #1743)
+        self.xaxis = scene.AxisWidget(orientation='bottom', text_color=fg,
+                                      axis_color=fg, tick_color=fg)
+        xaxis_widget = self.grid.add_widget(self.xaxis, row=3, col=4)
+        xaxis_widget.height_max = 40
+
         self.view = self.grid.add_view(row=2, col=4,
                                        border_color='grey', bgcolor="#efefef")
         self.view.camera = 'panzoom'
@@ -129,13 +137,6 @@ class PlotWidget(scene.Widget):
 
         self.cbar_right = self.grid.add_widget(None, row=2, col=5)
         self.cbar_right.width_max = 1
-
-        # row 3
-        # xaxis - column 4
-        self.xaxis = scene.AxisWidget(orientation='bottom', text_color=fg,
-                                      axis_color=fg, tick_color=fg)
-        xaxis_widget = self.grid.add_widget(self.xaxis, row=3, col=4)
-        xaxis_widget.height_max = 40
 
         # row 4
         # xlabel - column 4

--- a/vispy/plot/plotwidget.py
+++ b/vispy/plot/plotwidget.py
@@ -124,16 +124,10 @@ class PlotWidget(scene.Widget):
 
         # row 3
         # xaxis - column 4
-        # This needs to be added to the grid before the viewbox (to fix #1743)
         self.xaxis = scene.AxisWidget(orientation='bottom', text_color=fg,
                                       axis_color=fg, tick_color=fg)
         xaxis_widget = self.grid.add_widget(self.xaxis, row=3, col=4)
         xaxis_widget.height_max = 40
-
-        self.view = self.grid.add_view(row=2, col=4,
-                                       border_color='grey', bgcolor="#efefef")
-        self.view.camera = 'panzoom'
-        self.camera = self.view.camera
 
         self.cbar_right = self.grid.add_widget(None, row=2, col=5)
         self.cbar_right.width_max = 1
@@ -147,6 +141,12 @@ class PlotWidget(scene.Widget):
         # row 5
         self.cbar_bottom = self.grid.add_widget(None, row=5, col=4)
         self.cbar_bottom.height_max = 1
+
+        # This needs to be added to the grid last (to fix #1743)
+        self.view = self.grid.add_view(row=2, col=4,
+                                       border_color='grey', bgcolor="#efefef")
+        self.view.camera = 'panzoom'
+        self.camera = self.view.camera
 
         self._configured = True
         self.xaxis.link_view(self.view)

--- a/vispy/plot/tests/test_plot.py
+++ b/vispy/plot/tests/test_plot.py
@@ -40,11 +40,11 @@ def test_plot_widget_axes():
         # note: fig.show() must be called for this test to work... otherwise
         # Grid._update_child_widget_dim is not triggered and the axes aren't updated
         fig.show(run=False)
+        # currently, the AxisWidget adds a buffer of 5% of the 
+        # full range to either end of the axis domain
         buffer = (point[1] - point[0]) * 0.05
         expectation = [point[0] - buffer, point[1] + buffer]
         for call in domain_setter.call_args_list:
-            # currently, the AxisWidget adds a buffer of 5% of the 
-            # full range to either end of the axis domain
             assert [round(x, 2) for x in call[0][1]] == expectation
 
 

--- a/vispy/plot/tests/test_plot.py
+++ b/vispy/plot/tests/test_plot.py
@@ -5,6 +5,12 @@
 import vispy.plot as vp
 from vispy.testing import (assert_raises, requires_application,
                            run_tests_if_main)
+from vispy.visuals.axis import AxisVisual
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 @requires_application()
@@ -17,5 +23,29 @@ def test_figure_creation():
         assert fig[1:3, 2] is ax_right
         # collision
         assert_raises(ValueError, fig.__getitem__, (slice(1, 3), 1))
+
+
+@requires_application()
+def test_plot_widget_axes():
+    """Test that the axes domains are updated correctly when a figure is first drawn"""
+
+    fig = vp.Fig(size=(800, 800), show=False)
+    point = (0, 100)
+    fig[0, 0].plot((point, point))
+    # mocking the AxisVisual domain.setter
+    domain_setter = mock.Mock(wraps=AxisVisual.domain.fset)
+    mock_property = AxisVisual.domain.setter(domain_setter)
+
+    with mock.patch.object(AxisVisual, "domain", mock_property):
+        # note: fig.show() must be called for this test to work... otherwise
+        # Grid._update_child_widget_dim is not triggered and the axes aren't updated
+        fig.show(run=False)
+        buffer = (point[1] - point[0]) * 0.05
+        expectation = [point[0] - buffer, point[1] + buffer]
+        for call in domain_setter.call_args_list:
+            # currently, the AxisWidget adds a buffer of 5% of the 
+            # full range to either end of the axis domain
+            assert [round(x, 2) for x in call[0][1]] == expectation
+
 
 run_tests_if_main()


### PR DESCRIPTION
This PR Fixes #1742 by adding the xaxis `AxisWidget` to the `PlotWidget.grid` before the `ViewBox` gets added.

Explanation (hope this is clear):
The order that widgets get added to the `PlotWidget.grid` in `PlotWidget._configure_2d` is currently problematic, because the xaxis `AxisWidget` (but not the yaxis `AxisWidget`) is getting added to the grid after the `ViewBox` is added.  As a result, when the `Grid._prepare_draw` method triggers `Grid._update_child_widget_dim` and it [loops through the grid widgets](https://github.com/vispy/vispy/blob/6f4e52aeecc40c29bf2fde3d217c0a3e6ea6b438/vispy/scene/widgets/grid.py#L481-L502) to update their sizes, the `ViewBox` `rect.setter` gets called before the xaxis `AxisWidget` has had a chance to update its size.  It is the `ViewBox` `rect.setter` that ultimately triggers the `resize()` event that is hooked to the `AxisWidget._view_changed` method that changes the axis domain & labels.  And though the ViewBox `rect.setter` _does_ get called a second time after the xaxis widget has changed its size, this time it fails the `self._pos_or_size_changed` test and does not trigger the `resize` event necessary for the xaxis redraw.  (this also explains why the problem was only affecting the x axis, because the y axis was added to the grid before the viewbox).