### PR TITLE
Speed up arcball and turntable cameras

### DIFF
--- a/vispy/scene/cameras/arcball.py
+++ b/vispy/scene/cameras/arcball.py
@@ -6,6 +6,8 @@ from __future__ import division
 
 import numpy as np
 
+
+from ...util import transforms
 from ...util.quaternion import Quaternion
 from ...visuals.transforms import MatrixTransform
 from .perspective import Base3DRotationCamera
@@ -65,11 +67,10 @@ class ArcballCamera(Base3DRotationCamera):
         self._event_value = p2
         self.view_changed()
 
-    def _rotate_tr(self):
-        """Rotate the transformation matrix based on camera parameters"""
+    def _get_rotation_tr(self):
+        """Return a rotation matrix based on camera parameters"""
         rot, x, y, z = self._quaternion.get_axis_angle()
-        up, forward, right = self._get_dim_vectors()
-        self.transform.rotate(180 * rot / np.pi, (x, z, y))
+        return transforms.rotate(180 * rot / np.pi, (x, z, y))
 
     def _dist_to_trans(self, dist):
         """Convert mouse x, y movement into x, y, z translations"""

--- a/vispy/scene/cameras/turntable.py
+++ b/vispy/scene/cameras/turntable.py
@@ -6,6 +6,7 @@ from __future__ import division
 
 import numpy as np
 
+from ...util import transforms
 from .perspective import Base3DRotationCamera
 
 
@@ -134,11 +135,13 @@ class TurntableCamera(Base3DRotationCamera):
         self.azimuth = self._event_value[0] - (p2 - p1)[0] * 0.5
         self.elevation = self._event_value[1] + (p2 - p1)[1] * 0.5
 
-    def _rotate_tr(self):
-        """Rotate the transformation matrix based on camera parameters"""
+    def _get_rotation_tr(self):
+        """Return a rotation matrix based on camera parameters"""
         up, forward, right = self._get_dim_vectors()
-        self.transform.rotate(self.elevation, -right)
-        self.transform.rotate(self.azimuth, up)
+        return np.dot(
+            transforms.rotate(self.elevation, -right),
+            transforms.rotate(self.azimuth, up)
+        )
 
     def _dist_to_trans(self, dist):
         """Convert mouse x, y movement into x, y, z translations"""


### PR DESCRIPTION
In Base3DRotationCamera, instead of gradually constructing the view
matrix inside MatrixTransform, do prepare the final matrix first, then
assign it to MatrixTransform.

This is done to avoid the relatively costly operations each time the
matrix inside MatrixTransform changes.

See #1878.