### PR TITLE
MAINT: GLFW workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8"
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,20 @@ addons:
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar"
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8"
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
       addons:
@@ -34,7 +34,7 @@ matrix:
           packages:
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -45,7 +45,7 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -55,7 +55,7 @@ matrix:
             - *full_apt
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock"
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -69,7 +69,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 mesalib libglu"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu"
            CONDA_CHANNEL_PRIORITY=strict
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     - &full_apt [libgl1-mesa-dri, libegl1-mesa, cmake, xorg-dev, libglu1-mesa-dev, mercurial, libdbus-1-dev, libgl1-mesa-dev, libglu1-mesa-dev, libpulse-dev, libx11-dev, libxcursor-dev, libxext-dev, libxi-dev, libxinerama-dev, libxrandr-dev, libxss-dev, libxt-dev, libxv-dev, libxxf86vm-dev, libasound2-dev, libudev-dev, libsdl2-2.0-0]
     # full_apt should also have 'libts-dev' but it is not available on xenial
     # liblgfw2 is not whitelisted by Travis, so we don't try using it here (not usable anyway)
+
 # Size testing can be skipped by adding "[size skip]" within a commit message.
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+os: linux
 dist: xenial
 addons:
   apt:
@@ -22,7 +23,8 @@ matrix:
       os: osx
       osx_image: xcode10.1
 
-    - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
+    # also tests file sizes, style, line endings
+    - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
            PIP_DEPENDENCIES=numpydoc
       addons:
@@ -38,7 +40,8 @@ matrix:
             - *mesa_apt
             - *full_apt
 
-    - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples  # test examples
+    # test examples
+    - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
            PIP_DEPENDENCIES=husl pypng cassowary
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl mesalib libglu"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       addons:
@@ -157,7 +157,7 @@ script:
     - cd ${SRC_DIR}
     - python -c "import vispy; print(vispy.sys_info())"
     - if [ "${TEST}" == "standard" ]; then
-        make unit;
+        python make test unit --tb=short;
       fi;
     - if [ "${TEST}" == "examples" ] || [ "${DEPS}" == "minimal" ]; then
         make examples;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: generic
 dist: xenial
 addons:
   apt:
@@ -12,66 +12,64 @@ addons:
 
 matrix:
   include:
-    - env: PYTHON=3.7 DEPS=minimal TEST=standard
+    - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
       os: osx
-      language: generic
       osx_image: xcode10.1
-    - env: PYTHON=3.7 DEPS=full TEST=standard
+
+    - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock
       os: osx
-      language: generic
       osx_image: xcode10.1
-# Travis Examples are extremely slow for OSX (times out)
-#    - env: PYTHON=3.7 DEPS=full TEST=examples
-#      os: osx
-#      language: generic
-    - env: PYTHON=3.7 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
+
+    - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard  # also tests file sizes, style, line endings
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
+           PIP_DEPENDENCIES=numpydoc
       addons:
         apt:
           packages:
-    - env: PYTHON=3.7 DEPS=full TEST=standard
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
-            - *full_apt
-    - env: PYTHON=3.7 DEPS=full TEST=examples  # test examples
+
+    - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           PIP_DEPENDENCIES=husl pypng cassowary
       addons:
         apt:
           packages:
             - *mesa_apt
             - *full_apt
-    - env: PYTHON=2.7 DEPS=full TEST=standard
+
+    - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples  # test examples
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           PIP_DEPENDENCIES=husl pypng cassowary
       addons:
         apt:
           packages:
             - *mesa_apt
             - *full_apt
+
+    - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock
+           PIP_DEPENDENCIES=husl pypng cassowary
+      addons:
+        apt:
+          packages:
+            - *mesa_apt
+            - *full_apt
+
     # OSMesa requires a specific Travis run because since the system also
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
-    - env: PYTHON=3.7 DEPS=osmesa TEST=osmesa
+    - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
+           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 mesalib libglu
       addons:
         apt:
           packages:
 
 
 before_install:
-    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-        wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget -q http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-      fi;
-
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b -p ~/anaconda
-    - export PATH=~/anaconda/bin:$PATH
-    - conda config --add channels conda-forge
-    - conda update --yes --quiet conda
-    # Set strict channel priority
-    - conda config --set channel_priority strict
-
-
+    - git clone https://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
     - SRC_DIR=$(pwd)
     # file size checks run on minimal build for time
     - if [ "${DEPS}" == "minimal" ]; then
@@ -101,12 +99,6 @@ before_install:
 
 
 install:
-    # create basic conda-forge environment
-    - conda create -n testenv --yes --quiet pip python=$PYTHON;
-    - source activate testenv;
-    # add needed packages common to all backends/tests
-    - conda install --yes --quiet numpy scipy nose pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8;
-
     # On Python3, install system-wide copies of bundled libraries instead
     # Also install PyQt5, imaging (PIL or pillow), scipy, mpl, egl
     # wxpython available from conda-forge but not for OSX:
@@ -117,27 +109,8 @@ install:
     # WX requires OSMesa (mesa on conda) which has typically been an
     # additional test environment. With llvm=3.3 the combination of
     # EGL and mesa causes segmentation faults. See issue #1401.
-    # can remove the github numpydoc install once >0.8.0 is released and get it from conda
-    - if [ "${DEPS}" == "full" ]; then
-        conda install --yes pyopengl networkx pysdl2;
-        pip install numpydoc;
-        if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          conda install --yes matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw;
-          if [ "${PYTHON}" == "3.7" ]; then
-            conda install --yes freetype-py imageio "freetype<2.10.0";
-            pip install -q husl pypng cassowary;
-            rm -rf ${SRC_DIR}/vispy/ext/_bundled;
-          else
-            conda install --yes mock;
-          fi;
-        else
-          conda install --yes matplotlib jupyter pyqt=5 scikit-image mock;
-        fi;
-      fi;
-
-     # Install OSMesa
-    - if [ "${DEPS}" == "osmesa" ]; then
-        conda install --yes mesalib libglu;
+    - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] &&  [ "${PYTHON_VERSION}" == "3.7" ]; then
+        rm -rf ${SRC_DIR}/vispy/ext/_bundled;
       fi;
 
     # Install vispy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ addons:
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8"
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
@@ -28,15 +28,15 @@ matrix:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES=numpydoc
+           PIP_DEPENDENCIES="numpydoc"
       addons:
         apt:
           packages:
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES=husl pypng cassowary
+           PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
         apt:
           packages:
@@ -45,9 +45,9 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES=husl pypng cassowary
+           PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
         apt:
           packages:
@@ -55,9 +55,9 @@ matrix:
             - *full_apt
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock"
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES=husl pypng cassowary
+           PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
         apt:
           packages:
@@ -69,7 +69,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 mesalib libglu
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 mesalib libglu"
            CONDA_CHANNEL_PRIORITY=strict
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl mesalib libglu"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
@@ -27,6 +29,7 @@ matrix:
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
       addons:
@@ -35,6 +38,7 @@ matrix:
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -46,6 +50,7 @@ matrix:
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -56,6 +61,7 @@ matrix:
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
       addons:
@@ -70,6 +76,7 @@ matrix:
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu"
+           CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       addons:
         apt:
@@ -118,7 +125,7 @@ install:
     # WX requires OSMesa (mesa on conda) which has typically been an
     # additional test environment. With llvm=3.3 the combination of
     # EGL and mesa causes segmentation faults. See issue #1401.
-    - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] &&  [ "${PYTHON_VERSION}" == "3.7" ]; then
+    - if [ "${DEPS}" == "full" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] && [ "${PYTHON_VERSION}" == "3.7" ]; then
         rm -rf ${SRC_DIR}/vispy/ext/_bundled;
       fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,26 @@ addons:
     - &full_apt [libgl1-mesa-dri, libegl1-mesa, cmake, xorg-dev, libglu1-mesa-dev, mercurial, libdbus-1-dev, libgl1-mesa-dev, libglu1-mesa-dev, libpulse-dev, libx11-dev, libxcursor-dev, libxext-dev, libxi-dev, libxinerama-dev, libxrandr-dev, libxss-dev, libxt-dev, libxv-dev, libxxf86vm-dev, libasound2-dev, libudev-dev, libsdl2-2.0-0]
     # full_apt should also have 'libts-dev' but it is not available on xenial
     # liblgfw2 is not whitelisted by Travis, so we don't try using it here (not usable anyway)
-
 # Size testing can be skipped by adding "[size skip]" within a commit message.
 
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
+           CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock
+           CONDA_CHANNEL_PRIORITY=strict
       os: osx
       osx_image: xcode10.1
 
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8
+           CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES=numpydoc
       addons:
         apt:
@@ -33,6 +35,7 @@ matrix:
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES=husl pypng cassowary
       addons:
         apt:
@@ -43,6 +46,7 @@ matrix:
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio "freetype<2.10.0"
+           CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES=husl pypng cassowary
       addons:
         apt:
@@ -52,6 +56,7 @@ matrix:
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock
+           CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES=husl pypng cassowary
       addons:
         apt:
@@ -65,6 +70,7 @@ matrix:
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
            CONDA_DEPENDENCIES=numpy scipy pytest cython coveralls pytest-cov pytest-sugar pytest-faulthandler flake8 mesalib libglu
+           CONDA_CHANNEL_PRIORITY=strict
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
            CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
+           PIP_DEPENDENCIES="numpydoc"
       os: osx
       osx_image: xcode10.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ matrix:
         apt:
           packages:
 
+    # XXX eventually we need to support GLFW 3.3.1...
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -51,7 +52,7 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -62,7 +63,7 @@ matrix:
             - *full_apt
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 mock"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools nose pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls mock"
+        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls mock"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
       - PYTHON_VERSION: "3.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools nose pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls"
+        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
 # can remove the github numpydoc install once >0.8.0 is released
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls mock"
+        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls mock"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
       - PYTHON_VERSION: "3.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls"
+        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
 # can remove the github numpydoc install once >0.8.0 is released
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-* cp38-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar nose"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -5,15 +5,7 @@
 vispy backend for glfw.
 """
 
-# Note: to install GLFW on Ubuntu:
-# $ git clone git://github.com/glfw/glfw.git
-# $ cd glfw
-# $ cmake -DBUILD_SHARED_LIBS=true -DGLFW_BUILD_EXAMPLES=false \
-#         -DGLFW_BUILD_TESTS=false -DGLFW_BUILD_DOCS=false .
-# $ make
-# $ sudo make install
-# $ sudo apt-get -qq install libx11-dev
-
+# To install GLFW on Ubuntu, use sudo apt-get install libglfw3.
 # On OSX, consider using brew.
 
 from __future__ import division
@@ -450,7 +442,7 @@ class CanvasBackend(BaseCanvasBackend):
         else:
             return
         self._process_mod(key, down=down)
-        
+
         # NOTE: GLFW only provides localized characters via _on_key_char, so if
         # this event contains a character we store all other data and dispatch
         # it once the final unicode character is sent shortly after.

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -294,7 +294,7 @@ class CanvasBackend(BaseCanvasBackend):
         self._vispy_canvas.events.initialize()
 
     def _vispy_warmup(self):
-        etime = time() + 0.5
+        etime = time() + 0.25
         while time() < etime:
             sleep(0.01)
             self._vispy_canvas.set_current()

--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -294,7 +294,7 @@ class CanvasBackend(BaseCanvasBackend):
         self._vispy_canvas.events.initialize()
 
     def _vispy_warmup(self):
-        etime = time() + 0.25
+        etime = time() + 0.5
         while time() < etime:
             sleep(0.01)
             self._vispy_canvas.set_current()

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -515,7 +515,7 @@ class Canvas(object):
             self._backend._vispy_set_current()
             self.context.finish()
             self.close()
-        sleep(0.1)  # ensure window is really closed/destroyed
+        sleep(0.2)  # ensure window is really closed/destroyed
 
     def render(self):
         """ Render the canvas to an offscreen buffer and return the image

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -524,9 +524,9 @@ class Canvas(object):
         Returns
         -------
         image : array
-            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the 
+            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region.
-        
+
         """
         self.set_current()
         size = self.physical_size

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -11,7 +11,7 @@ from time import sleep
 from ..util.event import EmitterGroup, Event, WarningEmitter
 from ..util.ptime import time
 from ..util.dpi import get_dpi
-from ..util import config as util_config
+from ..util import config as util_config, logger
 from ..ext.six import string_types
 from . import Application, use_app
 from ..gloo.context import (GLContext, set_current_canvas, forget_canvas)
@@ -452,6 +452,7 @@ class Canvas(object):
         behavior), consider making the widget a sub-widget.
         """
         if self._backend is not None and not self._closed:
+            logger.debug('Closing canvas %s' % (self,))
             self._closed = True
             self.events.close()
             self._backend._vispy_close()
@@ -505,17 +506,20 @@ class Canvas(object):
                    self.app.backend_name, hex(id(self))))
 
     def __enter__(self):
+        logger.debug('Context manager enter starting for %s' % (self,))
         self.show()
         self._backend._vispy_warmup()
         return self
 
     def __exit__(self, type, value, traceback):
         # ensure all GL calls are complete
+        logger.debug('Context manager exit starting for %s' % (self,))
         if not self._closed:
             self._backend._vispy_set_current()
             self.context.finish()
             self.close()
-        sleep(0.2)  # ensure window is really closed/destroyed
+        sleep(0.1)  # ensure window is really closed/destroyed
+        logger.debug('Context manager exit complete for %s' % (self,))
 
     def render(self):
         """ Render the canvas to an offscreen buffer and return the image

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -151,6 +151,9 @@ def test_capability():
                 else:
                     bad_kwargs[key] = non_default_vals[key]
     # ensure all settable values can be set
+    if c.app.backend_name == 'Glfw' and \
+            c.app.backend_module.glfw.__version__ >= (3, 3, 0):
+        good_kwargs.pop('decorate')  # bug on 3.3.1?
     with Canvas(**good_kwargs):
         # some of these are hard to test, and the ones that are easy are
         # tested elsewhere, so let's just make sure it runs here

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -150,10 +150,12 @@ def test_capability():
                     good_kwargs[key] = non_default_vals[key]
                 else:
                     bad_kwargs[key] = non_default_vals[key]
-    # ensure all settable values can be set
+    # bug on 3.3.1
+    # https://github.com/glfw/glfw/issues/1620
     if c.app.backend_name == 'Glfw' and \
-            c.app.backend_module.glfw.__version__ >= (3, 3, 0):
-        good_kwargs.pop('decorate')  # bug on 3.3.1?
+            c.app.backend_module.glfw.__version__ == (3, 3, 1):
+        good_kwargs.pop('decorate')
+    # ensure all settable values can be set
     with Canvas(**good_kwargs):
         # some of these are hard to test, and the ones that are easy are
         # tested elsewhere, so let's just make sure it runs here

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -49,19 +49,14 @@ def _unit(mode, extra_arg_string='', coverage=False):
     import_dir = _get_import_dir()[0]
     cwd = op.abspath(op.join(import_dir, '..'))
     extra_args = list(extra_args)
-    use_pytest = False
     try:
         import pytest  # noqa, analysis:ignore
-        use_pytest = True
     except ImportError:
         raise SkipTest('Skipping unit tests, pytest not installed')
 
     if mode == 'nobackend':
         msg = 'Running tests with no backend'
-        if use_pytest:
-            extra_args += ['-m', '"not vispy_app_test"']
-        else:
-            extra_args += ['-a', '"!vispy_app_test"']
+        extra_args += ['-m', '"not vispy_app_test"']
     else:
         # check to make sure we actually have the backend of interest
         stdout, stderr, invalid = run_subprocess(
@@ -76,13 +71,12 @@ def _unit(mode, extra_arg_string='', coverage=False):
                                   % (mode, stdout), _line_sep))
             raise SkipTest()
         msg = 'Running tests with %s backend' % mode
-        if use_pytest:
-            extra_args += ['-m', 'vispy_app_test']
-        else:
-            extra_args += ['-a', 'vispy_app_test']
-    if coverage and use_pytest:
+        extra_args += ['-m', 'vispy_app_test']
+    if coverage:
         # Don't actually print the coverage because it's way too long
         extra_args += ['--cov', 'vispy', '--cov-report=']
+    if not any(e.startswith('-r') for e in extra_args):
+        extra_args.append('-ra')
     # make a call to "python" so that it inherits whatever the system
     # thinks is "python" (e.g., virtualenvs)
     extra_args += [import_dir]  # positional argument

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -54,11 +54,7 @@ def _unit(mode, extra_arg_string='', coverage=False):
         import pytest  # noqa, analysis:ignore
         use_pytest = True
     except ImportError:
-        try:
-            import nose  # noqa, analysis:ignore
-        except ImportError:
-            raise SkipTest('Skipping unit tests, neither pytest nor nose '
-                           'installed')
+        raise SkipTest('Skipping unit tests, pytest not installed')
 
     if mode == 'nobackend':
         msg = 'Running tests with no backend'

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -2,7 +2,7 @@
 # vispy: testskip
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
-"""Test running functions"""
+"""Test running functions."""
 
 from __future__ import print_function
 
@@ -75,9 +75,10 @@ def _unit(mode, extra_arg_string='', coverage=False):
         if invalid:
             stdout = stdout + '\n' + stderr
             stdout = '\n'.join('    ' + x for x in stdout.split('\n'))
-            VispySkipSuite('\s%s\n%s\n%s' % (_line_sep, 'Skipping backend %s, '
-                           'not installed or working properly:\n%s'
-                           % (mode, stdout), _line_sep))
+            raise VispySkipSuite(
+                '\n%s\n%s\n%s' % (_line_sep, 'Skipping backend %s, not '
+                                  'installed or working properly:\n%s'
+                                  % (mode, stdout), _line_sep))
         msg = 'Running tests with %s backend' % mode
         extra_args += ['-m', 'vispy_app_test']
     if coverage:

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 
 import numpy as np
+from functools import wraps
 import sys
 import os
 import inspect
@@ -229,9 +230,13 @@ def composed(*decs):
 
 
 def garbage_collect(f):
+    @wraps(f)
     def deco(*args, **kwargs):
         gc.collect()
-        return f(*args, **kwargs)
+        try:
+            return f(*args, **kwargs)
+        finally:
+            gc.collect()
     return deco
 
 
@@ -351,8 +356,7 @@ def requires_scipy(min_version='0.13'):
 
 
 @nottest
-def TestingCanvas(bgcolor='black', size=(100, 100), dpi=None, decorate=False,
-                  **kwargs):
+def TestingCanvas(bgcolor='black', size=(100, 100), dpi=None, **kwargs):
     """Class wrapper to avoid importing scene until necessary"""
     # On Windows decorations can force windows to be an incorrect size
     # (e.g., instead of 100x100 they will be 100x248), having no
@@ -386,7 +390,8 @@ def TestingCanvas(bgcolor='black', size=(100, 100), dpi=None, decorate=False,
             SceneCanvas.draw_visual(self, visual, event)
             self.context.finish()
 
-    return TestingCanvas(bgcolor, size, dpi, decorate, **kwargs)
+    # XXX need decorate=True for GLFW 3.3.1 for some reason
+    return TestingCanvas(bgcolor, size, dpi, decorate=True, **kwargs)
 
 
 @nottest

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -158,12 +158,14 @@ def has_pyopengl():
 
 
 def requires_pyopengl():
-    return np.testing.dec.skipif(not has_pyopengl(), 'Requires PyOpenGL')
+    import pytest
+    pytest.mark.skipif(not has_pyopengl(), reason='Requires PyOpenGL')
 
 
 def requires_ssl():
+    import pytest
     bad = os.getenv('CIBW_BUILDING', 'false') == 'true'
-    return np.testing.dec.skipif(bad, 'Requires proper SSL support')
+    return pytest.mark.skipif(bad, reason='Requires proper SSL support')
 
 
 ###############################################################################
@@ -235,8 +237,9 @@ def garbage_collect(f):
 
 def requires_application(backend=None, has=(), capable=(), force_gc=True):
     """Return a decorator for tests that require an application"""
+    import pytest
     good, msg = has_application(backend, has, capable)
-    dec_backend = np.testing.dec.skipif(not good, "Skipping test: %s" % msg)
+    dec_backend = pytest.mark.skipif(not good, reason="Skipping test: %s" % msg)
     try:
         import pytest
     except Exception:
@@ -250,12 +253,14 @@ def requires_application(backend=None, has=(), capable=(), force_gc=True):
 
 def requires_img_lib():
     """Decorator for tests that require an image library"""
+    import pytest
     from ..io import _check_img_lib
     if sys.platform.startswith('win'):
         has_img_lib = False  # PIL breaks tests on windows (!)
     else:
         has_img_lib = not all(c is None for c in _check_img_lib())
-    return np.testing.dec.skipif(not has_img_lib, 'imageio or PIL required')
+    return pytest.mark.skipif(
+        not has_img_lib, reason='imageio or PIL required')
 
 
 def has_ipython(version='3.0'):
@@ -281,19 +286,20 @@ def has_ipython(version='3.0'):
 
 
 def requires_ipython(version='3.0'):
+    import pytest
     ipython_present, message = has_ipython(version)
-
-    return np.testing.dec.skipif(not ipython_present, message)
+    return pytest.mark.skipif(not ipython_present, reason=message)
 
 
 def requires_numpydoc():
+    import pytest
     try:
         import numpydoc  # noqa
     except Exception:
         present = False
     else:
         present = True
-    return np.testing.dec.skipif(not present, 'numpydoc is required')
+    return pytest.mark.skipif(not present, reason='numpydoc is required')
 
 
 def has_matplotlib(version='1.2'):
@@ -338,8 +344,10 @@ def _has_scipy(min_version):
 
 
 def requires_scipy(min_version='0.13'):
-    return np.testing.dec.skipif(not _has_scipy(min_version),
-                                 'Requires Scipy version >= %s' % min_version)
+    import pytest
+    return pytest.mark.skipif(
+        not _has_scipy(min_version),
+        reason='Requires Scipy version >= %s' % min_version)
 
 
 @nottest
@@ -387,7 +395,7 @@ def save_testing_image(image, location):
     from ..util import make_png
     if image == "screenshot":
         image = _screenshot(alpha=False)
-    with open(location+'.png', 'wb') as fid:
+    with open(location + '.png', 'wb') as fid:
         fid.write(make_png(image))
 
 

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -159,7 +159,7 @@ def has_pyopengl():
 
 def requires_pyopengl():
     import pytest
-    pytest.mark.skipif(not has_pyopengl(), reason='Requires PyOpenGL')
+    return pytest.mark.skipif(not has_pyopengl(), reason='Requires PyOpenGL')
 
 
 def requires_ssl():

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -20,6 +20,7 @@ from ..util import use_log_level
 
 
 def SkipTest(*args, **kwargs):
+    """Backport for raising SkipTest that gives a better traceback."""
     __tracebackhide__ = True
     import pytest
     return pytest.skip(*args, **kwargs)

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -18,19 +18,16 @@ from distutils.version import LooseVersion
 from ..ext.six import string_types
 from ..util import use_log_level
 
+
+def SkipTest(*args, **kwargs):
+    __tracebackhide__ = True
+    import pytest
+    return pytest.skip(*args, **kwargs)
+
+
 ###############################################################################
 # Adapted from Python's unittest2
 # http://docs.python.org/2/license.html
-
-try:
-    from unittest.case import SkipTest
-except ImportError:
-    try:
-        from unittest2.case import SkipTest
-    except ImportError:
-        class SkipTest(Exception):
-            pass
-
 
 def _safe_rep(obj, short=False):
     """Helper for assert_* ports"""
@@ -364,12 +361,11 @@ def TestingCanvas(bgcolor='black', size=(100, 100), dpi=None, **kwargs):
     from ..scene import SceneCanvas
 
     class TestingCanvas(SceneCanvas):
-        def __init__(self, bgcolor, size, dpi, decorate, **kwargs):
+        def __init__(self, bgcolor, size, dpi, **kwargs):
             self._entered = False
             self._wanted_vp = None
             SceneCanvas.__init__(self, bgcolor=bgcolor, size=size,
-                                 dpi=dpi, decorate=decorate,
-                                 **kwargs)
+                                 dpi=dpi, **kwargs)
 
         def __enter__(self):
             SceneCanvas.__enter__(self)
@@ -390,8 +386,7 @@ def TestingCanvas(bgcolor='black', size=(100, 100), dpi=None, **kwargs):
             SceneCanvas.draw_visual(self, visual, event)
             self.context.finish()
 
-    # XXX need decorate=True for GLFW 3.3.1 for some reason
-    return TestingCanvas(bgcolor, size, dpi, decorate=True, **kwargs)
+    return TestingCanvas(bgcolor, size, dpi, **kwargs)
 
 
 @nottest

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -375,8 +375,11 @@ class Ticker(object):
                 minor.extend(np.linspace(maj + minstep,
                                          maj + majstep - minstep,
                                          minor_num))
-            major_frac = (major - offset) / scale
-            minor_frac = (np.array(minor) - offset) / scale
+            major_frac = major - offset
+            minor_frac = np.array(minor) - offset
+            if scale != 0:  # maybe something better to do here?
+                major_frac /= scale
+                minor_frac /= scale
             major_frac = major_frac[::-1] if flip else major_frac
             use_mask = (major_frac > -0.0001) & (major_frac < 1.0001)
             major_frac = major_frac[use_mask]


### PR DESCRIPTION
Hopefully makes GLFW 3.3.1 tests work. I think they might have some bug with `decorate` as not setting the value makes things pass on my system (at least on 3.4.0 dev that I installed). Probably worth filing an upstream bug if this actually works.

EDIT: Also replaced Travis custom setup with cleaner `ci-helpers` interface
EDIT: Also silenced some errors about bad division in `axis` tests
EDIT: Also configured Travis's runs to use `--tb=short` to shorten tracebacks