### PR TITLE
Add nearest interpolation to volume visual

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -35,8 +35,8 @@ def test_volume():
     assert V.method == 'iso'
 
     # Interpolation
-    V.method = 'nearest'
-    assert V.method == 'nearest'
+    V.interpolation = 'nearest'
+    assert V.interpolation == 'nearest'
         
     # Step size
     V.relative_step_size = 1.1

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -18,7 +18,8 @@ def test_volume():
     V = scene.visuals.Volume(vol)
     assert V.clim == (0, 1)
     assert V.method == 'mip'
-    
+    assert V.interpolation == 'linear'
+
     # Set wrong data
     with raises(ValueError):
         V.set_data(np.zeros((20, 20), 'float32'))
@@ -32,7 +33,11 @@ def test_volume():
     # Method
     V.method = 'iso'
     assert V.method == 'iso'
-    
+
+    # Interpolation
+    V.method = 'nearest'
+    assert V.method == 'nearest'
+        
     # Step size
     V.relative_step_size = 1.1
     assert V.relative_step_size == 1.1

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -538,7 +538,7 @@ class VolumeVisual(Visual):
 
     @interpolation.setter
     def interpolation(self, interp):
-        if i not in self._interpolation_names:
+        if interp not in self._interpolation_names:
             raise ValueError(
                 "interpolation must be one of %s"
                 % ', '.join(self._interpolation_names)

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -537,14 +537,14 @@ class VolumeVisual(Visual):
         return self._interpolation
 
     @interpolation.setter
-    def interpolation(self, i):
+    def interpolation(self, interp):
         if i not in self._interpolation_names:
             raise ValueError(
                 "interpolation must be one of %s"
                 % ', '.join(self._interpolation_names)
             )
-        if self._interpolation != i:
-            self._interpolation = i
+        if self._interpolation != interp:
+            self._interpolation = interp
             self._tex.interpolation = self._interpolation
             self.update()
             


### PR DESCRIPTION
This PR adds an `interpolation` property to the Volume visual and exposes a `nearest` and `linear`. It defaults to the `linear` behavior, which is what is currently supported, but provides the option for a `nearest` - which is particularly useful when viewing discrete (say integer labeled) regions in 3D.

Before with `linear`:
![orig_linear_interpolation](https://user-images.githubusercontent.com/6531703/71637606-ff67cd80-2bfb-11ea-8911-57ea2a1fe081.gif)

Now with `nearest`:
![better_3D_labels](https://user-images.githubusercontent.com/6531703/71637607-055dae80-2bfc-11ea-84f8-e4814032fab3.gif)

You can see these in use here https://github.com/napari/napari/pull/841 too

This PR adds documentation for the new property and a test for it.
