### PR TITLE
Implement volume contrast limits in shader, add gamma

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -62,6 +62,7 @@ def test_volume_draw():
         assert_image_approved(c.render(), 'visuals/volume.png')
 
 
+@requires_pyopengl()
 @requires_application()
 def test_volume_clims_and_gamma():
     """Test volume visual with clims and gamma on shader.

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -26,7 +26,7 @@ def test_volume():
     
     # Clim
     V.set_data(vol, (0.5, 0.8))
-    assert V.clim == (0.5, 0.8)
+    assert V.clim_range == (0.5, 0.8)
     with raises(ValueError):
         V.set_data((0.5, 0.8, 1.0))
     
@@ -73,14 +73,14 @@ def test_set_data_does_not_change_input():
     for dtype in ['uint8', 'int16', 'uint16', 'float32', 'float64']:
         vol_copy = np.array(vol, dtype=dtype, copy=True)
         # setting clim so that normalization would otherwise change the data
-        V.set_data(vol_copy, clim=(0, 200))
+        V.set_data(vol_copy, clim_range=(0, 200))
         assert np.allclose(vol, vol_copy)
 
     # for those using float32 who want to avoid the copy operation,
     # using set_data() with `copy=False` should be expected to alter the data.
     vol2 = np.array(vol, dtype='float32', copy=True)
     assert np.allclose(vol, vol2)
-    V.set_data(vol2, clim=(0, 200), copy=False)
+    V.set_data(vol2, clim_range=(0, 200), copy=False)
     assert not np.allclose(vol, vol2)
 
 

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -26,7 +26,7 @@ def test_volume():
     
     # Clim
     V.set_data(vol, (0.5, 0.8))
-    assert V.clim_range == (0.5, 0.8)
+    assert V.clim == (0.5, 0.8)
     with raises(ValueError):
         V.set_data((0.5, 0.8, 1.0))
     
@@ -73,14 +73,14 @@ def test_set_data_does_not_change_input():
     for dtype in ['uint8', 'int16', 'uint16', 'float32', 'float64']:
         vol_copy = np.array(vol, dtype=dtype, copy=True)
         # setting clim so that normalization would otherwise change the data
-        V.set_data(vol_copy, clim_range=(0, 200))
+        V.set_data(vol_copy, clim=(0, 200))
         assert np.allclose(vol, vol_copy)
 
     # for those using float32 who want to avoid the copy operation,
     # using set_data() with `copy=False` should be expected to alter the data.
     vol2 = np.array(vol, dtype='float32', copy=True)
     assert np.allclose(vol, vol2)
-    V.set_data(vol2, clim_range=(0, 200), copy=False)
+    V.set_data(vol2, clim=(0, 200), copy=False)
     assert not np.allclose(vol, vol2)
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -403,6 +403,13 @@ class VolumeVisual(Visual):
     gamma : float
         Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
         by default: 1.
+    clim_range_threshold : float
+        When changing the clims, if the new clim range is smaller than this fraction of the
+        last-used texture data range, then it will trigger a rescaling of the texture data.
+        For instance: if the texture data was last scaled from 0-1, and the clims are set to
+        0.4-0.5, then a texture rescale will be triggered if ``clim_range_threshold < 0.1``.
+        To prevent rescaling, set this value to 0.  To *always* rescale, set the value to
+        >= 1.
     emulate_texture : bool
         Use 2D textures to emulate a 3D texture. OpenGL ES 2.0 compatible,
         but has lower performance on desktop platforms.
@@ -414,7 +421,7 @@ class VolumeVisual(Visual):
 
     def __init__(self, vol, clim=None, method='mip', threshold=None, 
                  relative_step_size=0.8, cmap='grays', gamma=1.0,
-                 clim_range_threshold=0.1,
+                 clim_range_threshold=1,
                  emulate_texture=False, interpolation='linear'):
         
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -117,9 +117,16 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 applyColormap(float data) {{
-    float val = max(data - clim.x, 0) / (clim.y - clim.x);
-    return $cmap(pow(val, gamma));
+    if (clim.x < clim.y) {{
+        data = clamp(data, clim.x, clim.y);
+    }} else {{
+        data = clamp(data, clim.y, clim.x);
+    }}
+
+    data = (data - clim.x) / (clim.y - clim.x);
+    return $cmap(pow(data, gamma));
 }}
+
 
 vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
 {{   

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -400,6 +400,9 @@ class VolumeVisual(Visual):
         quality.
     cmap : str
         Colormap to use.
+    gamma : float
+        Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
+        by default: 1.
     emulate_texture : bool
         Use 2D textures to emulate a 3D texture. OpenGL ES 2.0 compatible,
         but has lower performance on desktop platforms.
@@ -538,7 +541,9 @@ class VolumeVisual(Visual):
 
     @property
     def clim(self):
-        """Contrast Limits. Volume display is mapped from black to white with these values.
+        """The contrast limits that were applied to the volume data.
+
+        Volume display is mapped from black to white with these values.
         Settable via set_data() as well as @clim.setter.
         """
         return self._clim

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -409,7 +409,7 @@ class VolumeVisual(Visual):
         For instance: if the texture data was last scaled from 0-1, and the clims are set to
         0.4-0.5, then a texture rescale will be triggered if ``clim_range_threshold < 0.1``.
         To prevent rescaling, set this value to 0.  To *always* rescale, set the value to
-        >= 1.
+        >= 1.  By default, 0.2
     emulate_texture : bool
         Use 2D textures to emulate a 3D texture. OpenGL ES 2.0 compatible,
         but has lower performance on desktop platforms.
@@ -421,7 +421,7 @@ class VolumeVisual(Visual):
 
     def __init__(self, vol, clim=None, method='mip', threshold=None, 
                  relative_step_size=0.8, cmap='grays', gamma=1.0,
-                 clim_range_threshold=1,
+                 clim_range_threshold=0.2,
                  emulate_texture=False, interpolation='linear'):
         
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
@@ -533,6 +533,20 @@ class VolumeVisual(Visual):
         # Get some stats
         self._kb_for_texture = np.prod(self._vol_shape) / 1024
 
+    def rescale_data(self):
+        """Force rescaling of data to the current contrast limits and texture upload.
+
+        Because Textures are currently 8-bits, and contrast adjustment is done during
+        rendering by scaling the values retrieved from the texture on the GPU (provided that
+        the new contrast limits settings are within the range of the clims used when the
+        last texture was uploaded), posterization may become visible if the contrast limits
+        become *too* small of a fraction of the clims used to normalize the texture.
+        This function is a convenience to "force" rescaling of the Texture data to the
+        current contrast limits range.
+        """
+        self.set_data(self._last_data, clim=self._clim)
+        self.update()
+
     @property
     def clim(self):
         """The contrast limits that were applied to the volume data.
@@ -555,33 +569,14 @@ class VolumeVisual(Visual):
         if not (clim.ndim == 1 and clim.size == 2):
             raise ValueError('clim must be a 2-element array-like')
         self._clim = tuple(clim)
-
-        # If the new clim range is outside of the range that was last used to set the
-        # texture data, update the texture.
-        min_exceeded = clim[0] < self._texture_limits[0]
-        max_exceeded = clim[1] > self._texture_limits[1]
-        if min_exceeded or max_exceeded:
-            tex_range = abs(np.subtract(*self._texture_limits))
-            # make the new texture range slightly larger than the current clims, in the
-            # direction of change.  i.e. if the clim max is increasing, make the texture
-            # max 40% higher than it currently is
-            new_range = (
-                clim[0] - (tex_range * 0.4 if min_exceeded else 0),
-                clim[1] + (tex_range * 0.4 if max_exceeded else 0)
-            )
-            # rescale the data ... note this will also temporarily update the clims...
-            self.set_data(self._last_data, new_range)
-            # so we re-call this setter, which will peg the clims to the current setter
-            # and trigger the update() method at the end of this method.
-            self.clim = clim
+        if (clim[0] < self._texture_limits[0]) or (clim[1] > self._texture_limits[1]):
+            self.rescale_data()
             return
-
         # if the clim range is too small of a percentage of the last-used texture range,
-        # posterization may occur, so downscale the texture range.
+        # posterization may be visible, so downscale the texture range.
         range_ratio = np.subtract(*clim) / abs(np.subtract(*self._texture_limits))
         if np.abs(range_ratio) < self._clim_range_threshold:
-            self.set_data(self._last_data, clim=self._clim)
-            self.update()
+            self.rescale_data()
         else:
             #  new clims are within reasonable range of the texture data, just call shader
             self.shared_program['clim'] = self.clim_normalized


### PR DESCRIPTION
This began as an internal PR at https://github.com/napari/napari/pull/1056, but I'd like to know if it's something you would consider.  In typical [napari](https://github.com/napari/napari) usage, it would be pretty normal to repeatedly change the min/max contrast limits while viewing a 3D volume.  Unfortunately, each change incurs a renormalization on the CPU in [`Volume.set_data`](https://github.com/vispy/vispy/blob/3ac28ff0daf8836b44c6eba8d3c98541e37c5702/vispy/visuals/volume.py#L487-L493), leading to very laggy performance.  This PR moves most of the _re_-calculation of clims to the shader as follows:

- `Volume.clim`→ `Volume.clim_range`: `Volume.clim` was previously just serving a one-time role of data normalization (0-1) prior to moving the volume to Texture memory.  Seems to me that normalization needn't be repeated often, if the user is able to provide the maximum _range_ of min/max values that they might want to use.  So `Volume.clim` becomes `Volume.clim_range`, and `set_data(vol, clim)` becomes `set_data(vol, clim_range)`
- `Volume.clim` now becomes a property that is passed to the shaders where the final scaling is done.
- this PR also adds `Volume.gamma`, and performs gamma calculations in the shaders at the moment of colormap lookup.

For typical volume sizes in napari (~256-1024 pixels<sup>3</sup>), this speeds up rendering after changing the contrast almost 5 fold (on my computer)

### breaking change
this is a **breaking** change, in that it changes the semantics of `Volume.clim` and adds a new property `Volume.clim_range` (that has the same meaning and usage as the previous `Volume.clim`.  The `clim` argument in `Volume.set_data` has been renamed to `clim_range` to reflect what it is actually doing (though a deprecation warning catches previous usage and warns).
It _would_ be possible to implement this without breaking the API, by just re-interpreting the meaning of the existing `Volume.clim` and creating a new property (maybe `display_limits`?) that controls the final lookup on the shader.  But I felt like that was much less clear.  Anyway, let me know what you think of the basic idea and we can discuss how you would prefer to handle breakages.