### PR TITLE
Make all AxisVisual parameters easily updatable after instantiation

### DIFF
--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -75,7 +75,7 @@ class AxisVisual(CompoundVisual):
                  scale_type="linear", axis_color=(1, 1, 1),
                  tick_color=(0.7, 0.7, 0.7), text_color='w',
                  minor_tick_length=5, major_tick_length=10,
-                 tick_width=2, tick_label_margin=5, tick_font_size=8,
+                 tick_width=2, tick_label_margin=12, tick_font_size=8,
                  axis_width=3,  axis_label=None,
                  axis_label_margin=35, axis_font_size=10,
                  font_size=None, anchors=None):
@@ -88,6 +88,7 @@ class AxisVisual(CompoundVisual):
             tick_font_size = font_size
             axis_font_size = font_size
 
+        self._initialized = False
         self._pos = None
         self._domain = None
 
@@ -97,8 +98,7 @@ class AxisVisual(CompoundVisual):
         self._stop_at_major = (False, False)
 
         self.ticker = Ticker(self, anchors=anchors)
-        self.tick_direction = np.array(tick_direction, float)
-        self.tick_direction = self.tick_direction
+        self.tick_direction = tick_direction
         self.scale_type = scale_type
 
         self.minor_tick_length = minor_tick_length  # px
@@ -124,13 +124,14 @@ class AxisVisual(CompoundVisual):
         if pos is not None:
             self.pos = pos
         self.domain = domain
+        self._initialized = True
 
     @property
-    def label_color(self):
+    def text_color(self):
         return self._text.color
 
-    @label_color.setter
-    def label_color(self, value):
+    @text_color.setter
+    def text_color(self, value):
         self._text.color = value
         self._axis_label.color = value
 
@@ -143,6 +144,14 @@ class AxisVisual(CompoundVisual):
         self._line.set_data(color=value)
 
     @property
+    def axis_width(self):
+        return self._line.width
+
+    @axis_width.setter
+    def axis_width(self, value):
+        self._line.set_data(width=value)
+
+    @property
     def tick_color(self):
         return self._ticks.color
 
@@ -151,12 +160,44 @@ class AxisVisual(CompoundVisual):
         self._ticks.set_data(color=value)
 
     @property
+    def tick_width(self):
+        return self._ticks.width
+
+    @tick_width.setter
+    def tick_width(self, value):
+        self._ticks.set_data(width=value)
+
+    @property
     def tick_font_size(self):
         return self._text.font_size
 
     @tick_font_size.setter
     def tick_font_size(self, value):
         self._text.font_size = value
+
+    @property
+    def tick_direction(self):
+        return self._tick_direction
+
+    @tick_direction.setter
+    def tick_direction(self, value):
+        self._tick_direction = np.array(value, float)
+
+    def __setattr__(self, name, val):
+        super().__setattr__(name, val)
+        if self._initialized:
+            if name in (
+                "minor_tick_length",
+                "major_tick_length",
+                "tick_label_margin",
+                "axis_label_margin",
+                "tick_direction",
+                "axis_label",
+                "pos",
+                "scale_type", 
+            ):
+                self._need_update = True
+                self.update()
 
     @property
     def axis_font_size(self):
@@ -173,8 +214,6 @@ class AxisVisual(CompoundVisual):
     @axis_label.setter
     def axis_label(self, axis_label):
         self._axis_label_text = axis_label
-        self._need_update = True
-        self.update()
 
     @property
     def pos(self):
@@ -183,8 +222,6 @@ class AxisVisual(CompoundVisual):
     @pos.setter
     def pos(self, pos):
         self._pos = np.array(pos, float)
-        self._need_update = True
-        self.update()
 
     @property
     def domain(self):

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -8,7 +8,7 @@ import math
 
 import numpy as np
 
-from .visual import CompoundVisual
+from .visual import CompoundVisual, updating_property
 from .line import LineVisual
 from .text import TextVisual
 
@@ -88,7 +88,6 @@ class AxisVisual(CompoundVisual):
             tick_font_size = font_size
             axis_font_size = font_size
 
-        self._initialized = False
         self._pos = None
         self._domain = None
 
@@ -98,15 +97,15 @@ class AxisVisual(CompoundVisual):
         self._stop_at_major = (False, False)
 
         self.ticker = Ticker(self, anchors=anchors)
-        self.tick_direction = tick_direction
+        self.tick_direction = np.array(tick_direction, float)
         self.scale_type = scale_type
 
-        self.minor_tick_length = minor_tick_length  # px
-        self.major_tick_length = major_tick_length  # px
-        self.tick_label_margin = tick_label_margin  # px
-        self.axis_label_margin = axis_label_margin  # px
+        self._minor_tick_length = minor_tick_length  # px
+        self._major_tick_length = major_tick_length  # px
+        self._tick_label_margin = tick_label_margin  # px
+        self._axis_label_margin = axis_label_margin  # px
 
-        self._axis_label_text = axis_label
+        self._axis_label = axis_label
 
         self._need_update = True
 
@@ -117,14 +116,13 @@ class AxisVisual(CompoundVisual):
                                  color=tick_color)
 
         self._text = TextVisual(font_size=tick_font_size, color=text_color)
-        self._axis_label = TextVisual(font_size=axis_font_size,
-                                      color=text_color)
+        self._axis_label_vis = TextVisual(font_size=axis_font_size,
+                                          color=text_color)
         CompoundVisual.__init__(self, [self._line, self._text, self._ticks,
-                                       self._axis_label])
+                                       self._axis_label_vis])
         if pos is not None:
             self.pos = pos
         self.domain = domain
-        self._initialized = True
 
     @property
     def text_color(self):
@@ -133,7 +131,7 @@ class AxisVisual(CompoundVisual):
     @text_color.setter
     def text_color(self, value):
         self._text.color = value
-        self._axis_label.color = value
+        self._axis_label_vis.color = value
 
     @property
     def axis_color(self):
@@ -175,64 +173,53 @@ class AxisVisual(CompoundVisual):
     def tick_font_size(self, value):
         self._text.font_size = value
 
-    @property
+    @updating_property
     def tick_direction(self):
-        return self._tick_direction
+        """The tick direction to use (in document coordinates)."""
 
     @tick_direction.setter
-    def tick_direction(self, value):
-        self._tick_direction = np.array(value, float)
-
-    def __setattr__(self, name, val):
-        super().__setattr__(name, val)
-        if self._initialized:
-            if name in (
-                "minor_tick_length",
-                "major_tick_length",
-                "tick_label_margin",
-                "axis_label_margin",
-                "tick_direction",
-                "axis_label",
-                "pos",
-                "scale_type",
-            ):
-                self._need_update = True
-                self.update()
+    def tick_direction(self, tick_direction):
+        self._tick_direction = np.array(tick_direction, float)
 
     @property
     def axis_font_size(self):
-        return self._axis_label.font_size
+        return self._axis_label_vis.font_size
 
     @axis_font_size.setter
     def axis_font_size(self, value):
-        self._axis_label.font_size = value
+        self._axis_label_vis.font_size = value
 
-    @property
+    @updating_property
+    def domain(self):
+        """The data values at the beginning and end of the axis, used for tick labels."""
+
+    @updating_property
     def axis_label(self):
-        return self._axis_label_text
+        """Text to use for the axis label."""
 
-    @axis_label.setter
-    def axis_label(self, axis_label):
-        self._axis_label_text = axis_label
-
-    @property
+    @updating_property
     def pos(self):
-        return self._pos
+        """Co-ordinates of start and end of the axis."""
 
     @pos.setter
     def pos(self, pos):
         self._pos = np.array(pos, float)
 
-    @property
-    def domain(self):
-        return self._domain
+    @updating_property
+    def minor_tick_length(self):
+        """The length of minor ticks, in pixels"""
 
-    @domain.setter
-    def domain(self, d):
-        if self._domain is None or d != self._domain:
-            self._domain = d
-            self._need_update = True
-            self.update()
+    @updating_property
+    def major_tick_length(self):
+        """The length of major ticks, in pixels"""
+
+    @updating_property
+    def tick_label_margin(self):
+        """Margin between ticks and tick labels"""
+
+    @updating_property
+    def axis_label_margin(self):
+        """Margin between ticks and axis labels"""
 
     @property
     def _vec(self):
@@ -249,15 +236,15 @@ class AxisVisual(CompoundVisual):
         self._text.pos = tick_label_pos
         self._text.anchors = anchors
         if self.axis_label is not None:
-            self._axis_label.text = self.axis_label
-            self._axis_label.pos = axis_label_pos
+            self._axis_label_vis.text = self.axis_label
+            self._axis_label_vis.pos = axis_label_pos
         self._need_update = False
 
     def _prepare_draw(self, view):
         if self._pos is None:
             return False
         if self.axis_label is not None:
-            self._axis_label.rotation = self._rotation_angle
+            self._axis_label_vis.rotation = self._rotation_angle
         if self._need_update:
             self._update_subvisuals()
 

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -194,7 +194,7 @@ class AxisVisual(CompoundVisual):
                 "tick_direction",
                 "axis_label",
                 "pos",
-                "scale_type", 
+                "scale_type",
             ):
                 self._need_update = True
                 self.update()

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -685,10 +685,13 @@ class updating_property:
     """A property descriptor that autoupdates the Visual during attribute setting.
 
     Use this as a decorator in place of the @property when you want the attribute to trigger
-    an immediate update to the visual upon change.
+    an immediate update to the visual upon change.  You may additionally declare an @setter,
+    and if you do, it will be called in addition to the standard logic:
+    `self._attr_name = value`.
+
     For example, the following code examples are equivalent:
 
-    class SomeVisual1:
+    class SomeVisual1(Visual):
         def __init__(self, someprop=None):
             self._someprop = someprop
 
@@ -705,7 +708,7 @@ class updating_property:
                     if hasattr(self, 'events'):
                         self.update()
 
-    class SomeVisual2:
+    class SomeVisual2(Visual):
         def __init__(self, someprop=None):
             self._someprop = someprop
 

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -753,5 +753,3 @@ class updating_property:
 
     def setter(self, fset):
         return type(self)(self.fget, fset, self.__doc__)
-
-

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -716,6 +716,19 @@ class updating_property:
             def someprop(self):
                 pass
 
+    NOTE: by default the __get__ method here will look for the conventional `_attr_name`
+    property on the object.  The result of this is that you don't actually have to put
+    anything in the body of a method decorated with @updating_property if you don't want to
+    do anything other than retrieve the property.  So you may see this slightly strange
+    pattern being used:
+
+    class SomeVisual2(Visual):
+    def __init__(self, someprop=None):
+        self._someprop = someprop
+
+        @updating_property
+        def someprop(self):
+            '''the docstring (or pass) is all that is needed'''
     """
 
     def __init__(self, fget=None, fset=None, doc=None):


### PR DESCRIPTION
I am starting to work with the `PlotWidget` a bit more for use in `napari`.  This is a small PR, partially for that and also to fix part of https://github.com/vispy/vispy/pull/1748#issuecomment-559789319.  It modifies `AxisVisual` to ensure that all of the parameters in the `__init__` method can be easily changed as attributes/properties after instantiation, and that changing them immediately updates the necessary subvisuals.

Rather than make a whole bunch of relatively empty `@property` and `@setter` methods just to set `_need_update` and call `self.update()` each time, I chose to modify the `__setatr__` method instead, calling `update()` for all parameters that wouldn't have otherwise induced a visual update.  (Note, parameters that are _not_ listed in there, such as `tick_width`, already update the visual without needing `update()`).  Let me know if you prefer the more explicit but verbose properties & setters.

There is one slight API change here: the `label_color` property is renamed to `text_color`, since that's what it was called in the function signature and class docstring.  Also added a couple more properties to access axis & tick widths/direction after instantiation.