### PR TITLE
Let camera link be limited to specified properties

### DIFF
--- a/vispy/geometry/rect.py
+++ b/vispy/geometry/rect.py
@@ -63,7 +63,7 @@ class Rect(object):
 
     @width.setter
     def width(self, w):
-        self.size[0] = w
+        self.size = (w, self.size[1])
 
     @property
     def height(self):
@@ -71,7 +71,7 @@ class Rect(object):
 
     @height.setter
     def height(self, h):
-        self.size[1] = h
+        self.size = (self.size[0], h)
 
     @property
     def left(self):

--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -333,14 +333,14 @@ class BaseCamera(Node):
         """
         if props is None:
             props = self._state_props
-        D = {}
+        state = {}
         for key in props:
             # We support tuple keys to accomodate camera linking.
             if isinstance(key, tuple):
-                D[key] = nested_getattr(self, key)
+                state[key] = nested_getattr(self, key)
             else:
-                D[key] = getattr(self, key)
-        return D
+                state[key] = getattr(self, key)
+        return state
 
     def set_state(self, state=None, **kwargs):
         """ Set the view state of the camera
@@ -357,8 +357,8 @@ class BaseCamera(Node):
             Unused keyword arguments.
         """
 
-        D = state or {}
-        D.update(kwargs)
+        state = state or {}
+        state.update(kwargs)
   
         # In first pass, process tuple keys which select subproperties. This
         # is an undocumented feature used for selective linking of camera state.
@@ -368,19 +368,19 @@ class BaseCamera(Node):
         # assigning the copied object back to the camera property. There needs
         # to be an assignment of the root property so setters are called and
         # update is triggered.
-        for key in list(D.keys()):
+        for key in list(state.keys()):
             if isinstance(key, tuple):
                 key1 = key[0]
-                if key1 not in D:
+                if key1 not in state:
                     root_prop = getattr(self, key1)
                     # We make copies by passing the old object to the type's
                     # constructor. This needs to be supported as is the case in
                     # e.g. the geometry.Rect class.
-                    D[key1] = root_prop.__class__(root_prop)
-                nested_setattr(D[key1], key[1:], D[key])
+                    state[key1] = root_prop.__class__(root_prop)
+                nested_setattr(state[key1], key[1:], state[key])
 
         # In second pass, assign the new root properties.
-        for key, val in D.items():
+        for key, val in state.items():
             if isinstance(key, tuple):
                 continue
             if key not in self._state_props:

--- a/vispy/scene/cameras/tests/test_link.py
+++ b/vispy/scene/cameras/tests/test_link.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+from vispy.scene.widgets import ViewBox
+from vispy.testing import run_tests_if_main
+
+
+def test_turntable_camera_link():
+    vbs = [ViewBox(camera='turntable') for _ in range(3)]
+    cams = [vb.camera for vb in vbs]
+
+    for cam in cams:
+        cam.elevation = 45.0
+        cam.azimuth = 120.0
+        cam.scale_factor = 4.0
+
+    cams[0].link(cams[1])
+    cams[0].link(cams[2], props=['azimuth', 'elevation'])
+
+    cams[1].elevation = 30.0
+    cams[1].azimuth = 90.0
+    cams[1].scale_factor = 2.0
+
+    assert cams[0].elevation == 30.0
+    assert cams[0].azimuth == 90.0
+    assert cams[0].scale_factor == 2.0
+
+    assert cams[2].elevation == 30.0
+    assert cams[2].azimuth == 90.0
+    assert cams[2].scale_factor == 4.0
+
+
+def test_panzoom_link():
+    vbs = [ViewBox(camera='panzoom') for _ in range(4)]
+    cams = [vb.camera for vb in vbs]
+
+    for cam in cams:
+        cam.rect = (0, 0, 100, 100)
+
+    cams[0].link(cams[1])
+    cams[0].link(cams[2], axis='x')
+    cams[0].link(cams[3], axis='y')
+
+    cams[1].rect = (-20, -20, 130, 130)
+
+    assert cams[0].rect.pos == (-20, -20) and cams[0].rect.size == (130, 130)
+    assert cams[2].rect.pos == (-20, 0) and cams[2].rect.size == (130, 100)
+    assert cams[3].rect.pos == (0, -20) and cams[3].rect.size == (100, 130)
+
+
+run_tests_if_main()


### PR DESCRIPTION
I suggest adding an argument to BaseCamera.link letting the user specify the camera properties to be linked.

The use case I have in mind is two turntable cameras with only the elevation and azimuth, not the scale_factor, being linked.