### PR TITLE
Use meshio fall back for reading and writing mesh files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
@@ -22,7 +22,7 @@ matrix:
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image mock meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
@@ -30,7 +30,7 @@ matrix:
 
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
@@ -40,7 +40,7 @@ matrix:
 
     # XXX eventually we need to support GLFW 3.3.1...
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -52,7 +52,7 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -63,7 +63,7 @@ matrix:
             - *full_apt
 
     - env: PYTHON_VERSION=2.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 mock"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 mock meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -78,7 +78,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls mock"
+        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls mock meshio"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
       - PYTHON_VERSION: "3.7"
         CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,6 @@ environment:
       CONDA_CHANNELS: "conda-forge"
 
   matrix:
-      - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls mock"
-        PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"
       - PYTHON_VERSION: "3.7"
         CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar cython coveralls meshio"
         PIP_DEPENDENCIES: "numpydoc https://files.pythonhosted.org/packages/71/5f/07aad120ca6e4339a5c127631341787bc6bc74add39a1f41223bda949721/freetype_py-2.1.0.post1-py2.py3-none-win_amd64.whl"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets meshio"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   CIBW_TEST_REQUIRES: "pytest pytest-sugar"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets meshio"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; pip install freetype-py"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,10 @@ trigger:
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-* cp38-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets meshio"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,10 @@ pr:
 variables:
   CIBW_BUILDING: "true"
   CIBW_SKIP: "cp27-* cp34-* cp35-* pp27-* pp36-*"
-  CIBW_TEST_REQUIRES: "pytest pytest-sugar"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"
-  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets meshio"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; pip install freetype-py"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ setup(
         'sdl2': ['PySDL2'],
         'wx': ['wxPython'],
         'doc': ['sphinx_bootstrap_theme', 'numpydoc'],
+        'io': ['meshio'],
     },
     packages=find_packages(exclude=['make']),
     ext_modules=cythonize(extensions),

--- a/vispy/io/mesh.py
+++ b/vispy/io/mesh.py
@@ -5,6 +5,7 @@
 """ Reading and writing of data like images and meshes.
 """
 
+import os
 from os import path as op
 
 from .wavefront import WavefrontReader, WavefrontWriter
@@ -65,7 +66,7 @@ def read_mesh(fname):
 
 
 def write_mesh(fname, vertices, faces, normals, texcoords, name='',
-               format='obj', overwrite=False, reshape_faces=True):
+               format=None, overwrite=False, reshape_faces=True):
     """ Write mesh data to file.
 
     Parameters
@@ -94,8 +95,29 @@ def write_mesh(fname, vertices, faces, normals, texcoords, name='',
     if op.isfile(fname) and not overwrite:
         raise IOError('file "%s" exists, use overwrite=True' % fname)
 
+    if format is None:
+        format = os.path.splitext(fname)[1][1:]
+
     # Check format
-    if format not in ('obj'):
-        raise ValueError('Only "obj" format writing currently supported')
-    WavefrontWriter.write(fname, vertices, faces,
-                          normals, texcoords, name, reshape_faces)
+    if format == 'obj':
+        WavefrontWriter.write(fname, vertices, faces,
+                              normals, texcoords, name, reshape_faces)
+        return
+
+    try:
+        import meshio
+    except ImportError:
+        raise ValueError('write_mesh does not understand format %s.' % format)
+
+    cell_data = {}
+    if normals is not None:
+        cell_data["normals"] = [normals]
+    if texcoords is not None:
+        cell_data["texcoords"] = [texcoords]
+
+    mesh = meshio.Mesh(vertices, [("triangle", faces)], cell_data=cell_data)
+
+    try:
+        mesh.write(fname, file_format=format)
+    except meshio.WriteError:
+        raise ValueError('write_mesh does not understand format %s.' % format)

--- a/vispy/io/mesh.py
+++ b/vispy/io/mesh.py
@@ -46,10 +46,22 @@ def read_mesh(fname):
         normals = mesh['face_normals']
         texcoords = None
         return vertices, faces, normals, texcoords
-    elif not format:
-        raise ValueError('read_mesh needs could not determine format.')
     else:
-        raise ValueError('read_mesh does not understand format %s.' % fmt)
+        try:
+            import meshio
+        except ImportError:
+            raise ValueError('read_mesh does not understand format %s.' % fmt)
+
+        try:
+            mesh = meshio.read(fname)
+        except meshio.ReadError:
+            raise ValueError('read_mesh does not understand format %s.' % fmt)
+
+        triangles = mesh.get_cells_type("triangle")
+        if len(triangles) == 0:
+            raise ValueError('mesh file does not contain triangles.')
+
+        return mesh.points, triangles, None, None
 
 
 def write_mesh(fname, vertices, faces, normals, texcoords, name='',

--- a/vispy/io/tests/test_io.py
+++ b/vispy/io/tests/test_io.py
@@ -64,6 +64,26 @@ def test_wavefront_non_triangular():
     assert lines[-2].startswith('f 2 1 8 7 6 4')
 
 
+def test_meshio():
+    '''Test meshio i/o'''
+    vertices = np.array([[0.0, 0.0, 0.0],
+                         [1.0, 0.0, 0.],
+                         [-.0, 1.0, 0.],
+                         [1.0, 1.0, 0.]])
+
+    faces = np.array([[0, 1, 3],
+                      [1, 2, 3]])
+    fname_out = op.join(temp_dir, 'temp.vtk')
+    write_mesh(fname_out, vertices=vertices,
+               faces=faces, normals=None,
+               texcoords=None, overwrite=True,
+               reshape_faces=False)
+    out_vertices, out_faces, _, _ = read_mesh(fname_out)
+
+    assert np.all(np.abs(out_vertices - vertices) < 1.0e-14)
+    assert np.all(out_faces == faces)
+
+
 def _slow_calculate_normals(rr, tris):
     """Efficiently compute vertex normals for triangulated surface"""
     # first, compute triangle normals


### PR DESCRIPTION
A rather unintrusive introduction of meshio into `read_mesh`. One could go further and have all i/o handled by meshio; obj and stl readers are in place. I didn't want to stretch it too far for this first PR though.

What works now:
```python
import vispy.io

verts, faces, _, _ = vispy.io.read_mesh("triceratops.vtu")
```
with all meshio-supported formats (there are around 30) _if_ meshio is installed and the mesh does in fact contain triangles.

Fixes #1817.