### PR TITLE
Remove isosurface green color in VolumeVisual

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -7,19 +7,19 @@ About this technique
 --------------------
 
 In Python, we define the six faces of a cuboid to draw, as well as
-texture cooridnates corresponding with the vertices of the cuboid.
+texture cooridnates corresponding with the vertices of the cuboid. 
 The back faces of the cuboid are drawn (and front faces are culled)
-because only the back faces are visible when the camera is inside the
+because only the back faces are visible when the camera is inside the 
 volume.
 
-In the vertex shader, we intersect the view ray with the near and far
+In the vertex shader, we intersect the view ray with the near and far 
 clipping planes. In the fragment shader, we use these two points to
 compute the ray direction and then compute the position of the front
 cuboid surface (or near clipping plane) along the view ray.
 
 Next we calculate the number of steps to walk from the front surface
 to the back surface and iterate over these positions in a for-loop.
-At each iteration, the fragment color or other voxel information is
+At each iteration, the fragment color or other voxel information is 
 updated depending on the selected rendering method.
 
 It is important for the texture interpolation is 'linear', since with
@@ -58,7 +58,7 @@ varying vec4 v_farpos;
 void main() {
     // v_texcoord = a_texcoord;
     v_position = a_position;
-
+    
     // Project local vertex coordinate to camera position. Then do a step
     // backward (in cam coords) and project back. Voila, we get our ray vector.
     vec4 pos_in_cam = $viewtransformf(vec4(v_position, 1));
@@ -66,11 +66,11 @@ void main() {
     // intersection of ray and near clipping plane (z = -1 in clip coords)
     pos_in_cam.z = -pos_in_cam.w;
     v_nearpos = $viewtransformi(pos_in_cam);
-
+    
     // intersection of ray and far clipping plane (z = +1 in clip coords)
     pos_in_cam.z = pos_in_cam.w;
     v_farpos = $viewtransformi(pos_in_cam);
-
+    
     gl_Position = $transform(vec4(v_position, 1.0));
 }
 """  # noqa
@@ -113,14 +113,14 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
-{{
+{{   
     // Calculate color by incorporating lighting
     vec4 color1;
     vec4 color2;
-
+    
     // View direction
     vec3 V = normalize(view_ray);
-
+    
     // calculate normal vector from gradient
     vec3 N; // normal
     color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
@@ -137,49 +137,49 @@ vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
     betterColor = max(max(color1, color2),betterColor);
     float gm = length(N); // gradient magnitude
     N = normalize(N);
-
+    
     // Flip normal so it points towards viewer
     float Nselect = float(dot(N,V) > 0.0);
     N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
-
+    
     // Get color of the texture (albeido)
     color1 = betterColor;
     color2 = color1;
     // todo: parametrise color1_to_color2
-
+    
     // Init colors
     vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 final_color;
-
+    
     // todo: allow multiple light, define lights on viewvox or subscene
-    int nlights = 1;
+    int nlights = 1; 
     for (int i=0; i<nlights; i++)
-    {{
+    {{ 
         // Get light direction (make sure to prevent zero devision)
-        vec3 L = normalize(view_ray);  //lightDirs[i];
+        vec3 L = normalize(view_ray);  //lightDirs[i]; 
         float lightEnabled = float( length(L) > 0.0 );
         L = normalize(L+(1.0-lightEnabled));
-
+        
         // Calculate lighting properties
         float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
         vec3 H = normalize(L+V); // Halfway vector
         float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
-
+        
         // Calculate mask
         float mask1 = lightEnabled;
-
+        
         // Calculate colors
         ambient_color +=  mask1 * u_ambient;  // * gl_LightSource[i].ambient;
         diffuse_color +=  mask1 * lambertTerm;
         specular_color += mask1 * specularTerm * u_specular;
     }}
-
+    
     // Calculate final color by componing different components
     final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
     final_color.a = color2.a;
-
+    
     // Done
     return final_color;
 }}
@@ -293,21 +293,21 @@ TRANSLUCENT_SNIPPETS = dict(
             float a1 = integrated_color.a;
             float a2 = color.a * (1 - a1);
             float alpha = max(a1 + a2, 0.001);
-
+            
             // Doesn't work.. GLSL optimizer bug?
-            //integrated_color = (integrated_color * a1 / alpha) +
-            //                   (color * a2 / alpha);
+            //integrated_color = (integrated_color * a1 / alpha) + 
+            //                   (color * a2 / alpha); 
             // This should be identical but does work correctly:
             integrated_color *= a1 / alpha;
             integrated_color += color * a2 / alpha;
-
+            
             integrated_color.a = alpha;
-
+            
             if( alpha > 0.99 ){
                 // stop integrating if the fragment becomes opaque
                 iter = nsteps;
             }
-
+        
         """,
     after_loop="""
         gl_FragColor = integrated_color;
@@ -322,7 +322,7 @@ ADDITIVE_SNIPPETS = dict(
         """,
     in_loop="""
         color = $cmap(val);
-
+        
         integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - color);
         """,
     after_loop="""
@@ -370,7 +370,7 @@ frag_dict = {
 
 class VolumeVisual(Visual):
     """ Displays a 3D Volume
-
+    
     Parameters
     ----------
     vol : ndarray
@@ -396,10 +396,10 @@ class VolumeVisual(Visual):
         but has lower performance on desktop platforms.
     """
 
-    def __init__(self, vol, clim=None, method='mip', threshold=None,
+    def __init__(self, vol, clim=None, method='mip', threshold=None, 
                  relative_step_size=0.8, cmap='grays',
                  emulate_texture=False):
-
+        
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
 
         # Storage of information of volume
@@ -423,7 +423,7 @@ class VolumeVisual(Visual):
                 [0, 1, 1],
                 [1, 1, 1],
             ], dtype=np.float32))
-        self._tex = tex_cls((10, 10, 10), interpolation='linear',
+        self._tex = tex_cls((10, 10, 10), interpolation='linear', 
                             wrapping='clamp_to_edge')
 
         # Create program
@@ -434,22 +434,22 @@ class VolumeVisual(Visual):
         self._draw_mode = 'triangle_strip'
         self._index_buffer = IndexBuffer()
 
-        # Only show back faces of cuboid. This is required because if we are
+        # Only show back faces of cuboid. This is required because if we are 
         # inside the volume, then the front faces are outside of the clipping
         # box and will not be drawn.
         self.set_gl_state('translucent', cull_face=False)
-
+        
         # Set data
         self.set_data(vol, clim)
-
+        
         # Set params
         self.method = method
         self.relative_step_size = relative_step_size
         self.threshold = threshold if (threshold is not None) else vol.mean()
         self.freeze()
-
+    
     def set_data(self, vol, clim=None, copy=True):
-        """ Set the volume data.
+        """ Set the volume data. 
 
         Parameters
         ----------
@@ -465,7 +465,7 @@ class VolumeVisual(Visual):
             raise ValueError('Volume visual needs a numpy array.')
         if not ((vol.ndim == 3) or (vol.ndim == 4 and vol.shape[-1] <= 4)):
             raise ValueError('Volume visual needs a 3D image.')
-
+        
         # Handle clim
         if clim is not None:
             clim = np.array(clim, float)
@@ -474,7 +474,7 @@ class VolumeVisual(Visual):
             self._clim = tuple(clim)
         if self._clim is None:
             self._clim = vol.min(), vol.max()
-
+        
         # Apply clim (copy data by default... see issue #1727)
         vol = np.array(vol, dtype='float32', copy=copy)
         if self._clim[1] == self._clim[0]:
@@ -483,28 +483,28 @@ class VolumeVisual(Visual):
         else:
             vol -= self._clim[0]
             vol /= self._clim[1] - self._clim[0]
-
+        
         # Apply to texture
         self._tex.set_data(vol)  # will be efficient if vol is same shape
-        self.shared_program['u_shape'] = (vol.shape[2], vol.shape[1],
+        self.shared_program['u_shape'] = (vol.shape[2], vol.shape[1], 
                                           vol.shape[0])
-
+        
         shape = vol.shape[:3]
         if self._vol_shape != shape:
             self._vol_shape = shape
             self._need_vertex_update = True
         self._vol_shape = shape
-
+        
         # Get some stats
         self._kb_for_texture = np.prod(self._vol_shape) / 1024
-
+    
     @property
     def clim(self):
         """ The contrast limits that were applied to the volume data.
         Settable via set_data().
         """
         return self._clim
-
+    
     @property
     def cmap(self):
         return self._cmap
@@ -520,7 +520,7 @@ class VolumeVisual(Visual):
         """The render method to use
 
         Current options are:
-
+        
             * translucent: voxel colors are blended along the view ray until
               the result is opaque.
             * mip: maxiumum intensity projection. Cast a ray and display the
@@ -529,10 +529,10 @@ class VolumeVisual(Visual):
               the result is saturated.
             * iso: isosurface. Cast a ray until a certain threshold is
               encountered. At that location, lighning calculations are
-              performed to give the visual appearance of a surface.
+              performed to give the visual appearance of a surface.  
         """
         return self._method
-
+    
     @method.setter
     def method(self, method):
         # Check and save
@@ -552,31 +552,31 @@ class VolumeVisual(Visual):
         self.shared_program['texture2D_LUT'] = self.cmap.texture_lut() \
             if (hasattr(self.cmap, 'texture_lut')) else None
         self.update()
-
+    
     @property
     def threshold(self):
         """ The threshold value to apply for the isosurface render method.
         """
         return self._threshold
-
+    
     @threshold.setter
     def threshold(self, value):
         self._threshold = float(value)
         if 'u_threshold' in self.shared_program:
             self.shared_program['u_threshold'] = self._threshold
         self.update()
-
+    
     @property
     def relative_step_size(self):
         """ The relative step size used during raycasting.
-
+        
         Larger values yield higher performance at reduced quality. If
         set > 2.0 the ray skips entire voxels. Recommended values are
         between 0.5 and 1.5. The amount of quality degredation depends
         on the render method.
         """
         return self._relative_step_size
-
+    
     @relative_step_size.setter
     def relative_step_size(self, value):
         value = float(value)
@@ -584,15 +584,15 @@ class VolumeVisual(Visual):
             raise ValueError('relative_step_size cannot be smaller than 0.1')
         self._relative_step_size = value
         self.shared_program['u_relative_step_size'] = value
-
+    
     def _create_vertex_data(self):
         """ Create and set positions and texture coords from the given shape
-
+        
         We have six faces with 1 quad (2 triangles) each, resulting in
         6*2*3 = 36 vertices in total.
         """
         shape = self._vol_shape
-
+        
         # Get corner coordinates. The -0.5 offset is to center
         # pixels/voxels. This works correctly for anisotropic data.
         x0, x1 = -0.5, shape[2] - 0.5
@@ -609,7 +609,7 @@ class VolumeVisual(Visual):
             [x0, y1, z1],
             [x1, y1, z1],
         ], dtype=np.float32)
-
+        
         """
           6-------7
          /|      /|
@@ -619,12 +619,12 @@ class VolumeVisual(Visual):
         |/      |/
         0-------1
         """
-
+        
         # Order is chosen such that normals face outward; front faces will be
         # culled.
         indices = np.array([2, 6, 0, 4, 5, 6, 7, 2, 3, 0, 1, 5, 3, 7],
                            dtype=np.uint32)
-
+        
         # Apply
         self._vertices.set_data(pos)
         self._index_buffer.set_data(indices)

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -7,19 +7,19 @@ About this technique
 --------------------
 
 In Python, we define the six faces of a cuboid to draw, as well as
-texture cooridnates corresponding with the vertices of the cuboid. 
+texture cooridnates corresponding with the vertices of the cuboid.
 The back faces of the cuboid are drawn (and front faces are culled)
-because only the back faces are visible when the camera is inside the 
+because only the back faces are visible when the camera is inside the
 volume.
 
-In the vertex shader, we intersect the view ray with the near and far 
+In the vertex shader, we intersect the view ray with the near and far
 clipping planes. In the fragment shader, we use these two points to
 compute the ray direction and then compute the position of the front
 cuboid surface (or near clipping plane) along the view ray.
 
 Next we calculate the number of steps to walk from the front surface
 to the back surface and iterate over these positions in a for-loop.
-At each iteration, the fragment color or other voxel information is 
+At each iteration, the fragment color or other voxel information is
 updated depending on the selected rendering method.
 
 It is important for the texture interpolation is 'linear', since with
@@ -58,7 +58,7 @@ varying vec4 v_farpos;
 void main() {
     // v_texcoord = a_texcoord;
     v_position = a_position;
-    
+
     // Project local vertex coordinate to camera position. Then do a step
     // backward (in cam coords) and project back. Voila, we get our ray vector.
     vec4 pos_in_cam = $viewtransformf(vec4(v_position, 1));
@@ -66,11 +66,11 @@ void main() {
     // intersection of ray and near clipping plane (z = -1 in clip coords)
     pos_in_cam.z = -pos_in_cam.w;
     v_nearpos = $viewtransformi(pos_in_cam);
-    
+
     // intersection of ray and far clipping plane (z = +1 in clip coords)
     pos_in_cam.z = pos_in_cam.w;
     v_farpos = $viewtransformi(pos_in_cam);
-    
+
     gl_Position = $transform(vec4(v_position, 1.0));
 }
 """  # noqa
@@ -90,7 +90,7 @@ varying vec4 v_nearpos;
 varying vec4 v_farpos;
 
 // uniforms for lighting. Hard coded until we figure out how to do lights
-const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
+const vec4 u_ambient = vec4(0.2, 0.2, 0.2, 1.0);
 const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
 const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
 const float u_shininess = 40.0;
@@ -113,14 +113,14 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
-{{   
+{{
     // Calculate color by incorporating lighting
     vec4 color1;
     vec4 color2;
-    
+
     // View direction
     vec3 V = normalize(view_ray);
-    
+
     // calculate normal vector from gradient
     vec3 N; // normal
     color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
@@ -137,49 +137,49 @@ vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
     betterColor = max(max(color1, color2),betterColor);
     float gm = length(N); // gradient magnitude
     N = normalize(N);
-    
+
     // Flip normal so it points towards viewer
     float Nselect = float(dot(N,V) > 0.0);
     N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
-    
+
     // Get color of the texture (albeido)
     color1 = betterColor;
     color2 = color1;
     // todo: parametrise color1_to_color2
-    
+
     // Init colors
     vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 final_color;
-    
+
     // todo: allow multiple light, define lights on viewvox or subscene
-    int nlights = 1; 
+    int nlights = 1;
     for (int i=0; i<nlights; i++)
-    {{ 
+    {{
         // Get light direction (make sure to prevent zero devision)
-        vec3 L = normalize(view_ray);  //lightDirs[i]; 
+        vec3 L = normalize(view_ray);  //lightDirs[i];
         float lightEnabled = float( length(L) > 0.0 );
         L = normalize(L+(1.0-lightEnabled));
-        
+
         // Calculate lighting properties
         float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
         vec3 H = normalize(L+V); // Halfway vector
         float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
-        
+
         // Calculate mask
         float mask1 = lightEnabled;
-        
+
         // Calculate colors
         ambient_color +=  mask1 * u_ambient;  // * gl_LightSource[i].ambient;
         diffuse_color +=  mask1 * lambertTerm;
         specular_color += mask1 * specularTerm * u_specular;
     }}
-    
+
     // Calculate final color by componing different components
     final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
     final_color.a = color2.a;
-    
+
     // Done
     return final_color;
 }}
@@ -293,21 +293,21 @@ TRANSLUCENT_SNIPPETS = dict(
             float a1 = integrated_color.a;
             float a2 = color.a * (1 - a1);
             float alpha = max(a1 + a2, 0.001);
-            
+
             // Doesn't work.. GLSL optimizer bug?
-            //integrated_color = (integrated_color * a1 / alpha) + 
-            //                   (color * a2 / alpha); 
+            //integrated_color = (integrated_color * a1 / alpha) +
+            //                   (color * a2 / alpha);
             // This should be identical but does work correctly:
             integrated_color *= a1 / alpha;
             integrated_color += color * a2 / alpha;
-            
+
             integrated_color.a = alpha;
-            
+
             if( alpha > 0.99 ){
                 // stop integrating if the fragment becomes opaque
                 iter = nsteps;
             }
-        
+
         """,
     after_loop="""
         gl_FragColor = integrated_color;
@@ -322,7 +322,7 @@ ADDITIVE_SNIPPETS = dict(
         """,
     in_loop="""
         color = $cmap(val);
-        
+
         integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - color);
         """,
     after_loop="""
@@ -343,10 +343,10 @@ ISO_SNIPPETS = dict(
             // Take the last interval in smaller steps
             vec3 iloc = loc - step;
             for (int i=0; i<10; i++) {
-                val = $sample(u_volumetex, iloc).g;
-                if (val > u_threshold) {
-                    color = $cmap(val);
-                    gl_FragColor = calculateColor(color, iloc, dstep);
+                color = $sample(u_volumetex, iloc);
+                if (color.g > u_threshold) {
+                    color = calculateColor(color, iloc, dstep);
+                    gl_FragColor = $cmap(color.g);
                     iter = nsteps;
                     break;
                 }
@@ -370,7 +370,7 @@ frag_dict = {
 
 class VolumeVisual(Visual):
     """ Displays a 3D Volume
-    
+
     Parameters
     ----------
     vol : ndarray
@@ -396,10 +396,10 @@ class VolumeVisual(Visual):
         but has lower performance on desktop platforms.
     """
 
-    def __init__(self, vol, clim=None, method='mip', threshold=None, 
+    def __init__(self, vol, clim=None, method='mip', threshold=None,
                  relative_step_size=0.8, cmap='grays',
                  emulate_texture=False):
-        
+
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
 
         # Storage of information of volume
@@ -423,7 +423,7 @@ class VolumeVisual(Visual):
                 [0, 1, 1],
                 [1, 1, 1],
             ], dtype=np.float32))
-        self._tex = tex_cls((10, 10, 10), interpolation='linear', 
+        self._tex = tex_cls((10, 10, 10), interpolation='linear',
                             wrapping='clamp_to_edge')
 
         # Create program
@@ -434,22 +434,22 @@ class VolumeVisual(Visual):
         self._draw_mode = 'triangle_strip'
         self._index_buffer = IndexBuffer()
 
-        # Only show back faces of cuboid. This is required because if we are 
+        # Only show back faces of cuboid. This is required because if we are
         # inside the volume, then the front faces are outside of the clipping
         # box and will not be drawn.
         self.set_gl_state('translucent', cull_face=False)
-        
+
         # Set data
         self.set_data(vol, clim)
-        
+
         # Set params
         self.method = method
         self.relative_step_size = relative_step_size
         self.threshold = threshold if (threshold is not None) else vol.mean()
         self.freeze()
-    
+
     def set_data(self, vol, clim=None, copy=True):
-        """ Set the volume data. 
+        """ Set the volume data.
 
         Parameters
         ----------
@@ -465,7 +465,7 @@ class VolumeVisual(Visual):
             raise ValueError('Volume visual needs a numpy array.')
         if not ((vol.ndim == 3) or (vol.ndim == 4 and vol.shape[-1] <= 4)):
             raise ValueError('Volume visual needs a 3D image.')
-        
+
         # Handle clim
         if clim is not None:
             clim = np.array(clim, float)
@@ -474,7 +474,7 @@ class VolumeVisual(Visual):
             self._clim = tuple(clim)
         if self._clim is None:
             self._clim = vol.min(), vol.max()
-        
+
         # Apply clim (copy data by default... see issue #1727)
         vol = np.array(vol, dtype='float32', copy=copy)
         if self._clim[1] == self._clim[0]:
@@ -483,28 +483,28 @@ class VolumeVisual(Visual):
         else:
             vol -= self._clim[0]
             vol /= self._clim[1] - self._clim[0]
-        
+
         # Apply to texture
         self._tex.set_data(vol)  # will be efficient if vol is same shape
-        self.shared_program['u_shape'] = (vol.shape[2], vol.shape[1], 
+        self.shared_program['u_shape'] = (vol.shape[2], vol.shape[1],
                                           vol.shape[0])
-        
+
         shape = vol.shape[:3]
         if self._vol_shape != shape:
             self._vol_shape = shape
             self._need_vertex_update = True
         self._vol_shape = shape
-        
+
         # Get some stats
         self._kb_for_texture = np.prod(self._vol_shape) / 1024
-    
+
     @property
     def clim(self):
         """ The contrast limits that were applied to the volume data.
         Settable via set_data().
         """
         return self._clim
-    
+
     @property
     def cmap(self):
         return self._cmap
@@ -520,7 +520,7 @@ class VolumeVisual(Visual):
         """The render method to use
 
         Current options are:
-        
+
             * translucent: voxel colors are blended along the view ray until
               the result is opaque.
             * mip: maxiumum intensity projection. Cast a ray and display the
@@ -529,10 +529,10 @@ class VolumeVisual(Visual):
               the result is saturated.
             * iso: isosurface. Cast a ray until a certain threshold is
               encountered. At that location, lighning calculations are
-              performed to give the visual appearance of a surface.  
+              performed to give the visual appearance of a surface.
         """
         return self._method
-    
+
     @method.setter
     def method(self, method):
         # Check and save
@@ -552,31 +552,31 @@ class VolumeVisual(Visual):
         self.shared_program['texture2D_LUT'] = self.cmap.texture_lut() \
             if (hasattr(self.cmap, 'texture_lut')) else None
         self.update()
-    
+
     @property
     def threshold(self):
         """ The threshold value to apply for the isosurface render method.
         """
         return self._threshold
-    
+
     @threshold.setter
     def threshold(self, value):
         self._threshold = float(value)
         if 'u_threshold' in self.shared_program:
             self.shared_program['u_threshold'] = self._threshold
         self.update()
-    
+
     @property
     def relative_step_size(self):
         """ The relative step size used during raycasting.
-        
+
         Larger values yield higher performance at reduced quality. If
         set > 2.0 the ray skips entire voxels. Recommended values are
         between 0.5 and 1.5. The amount of quality degredation depends
         on the render method.
         """
         return self._relative_step_size
-    
+
     @relative_step_size.setter
     def relative_step_size(self, value):
         value = float(value)
@@ -584,15 +584,15 @@ class VolumeVisual(Visual):
             raise ValueError('relative_step_size cannot be smaller than 0.1')
         self._relative_step_size = value
         self.shared_program['u_relative_step_size'] = value
-    
+
     def _create_vertex_data(self):
         """ Create and set positions and texture coords from the given shape
-        
+
         We have six faces with 1 quad (2 triangles) each, resulting in
         6*2*3 = 36 vertices in total.
         """
         shape = self._vol_shape
-        
+
         # Get corner coordinates. The -0.5 offset is to center
         # pixels/voxels. This works correctly for anisotropic data.
         x0, x1 = -0.5, shape[2] - 0.5
@@ -609,7 +609,7 @@ class VolumeVisual(Visual):
             [x0, y1, z1],
             [x1, y1, z1],
         ], dtype=np.float32)
-        
+
         """
           6-------7
          /|      /|
@@ -619,12 +619,12 @@ class VolumeVisual(Visual):
         |/      |/
         0-------1
         """
-        
+
         # Order is chosen such that normals face outward; front faces will be
         # culled.
         indices = np.array([2, 6, 0, 4, 5, 6, 7, 2, 3, 0, 1, 5, 3, 7],
                            dtype=np.uint32)
-        
+
         # Apply
         self._vertices.set_data(pos)
         self._index_buffer.set_data(indices)


### PR DESCRIPTION
This PR improves the isosurface rendering in the volume visual by getting rid of the default greenish tinge that was always being applied and allowing the isosurface to also respond to the changing of the colormaps. You can see it in action here https://github.com/napari/napari/pull/840 and below.

Original behavior:
![orig_iso_surface](https://user-images.githubusercontent.com/6531703/71637281-a5630a00-2bf3-11ea-861c-b1b4739733ae.gif)

Improved behavior:
![better_iso_surface](https://user-images.githubusercontent.com/6531703/71637282-ae53db80-2bf3-11ea-88e9-fc39438186c2.gif)

I realize this change will change how peoples renderings currently look, but I hope the majority of people will find the new behavior and improvement.