### PR TITLE
DOC: Drop installation instructions from readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ js/dist
 node_modules/
 vispy/static/
 vispy/version.py
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -72,46 +72,9 @@ and experimental OpenGL backend for matplotlib.
 Installation
 ------------
 
-VisPy runs on Python 2.7+ and Python 3.3+ and depends on NumPy. You also
-need a backend (PyQt4/PySide, PyQt5/PySide2, glfw, pyglet, SDL, or wx).
-
-PyQt5/PySide2 should be considered more experimental than PyQt4/PySide.
-
-VisPy can be installed either via `pip`::
-
-    pip install vispy
-
-or within the `Anaconda <https://www.anaconda.com/download/>`_ Python
-distribution. Anaconda provides a convenient package management system.
-Installing VisPy can then easily be achieved by adding `conda-forge` to the
-channels with::
-
-    conda config --add channels conda-forge
-
-Once the `conda-forge` channel has been enabled, `vispy` can be installed
-with::
-
-    conda install vispy
-
-Development Installation
-------------------------
-
-As VisPy is under heavy development at this time, we highly recommend
-developers to use the development version on Github (master branch). You need
-to clone the repository and install VisPy with
-``python setup.py install``.
-
-As a one-liner, assuming `git` is installed::
-
-    git clone --recurse-submodules https://github.com/vispy/vispy.git && cd vispy && python setup.py install --user
-
-This will automatically install the latest version of vispy.
-
-If you already have vispy cloned, you may need to update the git submodules
-to make sure you have the newest code::
-
-    git pull
-    git submodule update --init --recursive
+Please follow the detailed
+`installation instructions <http://vispy.org/installation.html>`_
+on the VisPy website.
 
 Structure of VisPy
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -77,26 +77,21 @@ need a backend (PyQt4/PySide, PyQt5/PySide2, glfw, pyglet, SDL, or wx).
 
 PyQt5/PySide2 should be considered more experimental than PyQt4/PySide.
 
-VisPy can be installed either via `pip`:
+VisPy can be installed either via `pip`::
 
-```
-pip install vispy
-```
+    pip install vispy
 
 or within the `Anaconda <https://www.anaconda.com/download/>`_ Python
 distribution. Anaconda provides a convenient package management system.
 Installing VisPy can then easily be achieved by adding `conda-forge` to the
-channels with:
+channels with::
 
-```
-conda config --add channels conda-forge
-```
+    conda config --add channels conda-forge
 
-Once the `conda-forge` channel has been enabled, `vispy` can be installed with:
+Once the `conda-forge` channel has been enabled, `vispy` can be installed
+with::
 
-```
-conda install vispy
-```
+    conda install vispy
 
 Development Installation
 ------------------------


### PR DESCRIPTION
Refer to documentation on the website instead.