### PR TITLE
Update base_camera link to enable axis sharing

### DIFF
--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -3,7 +3,6 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 from __future__ import division
-from collections import namedtuple
 
 from ...util import keys
 from ..node import Node
@@ -86,21 +85,8 @@ class BaseCamera(Node):
         self.flip = flip if (flip is not None) else (False, False, False)
         self.up = up
 
-        self.last_self_pos = None
-        self.last_cam_pos = None
-
-        self.last_self_left = None
-        self.last_cam_left = None
-
-        self.last_self_right = None
-        self.last_cam_right = None
-
-        self.last_self_top = None
-        self.last_cam_top = None
-
-        self.last_self_bottom = None
-        self.last_cam_bottom = None
-        self.master = False
+        self.last_self = None
+        self.last_cam = None
 
     @property
     def depth_value(self):
@@ -493,74 +479,43 @@ class BaseCamera(Node):
         if len(self._linked_cameras) != 0:
             if isinstance(self._linked_cameras[0], list):
                 ## link only one axis between to cameras
-                if(self._linked_cameras[0][1] == "x"):
-                    for i in range(len(self._linked_cameras)):
-                        cam = self._linked_cameras[i][0]
-                        self_state = self.get_state()
-                        cam_state = cam.get_state()
-                        s = self_state
-                        for u in range(2):
-                            if(u == 1):
-                                if(self.last_self_pos is not None and self.last_cam_pos is not None and self.last_cam_top is not None and self.last_cam_bottom is not None  and self.last_self_top is not None and self.last_self_bottom is not None):
-                                    self_state["rect"].pos = (self_state["rect"].pos[0], self.last_cam_pos[1])
-                                    self_state["rect"].top = self.last_cam_top
-                                    self_state["rect"].bottom = self.last_cam_bottom
-                                    cam.set_state(self_state)
-                                    self_state["rect"].pos = (self_state["rect"].pos[0], self.last_self_pos[1])
-                                    self_state["rect"].top = self.last_self_top
-                                    self_state["rect"].bottom = self.last_self_bottom
-                                    self.set_state(self_state)
-                                    self.last_self_pos = self.get_state()["rect"].pos
-                                    self.last_cam_pos = cam.get_state()["rect"].pos
-                                else:
-                                    self.last_self_pos = self.get_state()["rect"].pos
-                                    self.cam_self_pos = cam.get_state()["rect"].pos
-                                    self.last_self_top = self.get_state()["rect"].top
-                                    self.last_cam_top = cam.get_state()["rect"].top
-                                    self.last_self_bottom = self.get_state()["rect"].bottom
-                                    self.last_cam_bottom = cam.get_state()["rect"].bottom
-                            else:
-                                self.last_self_pos = self.get_state()["rect"].pos
-                                self.last_cam_pos = cam.get_state()["rect"].pos
-                                self.last_self_top = self.get_state()["rect"].top
-                                self.last_cam_top = cam.get_state()["rect"].top
-                                self.last_self_bottom = self.get_state()["rect"].bottom
-                                self.last_cam_bottom = cam.get_state()["rect"].bottom
-                elif (self._linked_cameras[0][1] == "y"):
-                    for i in range(len(self._linked_cameras)):
-                        cam = self._linked_cameras[i][0]
-                        self_state = self.get_state()
-                        cam_state = cam.get_state()
-                        s = self_state
-                        for u in range(2):
-                            if(u == 1):
-                                if(self.last_self_pos is not None and self.last_cam_pos is not None and self.last_cam_left is not None and self.last_cam_right is not None  and self.last_self_left is not None and self.last_self_right is not None):
-                                    self_state["rect"].pos = (self.last_cam_pos[0], self_state["rect"].pos[1])
-                                    self_state["rect"].left = self.last_cam_left
-                                    self_state["rect"].right = self.last_cam_right
-                                    cam.set_state(self_state)
-                                    self_state["rect"].pos = (self.last_self_pos[0], self_state["rect"].pos[1])
-                                    self_state["rect"].left = self.last_self_left
-                                    self_state["rect"].right = self.last_self_right
-                                    self.set_state(self_state)
-                                    self.last_self_pos = self.get_state()["rect"].pos
-                                    self.last_cam_pos = cam.get_state()["rect"].pos
-                                else:
-                                    self.last_self_pos = self.get_state()["rect"].pos
-                                    self.cam_self_pos = cam.get_state()["rect"].pos
-                                    self.last_self_left = self.get_state()["rect"].left
-                                    self.last_cam_left = cam.get_state()["rect"].left
-                                    self.last_self_right = self.get_state()["rect"].right
-                                    self.last_cam_right = cam.get_state()["rect"].right
-                            else:
-                                self.last_self_pos = self.get_state()["rect"].pos
-                                self.last_cam_pos = cam.get_state()["rect"].pos
-                                self.last_self_left = self.get_state()["rect"].left
-                                self.last_cam_left = cam.get_state()["rect"].left
-                                self.last_self_right = self.get_state()["rect"].right
-                                self.last_cam_right = cam.get_state()["rect"].right
-                else:
-                    raise Exception("Axis align has to be either 'x' or 'y' not " + self._linked_cameras[0][1])
+                for i in range(len(self._linked_cameras)):
+                    cam = self._linked_cameras[i][0]
+                    self_state = self.get_state()
+
+                    self.last_self = self.get_state()
+                    self.last_cam = cam.get_state()
+
+                    top = self.last_self["rect"].top
+                    bottom = self.last_self["rect"].bottom
+                    left = self.last_self["rect"].left
+                    right = self.last_self["rect"].right
+
+                    if (self._linked_cameras[0][1] == "x"):
+                        self_state["rect"].pos = (self_state["rect"].pos[0], self.last_cam["rect"].pos[1])
+                        self_state["rect"].top = self.last_cam["rect"].top
+                        self_state["rect"].bottom = self.last_cam["rect"].bottom
+                    elif (self._linked_cameras[0][1] == "y"):
+                        self_state["rect"].pos = (self.last_cam["rect"].pos[0], self_state["rect"].pos[1])
+                        self_state["rect"].left = self.last_cam["rect"].left
+                        self_state["rect"].right = self.last_cam["rect"].right
+                    else:
+                        raise ValueError(f"Axis align has to be either 'x' or 'y' not {self._linked_cameras[0][1]}")
+
+                    cam.set_state(self_state)
+
+                    if (self._linked_cameras[0][1] == "x"):
+                        self_state["rect"].pos = (self_state["rect"].pos[0], self.last_self["rect"].pos[1])
+                        self_state["rect"].top = top
+                        self_state["rect"].bottom = bottom
+                    elif (self._linked_cameras[0][1] == "y"):
+                        self_state["rect"].pos = (self.last_cam["rect"].pos[0], self_state["rect"].pos[1])
+                        self_state["rect"].left = left
+                        self_state["rect"].right = right
+                    else:
+                        raise ValueError(f"Axis align has to be either 'x' or 'y' not {self._linked_cameras[0][1]}")
+
+                    self.set_state(self_state)
             else:
                 # Apply same state to linked cameras, but prevent that camera
                 # to return the favor


### PR DESCRIPTION
This change enables linking viewbox cameras by one axis (x/y).
So a its possible to interact(zoom and pan) with one viewbox and the linked viewbox only updates the specified axis, instead of updateing both.
I wrote this to enable the matplotlib shared axis behavior in vispy
https://matplotlib.org/3.1.0/gallery/subplots_axes_and_figures/shared_axis_demo.html
the code can be undoubtedly improved but i haven't noticed a performance loss