### PR TITLE
ColorArray != operator using == (for Python 2)

### DIFF
--- a/vispy/color/color_array.py
+++ b/vispy/color/color_array.py
@@ -179,6 +179,9 @@ class ColorArray(object):
 
     def __eq__(self, other):
         return np.array_equal(self._rgba, other._rgba)
+    
+    def __ne__(self, other):
+        return not (self == other)
 
     ###########################################################################
     def __getitem__(self, item):


### PR DESCRIPTION
In Python 3, overriding `__eq__` [automatically generates an override of `__ne__` that uses `__eq__`](https://bugs.python.org/issue4395) as long as the class doesn't inherit from some class that already overrides `__ne__`. However, Python 2 does not implement this convenience.

Comparing color values is important because [setting the color on a `MeshVisual` automatically sets its dirty flag](https://github.com/vispy/vispy/blob/d45a7ddd7ccb5e49ac1e4aea67f09e0a47960151/vispy/visuals/mesh.py#L344), even if the new color is the same as the old one. Setting the dirty flag causes a big performance hit. Therefore, in code where object colors change often, but not every frame, it's natural for the user to write code like:

    if new_color != mesh.color:
        mesh.color = new_color

This comparison currently doesn't work correctly in Python 2 due to the lack of overridden `__ne__` in `ColorArray`.