### PR TITLE
Add MacOS 10.14 and manylinux2014 wheel builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; pip install freetype-py"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install cibuildwheel
         cibuildwheel --output-dir wheelhouse .
-    - bash: rm wheelhouse/*manylinux1* || true
     - task: PublishPipelineArtifact@1
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
@@ -109,7 +108,7 @@ jobs:
       inputs:
         patterns: |
           vispyDeployLinux/*
-          vispyDeployLinux2014/*2014*
+          vispyDeployLinux2014/*2014*.whl
           vispyDeployMacOS/*.whl
           vispyDeployWindows/*.whl
           vispyDeployMacOS_10_14/*.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
-  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig xvfb; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
+  CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; if [ `getconf LONG_BIT` == '64' ]; then pip install https://files.pythonhosted.org/packages/f2/00/6f332e63b33d24dc3761916e6d51402a7a82dd43c6ca8a96e24dda32c6b5/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_x86_64.whl; else pip install https://files.pythonhosted.org/packages/b8/ea/adfbeb3762a03c1d1c1ff751101efb1fddb7aadffa991d39bdb486d0557e/freetype_py-2.1.0.post1-py2.py3-none-manylinux1_i686.whl; fi"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
@@ -33,6 +33,23 @@ jobs:
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: vispyDeployLinux
+- job: manylinux2014
+  pool: {vmImage: 'Ubuntu-16.04'}
+  variables:
+    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+    CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+  steps:
+    - task: UsePythonVersion@0
+    - bash: |
+        git submodule update --init --recursive
+        python -m pip install --upgrade pip
+        pip install cibuildwheel
+        cibuildwheel --output-dir wheelhouse .
+    - bash: rm wheelhouse/*manylinux1* || true
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: vispyDeployLinux2014
 - job: macos
   pool: {vmImage: 'macOS-10.14'}
   steps:
@@ -46,6 +63,19 @@ jobs:
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: vispyDeployMacOS
+- job: macos_10_14
+  pool: {vmImage: 'macOS-10.14'}
+  steps:
+    - task: UsePythonVersion@0
+    - bash: |
+        git submodule update --init --recursive
+        python -m pip install --upgrade pip
+        pip install cibuildwheel
+        MACOSX_DEPLOYMENT_TARGET="10.14" cibuildwheel --output-dir wheelhouse .
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: vispyDeployMacOS_10_14
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
   steps:
@@ -69,7 +99,9 @@ jobs:
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
   dependsOn:
     - linux
+    - manylinux2014
     - macos
+    - macos_10_14
     - windows
   steps:
     - task: UsePythonVersion@0
@@ -77,8 +109,10 @@ jobs:
       inputs:
         patterns: |
           vispyDeployLinux/*
+          vispyDeployLinux2014/*2014*
           vispyDeployMacOS/*.whl
           vispyDeployWindows/*.whl
+          vispyDeployMacOS_10_14/*.whl
     - bash: |
         cd $(Pipeline.Workspace)
         python -m pip install --upgrade pip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,12 +64,7 @@ jobs:
 - job: windows
   pool: {vmImage: 'vs2017-win2016'}
   steps:
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x86}}
-    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
+    - task: UsePythonVersion@0
     - bash: |
         git submodule update --init --recursive
         python -m pip install --upgrade pip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; pip install freetype-py"
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}
@@ -33,22 +35,6 @@ jobs:
       inputs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: vispyDeployLinux
-- job: manylinux2014
-  pool: {vmImage: 'Ubuntu-16.04'}
-  variables:
-    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-    CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  steps:
-    - task: UsePythonVersion@0
-    - bash: |
-        git submodule update --init --recursive
-        python -m pip install --upgrade pip
-        pip install cibuildwheel
-        cibuildwheel --output-dir wheelhouse .
-    - task: PublishPipelineArtifact@1
-      inputs:
-        path: $(System.DefaultWorkingDirectory)/wheelhouse
-        artifact: vispyDeployLinux2014
 - job: macos
   pool: {vmImage: 'macOS-10.14'}
   steps:
@@ -98,7 +84,6 @@ jobs:
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
   dependsOn:
     - linux
-    - manylinux2014
     - macos
     - macos_10_14
     - windows
@@ -108,7 +93,6 @@ jobs:
       inputs:
         patterns: |
           vispyDeployLinux/*
-          vispyDeployLinux2014/*2014*.whl
           vispyDeployMacOS/*.whl
           vispyDeployWindows/*.whl
           vispyDeployMacOS_10_14/*.whl


### PR DESCRIPTION
Build wheels against more modern standards allow to use newer compilators and api which my produce better/faster shared libs. So I suggest to add builds of manylinux2014 and macos 10.14 wheels. 