### PR TITLE
Switch to setuptools_scm version.py usage to avoid import overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ js/node_modules
 js/dist
 node_modules/
 vispy/static/
+vispy/version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ recursive-include vispy *.vert
 include vispy/app/tests/qt-designer.ui
 include vispy/io/_data/spatial-filters.npy
 include vispy/util/fonts/data/*.ttf
+include vispy/version.py
 
 recursive-include examples *.py
 recursive-include examples *.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ requires = [
     "wheel",
     "setuptools>=30.3.0",
     "setuptools_scm",
+    # Use these when setuptools>=42 is more widely available
+    # "setuptools>=42",
+    # "setuptools_scm[toml]>=3.4",
     "setuptools_scm_git_archive",
     "Cython>=0.29.2",
     "numpy; python_version=='2.7'",
@@ -10,3 +13,6 @@ requires = [
     "numpy==1.13.3; python_version=='3.6'",
     "numpy==1.14.5; python_version>='3.7'",
 ]
+
+[tools.setuptools_scm]
+write_to = "vispy/version.py"

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
         'wx': ['wxPython'],
         'doc': ['sphinx_bootstrap_theme', 'numpydoc'],
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=['make']),
     ext_modules=cythonize(extensions),
     package_dir={'vispy': 'vispy'},
     data_files=[

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ extensions = [Extension('vispy.visuals.text._sdf_cpu',
 readme = open('README.rst', 'r').read()
 setup(
     name=name,
-    use_scm_version=True,
+    use_scm_version={'write_to': 'vispy/version.py'},
     author='Vispy contributors',
     author_email='vispy@googlegroups.com',
     license='(new) BSD',
@@ -209,7 +209,7 @@ setup(
         'jsdeps': NPM,
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    install_requires=['numpy', 'freetype-py', 'setuptools'],
+    install_requires=['numpy', 'freetype-py'],
     setup_requires=['numpy', 'cython', 'setuptools_scm', 'setuptools_scm_git_archive'],
     extras_require={
         'ipython-static': ['ipython'],

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -23,8 +23,8 @@ from pkg_resources import get_distribution, DistributionNotFound
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from .version import version as __version__  # noqa
+except ImportError:
     # package is not installed
     pass
 

--- a/vispy/__init__.py
+++ b/vispy/__init__.py
@@ -18,7 +18,6 @@ For more information, see http://vispy.org.
 """
 
 from __future__ import division
-from pkg_resources import get_distribution, DistributionNotFound
 
 __all__ = ['use', 'sys_info', 'set_log_level', 'test']
 

--- a/vispy/util/tests/test_import.py
+++ b/vispy/util/tests/test_import.py
@@ -16,7 +16,7 @@ import vispy
 
 
 # minimum that will be imported when importing vispy
-_min_modules = ['vispy', 'vispy.util', 'vispy.ext', 'vispy.ipython', 'vispy.testing']
+_min_modules = ['vispy', 'vispy.util', 'vispy.ext', 'vispy.ipython', 'vispy.testing', 'vispy.version']
 
 
 def loaded_vispy_modules(import_module, depth=None, all_modules=False):


### PR DESCRIPTION
Closes #1779 

This switches vispy to use a feature of setuptools_scm which writes the generated version number to a `vispy/version.py` file. This is different from what was previously done which was to use setuptools to read the installed package's metadata and extract the version number. As discussed in #1779, this can cause major overhead on systems with a lot of packages installed. This PR is the simplest workaround for that.

The downside to this is that developers installing vispy in a "development mode" may be confused by a `vispy/version.py` that is ignored by `.gitignore` and was generated just by them installed the package.

## Additionally

This starts to put in place some functionality that setuptools_scm recently documented and added to enable setuptools_scm from the pyproject.toml file. However, this requires setuptools 42 or above which is not widely available so I'm not sure it is smart to require that for building quite yet. Maybe version 0.7 or 0.8 (assuming this gets included in a 0.6.x release).