### PR TITLE
Fix shader version handling in webgl backend

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
       - v*
 variables:
   CIBW_BUILDING: "true"
-  CIBW_SKIP: "cp27-* cp34-*"
+  CIBW_SKIP: "cp27-* cp34-* cp38-*"
   CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ setup(
         'jsdeps': NPM,
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    install_requires=['numpy', 'freetype-py'],
+    install_requires=['numpy', 'freetype-py', 'setuptools'],
     setup_requires=['numpy', 'cython', 'setuptools_scm', 'setuptools_scm_git_archive'],
     extras_require={
         'ipython-static': ['ipython'],

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -582,7 +582,7 @@ def _convert_es2_shader(shader):
     for line in shader.lstrip().splitlines():
         line_strip = line.lstrip()
         if line_strip.startswith('#version'):
-            has_version = True
+            # has_version = True
             continue
         if line_strip.startswith('#extension'):
             extensions.append(line_strip)

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -46,7 +46,15 @@ def test_queue():
     
     # Convert for es2
     shader3 = glir.convert_shader('es2', shader2)
-    assert 'precision highp float;' in shader3
+    assert shader3.startswith('precision highp float;')
+
+    # Define shader with version number
+    shader4 = """
+        #version 100; precision highp float;uniform mediump vec4 u_foo;uniform vec4 u_bar;
+        """.strip().replace(';', ';\n')
+    shader5 = glir.convert_shader('es2', shader4)
+    # make sure that precision is first (version is removed)
+    assert shader5.startswith('precision highp float;')
 
 
 @requires_application()

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -46,15 +46,21 @@ def test_queue():
     
     # Convert for es2
     shader3 = glir.convert_shader('es2', shader2)
-    assert shader3.startswith('precision highp float;')
+    # make sure precision float is still in the shader
+    # it may not be the first (precision int might be there)
+    assert 'precision highp float;' in shader3
+    # precisions must come before code
+    assert shader3.startswith('precision')
 
     # Define shader with version number
     shader4 = """
         #version 100; precision highp float;uniform mediump vec4 u_foo;uniform vec4 u_bar;
         """.strip().replace(';', ';\n')
     shader5 = glir.convert_shader('es2', shader4)
+    assert 'precision highp float;' in shader5
     # make sure that precision is first (version is removed)
-    assert shader5.startswith('precision highp float;')
+    # precisions must come before code
+    assert shader3.startswith('precision')
 
 
 @requires_application()


### PR DESCRIPTION
Closes #1755

The WebGL shader handling currently removes the version directive from the shaders before they're sent to the client. This is maybe not the best long term solution, but this is the way I made it a while back.

Anyway, the code that removes the version directive from shader code also inserts certain `precision` directives which are required in webgl. Version directives, if they exist, must be the first line in a shader appearing before precision directives. Precision directives must also appear before code. It seems that I never tested this logic with a shader that actually includes a version directive since there is a bug where `precision` lines are being reinserted *after* the first line of code. This PR fixes this.

## TODO

- [x] Add tests