### PR TITLE
Make demos easier to switch to PySide2 from PyQt5

### DIFF
--- a/examples/basics/scene/isocurve_for_trisurface_qt.py
+++ b/examples/basics/scene/isocurve_for_trisurface_qt.py
@@ -41,6 +41,7 @@ except Exception:
 # Provide automatic signal function selection for PyQtX/PySide2
 pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
 
+
 class ObjectWidget(QWidget):
     """
     Widget for editing OBJECT parameters

--- a/examples/basics/scene/isocurve_for_trisurface_qt.py
+++ b/examples/basics/scene/isocurve_for_trisurface_qt.py
@@ -25,22 +25,27 @@ except ImportError:
     pass
 
 try:
-    from PyQt4.QtCore import pyqtSignal, Qt
+    from PyQt4 import QtCore
+    from PyQt4.QtCore import Qt
     from PyQt4.QtGui import (QApplication, QMainWindow, QWidget, QLabel,
                              QSpinBox, QComboBox, QGridLayout, QVBoxLayout,
                              QSplitter)
 except Exception:
-    from PyQt5.QtCore import pyqtSignal, Qt
+    # To switch between PyQt5 and PySide2 bindings just change the from import
+    from PyQt5 import QtCore
+    from PyQt5.QtCore import Qt
     from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel,
                                  QSpinBox, QComboBox, QGridLayout, QVBoxLayout,
                                  QSplitter)
 
+# Provide automatic signal function selection for PyQtX/PySide2
+pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
 
 class ObjectWidget(QWidget):
     """
     Widget for editing OBJECT parameters
     """
-    signal_object_changed = pyqtSignal(name='objectChanged')
+    signal_object_changed = pyqtsignal(name='objectChanged')
 
     def __init__(self, parent=None):
         super(ObjectWidget, self).__init__(parent)

--- a/examples/demo/gloo/primitive_mesh_viewer_qt.py
+++ b/examples/demo/gloo/primitive_mesh_viewer_qt.py
@@ -22,8 +22,6 @@ except ImportError:
 
 # To switch between PyQt5 and PySide2 bindings just change the from import
 from PyQt5 import QtCore, QtWidgets
-# Provide automatic signal function selection for PyQt5/PySide2
-pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
 
 import sys
 
@@ -32,6 +30,10 @@ from vispy import app, gloo
 from vispy.util.transforms import perspective, translate, rotate
 from vispy.geometry import meshdata as md
 from vispy.geometry import generation as gen
+
+# Provide automatic signal function selection for PyQt5/PySide2
+pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
+
 
 OBJECT = {'sphere': [('rows', 3, 1000, 'int', 3),
                      ('cols', 3, 1000, 'int', 3),

--- a/examples/demo/gloo/primitive_mesh_viewer_qt.py
+++ b/examples/demo/gloo/primitive_mesh_viewer_qt.py
@@ -19,7 +19,12 @@ try:
 except ImportError:
     pass
 
+
+# To switch between PyQt5 and PySide2 bindings just change the from import
 from PyQt5 import QtCore, QtWidgets
+# Provide automatic signal function selection for PyQt5/PySide2
+pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
+
 import sys
 
 import numpy as np
@@ -139,7 +144,7 @@ class ObjectWidget(QtWidgets.QWidget):
     """
     Widget for editing OBJECT parameters
     """
-    signal_objet_changed = QtCore.pyqtSignal(ObjectParam, name='objectChanged')
+    signal_objet_changed = pyqtsignal(ObjectParam, name='objectChanged')
 
     def __init__(self, parent=None, param=None):
         super(ObjectWidget, self).__init__(parent)

--- a/examples/demo/visuals/wiggly_bar.py
+++ b/examples/demo/visuals/wiggly_bar.py
@@ -43,7 +43,11 @@ import numpy as np
 import string
 import logging
 import traceback
+
+# To switch between PyQt5 and PySide2 bindings just change the from import
 from PyQt5 import QtCore, QtGui, QtWidgets
+# Provide automatic signal function selection for PyQt5/PySide2
+pyqtsignal = QtCore.pyqtSignal if hasattr(QtCore, 'pyqtSignal') else QtCore.Signal
 
 logger = logging.getLogger(__name__)
 
@@ -731,7 +735,7 @@ class Paramlist(object):
 
 class SetupWidget(QtWidgets.QWidget):
 
-    changed_parameter_sig = QtCore.pyqtSignal(Paramlist)
+    changed_parameter_sig = pyqtsignal(Paramlist)
 
     def __init__(self, parent=None):
         """Widget for holding all the parameter options in neat lists.


### PR DESCRIPTION

While most of examples/demos have hardcoded PyQt5 usage, it is generally trivial to pass to PySide2 by just replacing PyQt5 with PySide2 in the imports. But there are a few exceptions, like the two demos touched by this PR, that use signals where the PyQt5 and PySide2 API differs. 
This PR makes also those demos easily switchable.


I'm not sure a general revision of demo code, or just a plain explanation, would be advisable given that PySide2 is getting more important with the backing of Qt. 
If so I can try to contribute in this sense.

Federico