### PR TITLE
Make it possible to get and set the face, bold, and italic properties of Text via properties

### DIFF
--- a/examples/basics/visuals/text_visual.py
+++ b/examples/basics/visuals/text_visual.py
@@ -134,6 +134,10 @@ class Canvas(app.Canvas):
                 self.anchor_ind = 0
             else:
                 self.anchor_ind += 1
+        if event.key == 'b':
+            self.text.bold = not self.text.bold
+        if event.key == 'i':
+            self.text.italic = not self.text.italic
         self.update_text()
 
     def update_text(self):

--- a/vispy/visuals/tests/test_text.py
+++ b/vispy/visuals/tests/test_text.py
@@ -55,4 +55,31 @@ def test_text_rotation_update():
         assert_allclose(text.shared_program['a_rotation'], np.radians(30.))
 
 
+@requires_application()
+def test_face_bold_italic():
+
+    with TestingCanvas() as c:
+
+        # Check defaults
+        text = Text('testing', pos=(100, 100), parent=c.scene)
+        assert not text.bold and not text.italic
+
+        # Check getter properties
+        text = Text('testing', pos=(100, 100), bold=True, italic=True, parent=c.scene)
+        assert text.bold and text.italic
+
+        # Check that changing a property changes the font object
+        font1 = text._font
+        text.bold = False
+        font2 = text._font
+        assert font1 is not font2
+        text.italic = False
+        font3 = text._font
+        assert font2 is not font3
+        text.bold = True
+        text.italic = True
+        font4 = text._font
+        assert font1 is font4
+
+
 run_tests_if_main()

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -414,7 +414,10 @@ class TextVisual(Visual):
         # Init font handling stuff
         # _font_manager is a temporary solution to use global mananger
         self._font_manager = font_manager or FontManager(method=method)
-        self._font = self._font_manager.get_font(face, bold, italic)
+        self._face = face
+        self._bold = bold
+        self._italic = italic
+        self._update_font()
         self._vertices = None
         self._color_vbo = None
         self._anchors = (anchor_x, anchor_y)
@@ -605,6 +608,36 @@ class TextVisual(Visual):
 
     def _compute_bounds(self, axis, view):
         return self._pos[:, axis].min(), self._pos[:, axis].max()
+
+    @property
+    def face(self):
+        return self._face
+
+    @face.setter
+    def face(self, value):
+        self._face = value
+        self._update_font()
+
+    @property
+    def bold(self):
+        return self._bold
+
+    @bold.setter
+    def bold(self, value):
+        self._bold = value
+        self._update_font()
+
+    @property
+    def italic(self):
+        return self._italic
+
+    @italic.setter
+    def italic(self, value):
+        self._italic = value
+        self._update_font()
+
+    def _update_font(self):
+        self._font = self._font_manager.get_font(self._face, self._bold, self._italic)
 
 
 class SDFRendererCPU(object):

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -638,6 +638,7 @@ class TextVisual(Visual):
 
     def _update_font(self):
         self._font = self._font_manager.get_font(self._face, self._bold, self._italic)
+        self.update()
 
 
 class SDFRendererCPU(object):


### PR DESCRIPTION
For a use case I have, I needed to be able to find out whether a ``Text`` object had a bold font, and needed to be able to set it, so I decided to add properties for the face, bold, and italic properties of Text (since these can be set via the ``__init__``, I thought having properties that match these arguments would make sense).