### PR TITLE
Skip bad font in test_font

### DIFF
--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -8,9 +8,20 @@ import warnings
 
 from vispy.testing import assert_in, run_tests_if_main
 from vispy.util.fonts import list_fonts, _load_glyph, _vispy_fonts
+import pytest
 
-warnings.simplefilter('always')
+known_bad_fonts = set([
+    'Noto Color Emoji',  # https://github.com/vispy/vispy/issues/1771
+])
 
+@pytest.fixture(scope='module')
+def setup():
+    with warnings.catch_warnings():
+        warnings.simplefilter('always')
+        yield
+
+# try both a vispy and system font   <--- what does this mean???
+sys_fonts = set(list_fonts()) - set(_vispy_fonts)
 
 def test_font_list():
     """Test font listing"""
@@ -19,23 +30,20 @@ def test_font_list():
     for font in _vispy_fonts:
         assert_in(font, f)
 
-
-def test_font_glyph():
+@pytest.mark.parametrize('face', ['OpenSans'] + sorted(sys_fonts))
+def test_font_glyph(setup, face):
     """Test loading glyphs"""
-    # try both a vispy and system font
-    sys_fonts = set(list_fonts()) - set(_vispy_fonts)
-    # assert_true(len(sys_fonts) > 0) not always the case!
-    for face in ['OpenSans'] + sorted(list(sys_fonts)):
-        print(face)  # useful for debugging
-        font_dict = dict(face=face, size=12, bold=False, italic=False)
-        glyphs_dict = dict()
-        chars = 'foobar^C&#'
-        for char in chars:
-            # Warning that Arial might not exist
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter('always')
-                _load_glyph(font_dict, char, glyphs_dict)
-        assert_equal(len(glyphs_dict), np.unique([c for c in chars]).size)
+    if face in known_bad_fonts:
+        pytest.skip()
+    font_dict = dict(face=face, size=12, bold=False, italic=False)
+    glyphs_dict = dict()
+    chars = 'foobar^C&#'
+    for char in chars:
+        # Warning that Arial might not exist
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always')
+            _load_glyph(font_dict, char, glyphs_dict)
+    assert_equal(len(glyphs_dict), np.unique([c for c in chars]).size)
 
 
 run_tests_if_main()

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -14,12 +14,6 @@ known_bad_fonts = set([
     'Noto Color Emoji',  # https://github.com/vispy/vispy/issues/1771
 ])
 
-@pytest.fixture(scope='module')
-def setup():
-    with warnings.catch_warnings():
-        warnings.simplefilter('always')
-        yield
-
 # try both a vispy and system font   <--- what does this mean???
 sys_fonts = set(list_fonts()) - set(_vispy_fonts)
 
@@ -31,7 +25,7 @@ def test_font_list():
         assert_in(font, f)
 
 @pytest.mark.parametrize('face', ['OpenSans'] + sorted(sys_fonts))
-def test_font_glyph(setup, face):
+def test_font_glyph(face):
     """Test loading glyphs"""
     if face in known_bad_fonts:
         pytest.skip()

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -29,7 +29,7 @@ def test_font_list():
 def test_font_glyph(face):
     """Test loading glyphs"""
     if face in known_bad_fonts:
-        pytest.skip()
+        pytest.xfail()
     font_dict = dict(face=face, size=12, bold=False, italic=False)
     glyphs_dict = dict()
     chars = 'foobar^C&#'

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -16,12 +16,14 @@ known_bad_fonts = set([
 # try both a vispy and system font   <--- what does this mean???
 sys_fonts = set(list_fonts()) - set(_vispy_fonts)
 
+
 def test_font_list():
     """Test font listing"""
     f = list_fonts()
     assert len(f) > 0
     for font in _vispy_fonts:
         assert_in(font, f)
+
 
 @pytest.mark.parametrize('face', ['OpenSans'] + sorted(sys_fonts))
 def test_font_glyph(face):

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -3,7 +3,6 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 import numpy as np
-from nose.tools import assert_true, assert_equal
 import warnings
 
 from vispy.testing import assert_in, run_tests_if_main
@@ -20,7 +19,7 @@ sys_fonts = set(list_fonts()) - set(_vispy_fonts)
 def test_font_list():
     """Test font listing"""
     f = list_fonts()
-    assert_true(len(f) > 0)
+    assert len(f) > 0
     for font in _vispy_fonts:
         assert_in(font, f)
 
@@ -37,7 +36,7 @@ def test_font_glyph(face):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter('always')
             _load_glyph(font_dict, char, glyphs_dict)
-    assert_equal(len(glyphs_dict), np.unique([c for c in chars]).size)
+    assert len(glyphs_dict) == np.unique([c for c in chars]).size
 
 
 run_tests_if_main()


### PR DESCRIPTION
Fixes: https://github.com/vispy/vispy/issues/1771

Also uses fixtures so as not to change the global state of the the warnings filter.