### PR TITLE
Add ImageVisual gamma and smarter in-shader contrast limits

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -50,6 +50,7 @@ vec4 map_local_to_tex(vec4 x) {
     return vec4(p3.xy / image_size, 0, 1);
 }
 
+
 void main()
 {
     vec2 texcoord;
@@ -80,7 +81,7 @@ _interpolation_template = """
         }
         return %s($texture, $shape, texcoord);
     }"""
-    
+
 _texture_lookup = """
     vec4 texture_lookup(vec2 texcoord) {
         if(texcoord.x < 0.0 || texcoord.x > 1.0 ||

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -134,6 +134,9 @@ class ImageVisual(Visual):
     clim : str | tuple
         Limits to use for the colormap. Can be 'auto' to auto-set bounds to
         the min and max of the data.
+    gamma : float
+        Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
+        by default: 1.
     interpolation : str
         Selects method of image interpolation. Makes use of the two Texture2D
         interpolation methods and the available interpolation methods defined
@@ -305,6 +308,20 @@ class ImageVisual(Visual):
     def cmap(self, cmap):
         self._cmap = get_colormap(cmap)
         self._need_colortransform_update = True
+        self.update()
+
+    @property
+    def gamma(self):
+        """The gamma used when rendering the image."""
+        return self._gamma
+
+    @gamma.setter
+    def gamma(self, value):
+        """Set gamma used when rendering the image."""
+        if value <= 0:
+            raise ValueError("gamma must be > 0")
+        self._gamma = float(value)
+        self.shared_program['gamma'] = self._gamma
         self.update()
 
     @property
@@ -486,16 +503,3 @@ class ImageVisual(Visual):
         if view._need_method_update:
             self._update_method(view)
 
-    @property
-    def gamma(self):
-        """The gamma used when rendering the image."""
-        return self._gamma
-
-    @gamma.setter
-    def gamma(self, value):
-        """Set gamma used when rendering the image."""
-        if value <= 0:
-            raise ValueError("gamma must be > 0")
-        self._gamma = float(value)
-        self.shared_program['gamma'] = self._gamma
-        self.update()

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -92,8 +92,8 @@ _texture_lookup = """
     }"""
 
 
-_null_color_transform = 'vec4 pass(vec4 color) { return color; }'
-_c2l = 'float cmap(vec4 color) { return (color.r + color.g + color.b) / 3.; }'
+_null_color_transform = "vec4 pass(vec4 color) { return color; }"
+_c2l = "float cmap(vec4 color) { return (color.r + color.g + color.b) / 3.; }"
 
 
 def _build_color_transform(data, cmap):
@@ -156,9 +156,18 @@ class ImageVisual(Visual):
     The colormap functionality through ``cmap`` and ``clim`` are only used
     if the data are 2D.
     """
-    def __init__(self, data=None, method='auto', grid=(1, 1),
-                 cmap='viridis', clim='auto', gamma=1,
-                 interpolation='nearest', **kwargs):
+
+    def __init__(
+        self,
+        data=None,
+        method="auto",
+        grid=(1, 1),
+        cmap="viridis",
+        clim="auto",
+        gamma=1,
+        interpolation="nearest",
+        **kwargs
+    ):
         self._data = None
         self._gamma = gamma
 
@@ -167,7 +176,7 @@ class ImageVisual(Visual):
         # `load_spatial_filters(packed=False)`
         kernel, self._interpolation_names = load_spatial_filters()
 
-        self._kerneltex = Texture2D(kernel, interpolation='nearest')
+        self._kerneltex = Texture2D(kernel, interpolation="nearest")
         # The unpacking can be debugged by changing "spatial-filters.frag"
         # to have the "unpack" function just return the .r component. That
         # combined with using the below as the _kerneltex allows debugging
@@ -177,10 +186,8 @@ class ImageVisual(Visual):
 
         # create interpolation shader functions for available
         # interpolations
-        fun = [Function(_interpolation_template % n)
-               for n in self._interpolation_names]
-        self._interpolation_names = [n.lower()
-                                     for n in self._interpolation_names]
+        fun = [Function(_interpolation_template % n) for n in self._interpolation_names]
+        self._interpolation_names = [n.lower() for n in self._interpolation_names]
 
         self._interpolation_fun = dict(zip(self._interpolation_names, fun))
         self._interpolation_names.sort()
@@ -188,20 +195,21 @@ class ImageVisual(Visual):
 
         # overwrite "nearest" and "bilinear" spatial-filters
         # with  "hardware" interpolation _data_lookup_fn
-        self._interpolation_fun['nearest'] = Function(_texture_lookup)
-        self._interpolation_fun['bilinear'] = Function(_texture_lookup)
+        self._interpolation_fun["nearest"] = Function(_texture_lookup)
+        self._interpolation_fun["bilinear"] = Function(_texture_lookup)
 
         if interpolation not in self._interpolation_names:
-            raise ValueError("interpolation must be one of %s" %
-                             ', '.join(self._interpolation_names))
+            raise ValueError(
+                "interpolation must be one of %s" % ", ".join(self._interpolation_names)
+            )
 
         self._interpolation = interpolation
 
         # check texture interpolation
-        if self._interpolation == 'bilinear':
-            texture_interpolation = 'linear'
+        if self._interpolation == "bilinear":
+            texture_interpolation = "linear"
         else:
-            texture_interpolation = 'nearest'
+            texture_interpolation = "nearest"
 
         self._method = method
         self._grid = grid
@@ -210,23 +218,24 @@ class ImageVisual(Visual):
         self._need_vertex_update = True
         self._need_colortransform_update = True
         self._need_interpolation_update = True
-        self._texture = Texture2D(np.zeros((1, 1, 4)),
-                                  interpolation=texture_interpolation)
+        self._texture = Texture2D(
+            np.zeros((1, 1, 4)), interpolation=texture_interpolation
+        )
         self._subdiv_position = VertexBuffer()
         self._subdiv_texcoord = VertexBuffer()
 
         # impostor quad covers entire viewport
-        vertices = np.array([[-1, -1], [1, -1], [1, 1],
-                             [-1, -1], [1, 1], [-1, 1]],
-                            dtype=np.float32)
+        vertices = np.array(
+            [[-1, -1], [1, -1], [1, 1], [-1, -1], [1, 1], [-1, 1]], dtype=np.float32
+        )
         self._impostor_coords = VertexBuffer(vertices)
         self._null_tr = NullTransform()
 
         self._init_view(self)
         super(ImageVisual, self).__init__(vcode=VERT_SHADER, fcode=FRAG_SHADER)
-        self.set_gl_state('translucent', cull_face=False)
-        self._draw_mode = 'triangles'
-        self.shared_program['gamma'] = self._gamma
+        self.set_gl_state("translucent", cull_face=False)
+        self._draw_mode = "triangles"
+        self.shared_program["gamma"] = self._gamma
 
         # define _data_lookup_fn as None, will be setup in
         # self._build_interpolation()
@@ -264,19 +273,18 @@ class ImageVisual(Visual):
 
     @property
     def clim(self):
-        return (self._clim if isinstance(self._clim, string_types) else
-                tuple(self._clim))
+        return self._clim if isinstance(self._clim, string_types) else tuple(self._clim)
 
     @clim.setter
     def clim(self, clim):
         if isinstance(clim, string_types):
-            if clim != 'auto':
+            if clim != "auto":
                 raise ValueError('clim must be "auto" if a string')
             self._need_texture_upload = True
         else:
             clim = np.array(clim, float)
             if clim.shape != (2,):
-                raise ValueError('clim must have two elements')
+                raise ValueError("clim must have two elements")
             if self._texture_limits is not None and (
                 (clim[0] < self._texture_limits[0])
                 or (clim[1] > self._texture_limits[1])
@@ -284,7 +292,7 @@ class ImageVisual(Visual):
                 self._need_texture_upload = True
         self._clim = clim
         if self._texture_limits is not None:
-            self.shared_program['clim'] = self.clim_normalized
+            self.shared_program["clim"] = self.clim_normalized
         self.update()
 
     @property
@@ -321,7 +329,7 @@ class ImageVisual(Visual):
         if value <= 0:
             raise ValueError("gamma must be > 0")
         self._gamma = float(value)
-        self.shared_program['gamma'] = self._gamma
+        self.shared_program["gamma"] = self._gamma
         self.update()
 
     @property
@@ -346,8 +354,9 @@ class ImageVisual(Visual):
     @interpolation.setter
     def interpolation(self, i):
         if i not in self._interpolation_names:
-            raise ValueError("interpolation must be one of %s" %
-                             ', '.join(self._interpolation_names))
+            raise ValueError(
+                "interpolation must be one of %s" % ", ".join(self._interpolation_names)
+            )
         if self._interpolation != i:
             self._interpolation = i
             self._need_interpolation_update = True
@@ -365,23 +374,23 @@ class ImageVisual(Visual):
         """
         interpolation = self._interpolation
         self._data_lookup_fn = self._interpolation_fun[interpolation]
-        self.shared_program.frag['get_data'] = self._data_lookup_fn
+        self.shared_program.frag["get_data"] = self._data_lookup_fn
 
         # only 'bilinear' uses 'linear' texture interpolation
-        if interpolation == 'bilinear':
-            texture_interpolation = 'linear'
+        if interpolation == "bilinear":
+            texture_interpolation = "linear"
         else:
             # 'nearest' (and also 'bilinear') doesn't use spatial_filters.frag
             # so u_kernel and shape setting is skipped
-            texture_interpolation = 'nearest'
-            if interpolation != 'nearest':
-                self.shared_program['u_kernel'] = self._kerneltex
-                self._data_lookup_fn['shape'] = self._data.shape[:2][::-1]
+            texture_interpolation = "nearest"
+            if interpolation != "nearest":
+                self.shared_program["u_kernel"] = self._kerneltex
+                self._data_lookup_fn["shape"] = self._data.shape[:2][::-1]
 
         if self._texture.interpolation != texture_interpolation:
             self._texture.interpolation = texture_interpolation
 
-        self._data_lookup_fn['texture'] = self._texture
+        self._data_lookup_fn["texture"] = self._texture
 
         self._need_interpolation_update = False
 
@@ -393,48 +402,49 @@ class ImageVisual(Visual):
         w = 1.0 / grid[1]
         h = 1.0 / grid[0]
 
-        quad = np.array([[0, 0, 0], [w, 0, 0], [w, h, 0],
-                         [0, 0, 0], [w, h, 0], [0, h, 0]],
-                        dtype=np.float32)
+        quad = np.array(
+            [[0, 0, 0], [w, 0, 0], [w, h, 0], [0, 0, 0], [w, h, 0], [0, h, 0]],
+            dtype=np.float32,
+        )
         quads = np.empty((grid[1], grid[0], 6, 3), dtype=np.float32)
         quads[:] = quad
 
-        mgrid = np.mgrid[0.:grid[1], 0.:grid[0]].transpose(1, 2, 0)
+        mgrid = np.mgrid[0.0 : grid[1], 0.0 : grid[0]].transpose(1, 2, 0)
         mgrid = mgrid[:, :, np.newaxis, :]
         mgrid[..., 0] *= w
         mgrid[..., 1] *= h
 
         quads[..., :2] += mgrid
-        tex_coords = quads.reshape(grid[1]*grid[0]*6, 3)
+        tex_coords = quads.reshape(grid[1] * grid[0] * 6, 3)
         tex_coords = np.ascontiguousarray(tex_coords[:, :2])
         vertices = tex_coords * self.size
 
-        self._subdiv_position.set_data(vertices.astype('float32'))
-        self._subdiv_texcoord.set_data(tex_coords.astype('float32'))
+        self._subdiv_position.set_data(vertices.astype("float32"))
+        self._subdiv_texcoord.set_data(tex_coords.astype("float32"))
 
     def _update_method(self, view):
         """Decide which method to use for *view* and configure it accordingly.
         """
         method = self._method
-        if method == 'auto':
+        if method == "auto":
             if view.transforms.get_transform().Linear:
-                method = 'subdivide'
+                method = "subdivide"
             else:
-                method = 'impostor'
+                method = "impostor"
         view._method_used = method
 
-        if method == 'subdivide':
-            view.view_program['method'] = 0
-            view.view_program['a_position'] = self._subdiv_position
-            view.view_program['a_texcoord'] = self._subdiv_texcoord
-        elif method == 'impostor':
-            view.view_program['method'] = 1
-            view.view_program['a_position'] = self._impostor_coords
-            view.view_program['a_texcoord'] = self._impostor_coords
+        if method == "subdivide":
+            view.view_program["method"] = 0
+            view.view_program["a_position"] = self._subdiv_position
+            view.view_program["a_texcoord"] = self._subdiv_texcoord
+        elif method == "impostor":
+            view.view_program["method"] = 1
+            view.view_program["a_position"] = self._impostor_coords
+            view.view_program["a_texcoord"] = self._impostor_coords
         else:
             raise ValueError("Unknown image draw method '%s'" % method)
 
-        self.shared_program['image_size'] = self.size
+        self.shared_program["image_size"] = self.size
         view._need_method_update = False
         self._prepare_transforms(view)
 
@@ -447,7 +457,7 @@ class ImageVisual(Visual):
             # deal with clim on CPU b/c of texture depth limits :(
             # can eventually do this by simulating 32-bit float... maybe
             clim = self._clim
-            if isinstance(clim, string_types) and clim == 'auto':
+            if isinstance(clim, string_types) and clim == "auto":
                 clim = np.min(data), np.max(data)
             clim = np.asarray(clim, dtype=np.float32)
             data = data - clim[0]  # not inplace so we don't modify orig data
@@ -457,10 +467,11 @@ class ImageVisual(Visual):
                 data[:] = 1 if data[0, 0] != 0 else 0
             self._clim = np.array(clim)
         else:
-            self._clim = (0, 1)
+            if isinstance(self._clim, string_types) and self._clim == "auto":
+                self._clim = (0, 1)
 
         self._texture_limits = np.array(self._clim)
-        self.shared_program['clim'] = self.clim_normalized
+        self.shared_program["clim"] = self.clim_normalized
         self._texture.set_data(data)
         self._need_texture_upload = False
 
@@ -474,12 +485,12 @@ class ImageVisual(Visual):
         trs = view.transforms
         prg = view.view_program
         method = view._method_used
-        if method == 'subdivide':
-            prg.vert['transform'] = trs.get_transform()
-            prg.frag['transform'] = self._null_tr
+        if method == "subdivide":
+            prg.vert["transform"] = trs.get_transform()
+            prg.frag["transform"] = self._null_tr
         else:
-            prg.vert['transform'] = self._null_tr
-            prg.frag['transform'] = trs.get_transform().inverse
+            prg.vert["transform"] = self._null_tr
+            prg.frag["transform"] = trs.get_transform().inverse
 
     def _prepare_draw(self, view):
         if self._data is None:
@@ -493,15 +504,16 @@ class ImageVisual(Visual):
 
         if self._need_colortransform_update:
             prg = view.view_program
-            self.shared_program.frag['color_transform'] = \
-                _build_color_transform(self._data, self.cmap)
+            self.shared_program.frag["color_transform"] = _build_color_transform(
+                self._data, self.cmap
+            )
             self._need_colortransform_update = False
-            prg['texture2D_LUT'] = self.cmap.texture_lut() \
-                if (hasattr(self.cmap, 'texture_lut')) else None
+            prg["texture2D_LUT"] = (
+                self.cmap.texture_lut() if (hasattr(self.cmap, "texture_lut")) else None
+            )
 
         if self._need_vertex_update:
             self._build_vertex_data()
 
         if view._need_method_update:
             self._update_method(view)
-

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -456,6 +456,8 @@ class ImageVisual(Visual):
             else:
                 data[:] = 1 if data[0, 0] != 0 else 0
             self._clim = np.array(clim)
+        else:
+            self._clim = (0, 1)
 
         self._texture_limits = np.array(self._clim)
         self.shared_program['clim'] = self.clim_normalized

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -80,6 +80,7 @@ _interpolation_template = """
         }
         return %s($texture, $shape, texcoord);
     }"""
+    
 _texture_lookup = """
     vec4 texture_lookup(vec2 texcoord) {
         if(texcoord.x < 0.0 || texcoord.x > 1.0 ||

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -287,7 +287,7 @@ class ImageVisual(Visual):
     @property
     def clim_normalized(self):
         """Normalize current clims between 0-1 based on last-used texture data range.
-        In set_data(), the data is normalized (on the CPU) to 0-1 using ``clim``.
+        In _build_texture(), the data is normalized (on the CPU) to 0-1 using ``clim``.
         During rendering, the frag shader will apply the final contrast adjustment based on
         the current ``clim``.
         """

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -109,8 +109,8 @@ _apply_gamma = """
     }
 """
 
-_null_color_transform = "vec4 pass(vec4 color) { return color; }"
-_c2l = "float cmap(vec4 color) { return (color.r + color.g + color.b) / 3.; }"
+_null_color_transform = 'vec4 pass(vec4 color) { return color; }'
+_c2l = 'float cmap(vec4 color) { return (color.r + color.g + color.b) / 3.; }'
 
 
 def _build_color_transform(data, clim, gamma, cmap):
@@ -124,8 +124,8 @@ def _build_color_transform(data, clim, gamma, cmap):
         fclim = Function(_apply_clim)
         fgamma = Function(_apply_gamma)
         fun = FunctionChain(None, [Function(_null_color_transform), fclim, fgamma])
-    fclim["clim"] = clim
-    fgamma["gamma"] = gamma
+    fclim['clim'] = clim
+    fgamma['gamma'] = gamma
     return fun
 
 
@@ -182,7 +182,7 @@ class ImageVisual(Visual):
     if the data are 2D.
     """
     def __init__(self, data=None, method='auto', grid=(1, 1),
-                 cmap='viridis', clim='auto', gamma=1,
+                 cmap='viridis', clim='auto', gamma=1.0,
                  interpolation='nearest', **kwargs):
         self._data = None
         self._gamma = gamma
@@ -308,7 +308,7 @@ class ImageVisual(Visual):
                 self._need_texture_upload = True
         self._clim = clim
         if self._texture_limits is not None:
-            self.shared_program.frag["color_transform"][1]["clim"] = self.clim_normalized
+            self.shared_program.frag['color_transform'][1]['clim'] = self.clim_normalized
         self.update()
 
     @property
@@ -345,7 +345,7 @@ class ImageVisual(Visual):
         if value <= 0:
             raise ValueError("gamma must be > 0")
         self._gamma = float(value)
-        self.shared_program.frag["color_transform"][2]["gamma"] = self._gamma
+        self.shared_program.frag['color_transform'][2]['gamma'] = self._gamma
         self.update()
 
     @property
@@ -482,7 +482,7 @@ class ImageVisual(Visual):
             self._clim = np.array(clim)
         else:
             # assume that RGB data is already scaled (0, 1)
-            if isinstance(self._clim, string_types) and self._clim == "auto":
+            if isinstance(self._clim, string_types) and self._clim == 'auto':
                 self._clim = (0, 1)
 
         self._texture_limits = np.array(self._clim)
@@ -518,7 +518,7 @@ class ImageVisual(Visual):
 
         if self._need_colortransform_update:
             prg = view.view_program
-            self.shared_program.frag["color_transform"] = _build_color_transform(
+            self.shared_program.frag['color_transform'] = _build_color_transform(
                 self._data, self.clim_normalized, self.gamma, self.cmap
             )
             self._need_colortransform_update = False

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -30,7 +30,7 @@ def test_image_clims_and_gamma():
         for three_d in (True,):
             shape = size + ((3,) if three_d else ())
             np.random.seed(0)
-            image = Image(cmap="grays", clim=[0, 1], parent=c.scene)
+            image = Image(cmap='grays', clim=[0, 1], parent=c.scene)
             data = np.random.rand(*shape)
             image.set_data(data)
             rendered = c.render()

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -4,7 +4,7 @@ import numpy as np
 from vispy.scene.visuals import Image
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
-from vispy.testing.image_tester import assert_image_approved
+from vispy.testing.image_tester import assert_image_approved, downsample
 
 
 @requires_application()
@@ -20,6 +20,54 @@ def test_image():
             image.set_data(data)
             assert_image_approved(c.render(), "visuals/image%s.png" %
                                   ("_rgb" if three_d else "_mono"))
+
+
+@requires_application()
+def test_image_clims_and_gamma():
+    """Test image visual with clims and gamma on shader."""
+    size = (40, 40)
+    with TestingCanvas(size=size, bgcolor="w") as c:
+        for three_d in (True,):
+            shape = size + ((3,) if three_d else ())
+            np.random.seed(0)
+            image = Image(cmap="grays", clim=[0, 1], parent=c.scene)
+            data = np.random.rand(*shape)
+            image.set_data(data)
+            rendered = c.render()
+            _dtype = rendered.dtype
+            shape_ratio = rendered.shape[0] // data.shape[0]
+            rendered1 = downsample(rendered, shape_ratio, axis=(0, 1)).astype(_dtype)
+            predicted = _make_rgba(data)
+            assert np.allclose(predicted, rendered1, atol=1)
+
+            # adjust contrast limits
+            new_clim = (0.3, 0.8)
+            image.clim = new_clim
+            rendered2 = downsample(c.render(), shape_ratio, axis=(0, 1)).astype(_dtype)
+            scaled_data = np.clip((data - new_clim[0]) / np.diff(new_clim)[0], 0, 1)
+            predicted = _make_rgba(scaled_data)
+            assert np.allclose(predicted, rendered2, atol=1)
+            assert not np.allclose(rendered1, rendered2, atol=10)
+
+            # adjust gamma
+            image.gamma = 2
+            rendered3 = downsample(c.render(), shape_ratio, axis=(0, 1)).astype(_dtype)
+            predicted = _make_rgba(scaled_data ** 2)
+            assert np.allclose(
+                predicted.astype(np.float), rendered3.astype(np.float), atol=2
+            )
+            assert not np.allclose(
+                rendered2.astype(np.float), rendered3.astype(np.float), atol=10
+            )
+
+
+def _make_rgba(array):
+    if array.ndim == 2:
+        out = np.stack([array] * 4, axis=2)
+        out[:, :, 3] = 1
+    else:
+        out = np.concatenate((array, np.ones((*array.shape[:2], 1))), axis=2)
+    return np.round((out.astype(np.float) * 255)).astype(np.uint8)
 
 
 run_tests_if_main()


### PR DESCRIPTION
This is a companion to #1842.  It puts (re)calculation of contrast limits (and adds gamma) to the `ImageVisual` shader.  If `clims` are changed after the `ImageVisual` has been created, then the texture will only be rebuilt (`_need_texture_upload == True`) if the new `clims` are outside of the bounds of the previous clims.  (note: unlike `VolumeVisual` in #1842, `ImageVisual` holds a copy of the data, so rescaling is easier).

possible embellishments include: allowing gamma and/or contrast limits to be set _per_ channel (for an rgb image).