### PR TITLE
Fix texture alignment to use data itemsize

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -1503,7 +1503,7 @@ class GlirTexture1D(GlirTexture):
         if gtype is None:
             raise ValueError("Type %r not allowed for texture" % data.dtype)
         # Set alignment (width is nbytes_per_pixel * npixels_per_line)
-        alignment = self._get_alignment(data.shape[-1])
+        alignment = self._get_alignment(data.shape[-1] * data.itemsize)
         if alignment != 4:
             gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, alignment)
         # Upload
@@ -1536,7 +1536,7 @@ class GlirTexture2D(GlirTexture):
         if gtype is None:
             raise ValueError("Type %r not allowed for texture" % data.dtype)
         # Set alignment (width is nbytes_per_pixel * npixels_per_line)
-        alignment = self._get_alignment(data.shape[-2]*data.shape[-1])
+        alignment = self._get_alignment(data.shape[-2] * data.shape[-1] * data.itemsize)
         if alignment != 4:
             gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, alignment)
         # Upload
@@ -1632,8 +1632,7 @@ class GlirTexture3D(GlirTexture):
         if gtype is None:
             raise ValueError("Type not allowed for texture")
         # Set alignment (width is nbytes_per_pixel * npixels_per_line)
-        alignment = self._get_alignment(data.shape[-3] *
-                                        data.shape[-2] * data.shape[-1])
+        alignment = self._get_alignment(data.shape[-2] * data.shape[-1] * data.itemsize)
         if alignment != 4:
             gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, alignment)
         # Upload
@@ -1674,7 +1673,7 @@ class GlirTextureCube(GlirTexture):
             raise ValueError("Type %r not allowed for texture" % data.dtype)
         self.activate()
         # Set alignment (width is nbytes_per_pixel * npixels_per_line)
-        alignment = self._get_alignment(data.shape[-2] * data.shape[-1])
+        alignment = self._get_alignment(data.shape[-2] * data.shape[-1] * data.itemsize)
         if alignment != 4:
             gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, alignment)
         # Upload

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -214,6 +214,7 @@ def test_texture2d_alignment(gl, check3d):
     ])
     gl.glPixelStorei.reset_mock()
 
+
 @requires_pyopengl()
 @mock.patch('vispy.gloo.glir._check_pyopengl_3D')
 @mock.patch('vispy.gloo.glir.gl')
@@ -263,15 +264,15 @@ def test_texture3d_alignment(gl, check3d):
 @requires_pyopengl()
 @mock.patch('vispy.gloo.glir._check_pyopengl_3D')
 @mock.patch('vispy.gloo.glir.gl')
-def test_texture3d_alignment(gl, check3d):
+def test_texture_cube_alignment(gl, check3d):
     """Test that textures set unpack alignment properly.
 
     See https://github.com/vispy/vispy/pull/1758
 
     """
-    from ..glir import GlirTexture3D
+    from ..glir import GlirTextureCube
     check3d.return_value = gl
-    t = GlirTexture3D(mock.MagicMock(), 3)
+    t = GlirTextureCube(mock.MagicMock(), 3)
 
     shape = (68, 296, 393, 1)
     t.set_size(shape, 'luminance', 'luminance')

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -292,7 +292,7 @@ class BaseTexture(GLObject):
 
         Notes
         -----
-        This operation implicitely resizes the texture to the shape of
+        This operation implicitly resizes the texture to the shape of
         the data if given offset is None.
         """
         return self._set_data(data, offset, copy)


### PR DESCRIPTION
See https://github.com/napari/napari/issues/576 for the main discussion of this.

## OpenGL PACK/UNPACK Alignment

When writing or reading data to/from the GPU with OpenGL we need to specify the row alignment of our data. For writing data to the GPU we set the "GL_UNPACK_ALIGNMENT" parameter to 1, 2, 4, or 8. This tells OpenGL if the next row of data will be in the next byte, next 2-bytes, 4-bytes, or 8-bytes.

**Edit for clarification:** I meant the next aligned 2-bytes or 4-bytes, or 8-bytes. So if the data goes up to byte 30 and our alignment is 8 then OpenGL will get our next from starting at byte offset 32.

## How this applies to Vispy

In general Vispy requires or copies the data it is given by the user to be memory contiguous. So you might argue that the alignment can always be 1 (the next row starts in the next immediate byte). It isn't clear, but it seems there are some performance improvements if you choose a higher alignment. I have not tested this, but based on the Vispy code that was written a long time ago this seems to be the idea.

## The issue being fixed

Vispy currently assumes that all data are bytes (unsigned 8-bit integers), but this is often not true (32-bit floats, etc). Alignment should be based on width of a row, number of "bands" per pixel (3 for RGB, 1 for Luminance, etc), number of bytes per element (4 for 32-bit float, 1 for uint8, etc). This is the first bug fixed by this PR (use `data.itemsize` when determining alignment).

So for a 2D texture we should be getting the highest possible alignment for:

```
bytes_per_row = width * num_bands * itemsize
```

For 3D textures we should still only care about the width of a "row" (the last data dimension not including number of bands). This is the second bug being fixed by this PR where the Texture3D was using the "height" and "width".

Let's see what tests fail and then I'll come up with some tests to specifically check this based on the discussion in https://github.com/napari/napari/issues/576.