### PR TITLE
Allow for precision definitions in shaders

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -618,13 +618,9 @@ def _convert_desktop_shader(shader):
     for line in shader.lstrip().splitlines():
         line_strip = line.lstrip()
         has_version = has_version or line.startswith('#version')
-        if line_strip.startswith('precision '):
-            line = ''
         if line_strip.startswith('#extension'):
             extensions.append(line_strip)
             line = ''
-        for prec in (' highp ', ' mediump ', ' lowp '):
-            line = line.replace(prec, ' ')
         lines.append(line.rstrip())
     # Write
     # Make sure extensions are at the top, but after version

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -13,6 +13,7 @@ import numpy as np
 
 
 def test_queue():
+    """Test GlirQueue and shader conversions."""
     q = glir.GlirQueue()
     parser = glir.GlirParser()
     
@@ -43,9 +44,9 @@ def test_queue():
         """.strip().replace(';', ';\n')
     # Convert for desktop
     shader2 = glir.convert_shader('desktop', shader1)
-    assert 'highp' not in shader2
-    assert 'mediump' not in shader2
-    assert 'precision' not in shader2
+    assert 'highp' in shader2
+    assert 'mediump' in shader2
+    assert 'precision' in shader2
     
     # Convert for es2
     shader3 = glir.convert_shader('es2', shader2)


### PR DESCRIPTION
While looking at #1850 we realized that vispy is still removing `precision` definitions from shaders. As far as I can tell this has been this way since almost the beginning of vispy. The best guess from Almar was that some drivers may not have handled the precision identifiers back then even though it is part of the OpenGL ES 2.0 spec. It's been at least 5 years since that code was written so let's see if the tests pass and allow more complex shaders to work out of the box.