### PR TITLE
Fix GitHub raw file download base URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,17 +62,6 @@ matrix:
             - *mesa_apt
             - *full_apt
 
-    - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 mock"
-           CONDA_CHANNELS=conda-forge
-           CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES="husl pypng cassowary"
-      addons:
-        apt:
-          packages:
-            - *mesa_apt
-            - *full_apt
-
     # OSMesa requires a specific Travis run because since the system also
     # has (on-screen) OpenGL installed, we need to setup environment variable
     # to avoid having the linker load the wrong libglapi.so which would cause

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,6 @@ environment:
       CONDA_CHANNELS: "conda-forge"
 
   matrix:
-      - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls mock"
-        PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
       - PYTHON_VERSION: "3.7"
         CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"

--- a/vispy/util/fetching.py
+++ b/vispy/util/fetching.py
@@ -43,7 +43,7 @@ def load_data_file(fname, directory=None, force_download=False):
     fname : str
         The path to the file on the local system.
     """
-    _url_root = 'http://github.com/vispy/demo-data/raw/master/'
+    _url_root = 'https://raw.githubusercontent.com/vispy/demo-data/master/'
     url = _url_root + fname
     if directory is None:
         directory = config['data_path']


### PR DESCRIPTION
The VisPy cron job for Travis CI is failing on OSX. Not sure why specifically OSX, but while investigating I noticed that the GitHub raw file URL gets redirected. This PR changes VisPy's default download URL to be this new base URL. Let's see if the tests pass with it...