### PR TITLE
Fixup decorator to enable full use of pytest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: vispyDeployLinux
 - job: macos
-  pool: {vmImage: 'macOS-10.13'}
+  pool: {vmImage: 'macOS-10.14'}
   steps:
     - task: UsePythonVersion@0
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
       - v*
 variables:
   CIBW_BUILDING: "true"
-  CIBW_SKIP: "cp27-* cp34-* cp38-*"
+  CIBW_SKIP: "cp27-* cp34-* pp27-* pp36-*"
   CIBW_TEST_REQUIRES: "pytest pytest-sugar"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -2,6 +2,7 @@
 
 import json
 import tempfile
+from unittest import mock
 
 from vispy import config
 from vispy.app import Canvas
@@ -9,11 +10,6 @@ from vispy.gloo import glir
 from vispy.testing import requires_application, requires_pyopengl, run_tests_if_main
 
 import numpy as np
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 def test_queue():

--- a/vispy/plot/tests/test_plot.py
+++ b/vispy/plot/tests/test_plot.py
@@ -6,11 +6,7 @@ import vispy.plot as vp
 from vispy.testing import (assert_raises, requires_application,
                            run_tests_if_main)
 from vispy.visuals.axis import AxisVisual
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 @requires_application()

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -11,6 +11,7 @@ import sys
 import os
 import inspect
 import gc
+import functools
 
 from distutils.version import LooseVersion
 
@@ -227,6 +228,9 @@ def composed(*decs):
 
 
 def garbage_collect(f):
+    # Pytest expects things like the name of the functions not to change
+    # Therefore, we must use the functools.wraps decorator on our deco
+    @functools.wraps(f)
     def deco(*args, **kwargs):
         gc.collect()
         return f(*args, **kwargs)


### PR DESCRIPTION
I get that moving backends is a "decision" that must be thought of. 

This is just a little fix that enables decorators to be stacked and used with pytest.

Otherwise, enabling the gc destroys other pytest decorators.