### PR TITLE
Fix automatic limits of ImageVisual with non-finites values

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -401,7 +401,8 @@ class ImageVisual(Visual):
             # can eventually do this by simulating 32-bit float... maybe
             clim = self._clim
             if isinstance(clim, string_types) and clim == 'auto':
-                clim = np.min(data), np.max(data)
+                finite_data = data[np.isfinite(data)]
+                clim = np.min(finite_data), np.max(finite_data)
             clim = np.asarray(clim, dtype=np.float32)
             data = data - clim[0]  # not inplace so we don't modify orig data
             if clim[1] - clim[0] > 0:


### PR DESCRIPTION
Hello @djhoese ,

Here's the PR that only contains the patch when there's non finite values inside the data.

Small code for reproducibility :

```python
import numpy as np

from vispy import scene
from vispy import app
from vispy.scene.cameras import PanZoomCamera

# Camera and scene canvas :
cam = PanZoomCamera(rect=(0, 0, 4, 5))
sc = scene.SceneCanvas(bgcolor='black')
wc = sc.central_widget.add_view(camera=cam)

# 2d array of data
data = np.arange(20).reshape(5, 4).astype(float)
data[2, 0] = -np.inf
data[2, -1] = np.inf
data[-1, 2:3] = np.nan

# Red image :
im_red = scene.visuals.Image(data, parent=wc.scene, cmap='viridis')

sc.show()
app.run()
```

Basically, if the data contains NaN or inf, the minimum and maximum of clim are not corrects which forces the render to be a single color :
![Screenshot_20191126_191530](https://user-images.githubusercontent.com/15892073/69660690-1f4a2580-1081-11ea-89b2-eebf614bfd76.png)

After modifications :
![Screenshot_20191126_191744](https://user-images.githubusercontent.com/15892073/69660825-6f28ec80-1081-11ea-9ff5-33e6e79c0f07.png)

**Note** : on matplotlib those pixels are discarded which is not the case here.
![Screenshot_20191126_191913](https://user-images.githubusercontent.com/15892073/69660918-a39ca880-1081-11ea-87a3-d2ad05601ccf.png)
 
