### PR TITLE
Fix DataBuffer.set_subdata docstring with wrong offset units

### DIFF
--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -162,7 +162,8 @@ class DataBuffer(Buffer):
         data : ndarray
             Data to be uploaded
         offset: int
-            Offset in buffer where to start copying data
+            Offset in buffer where to start copying data (i.e. index of
+            starting element).
         copy: bool
             Since the operation is deferred, data may change before
             data is actually uploaded to GPU memory.

--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -299,9 +299,9 @@ class DataBuffer(Buffer):
         elif data.size > stop - start:
             raise ValueError('Data too big to fit GPU data '
                              '(%d > %d-%d).' % (data.size, stop, start))
-        
+
         # Set data
-        offset = start  # * self.itemsize
+        offset = start
         self.set_subdata(data=data, offset=offset, copy=True)
 
     def __repr__(self):

--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -162,7 +162,7 @@ class DataBuffer(Buffer):
         data : ndarray
             Data to be uploaded
         offset: int
-            Offset in buffer where to start copying data (in bytes)
+            Offset in buffer where to start copying data
         copy: bool
             Since the operation is deferred, data may change before
             data is actually uploaded to GPU memory.


### PR DESCRIPTION
The `offset` is in "item count" unit not in "byte count" unit as is the case in the dtype-agnostic `Buffer` class.
The doc was probably copied over from the `Buffer` class without adaptation.