### PR TITLE
Fix test runners not passing arguments properly on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,8 +131,8 @@ External links
 -  `Gallery <http://vispy.org/gallery.html>`__
 -  `Documentation <http://vispy.readthedocs.org>`__
 
-.. |Build Status| image:: https://travis-ci.org/vispy/vispy.svg?branch=master
-   :target: https://travis-ci.org/vispy/vispy
+.. |Build Status| image:: https://travis-ci.com/vispy/vispy.svg?branch=master
+   :target: https://travis-ci.com/vispy/vispy
 .. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/v09sc8ua4ju2ngyy/branch/master?svg=true
    :target: https://ci.appveyor.com/project/vispy/vispy/branch/master
 .. |Coverage Status| image:: https://img.shields.io/coveralls/vispy/vispy/master.svg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
   CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"
   CIBW_BEFORE_BUILD_LINUX: "yum install -y fontconfig; pip install -U pip setuptools; pip install freetype-py"
+  # If freetype-py is installed from source (no wheel found), include bundled freetype library
+  CIBW_ENVIRONMENT_WINDOWS: "FREETYPEPY_BUNDLE_FT=1"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 jobs:

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -65,7 +65,7 @@ def _unit(mode, extra_arg_string='', coverage=False):
 
     if mode == 'nobackend':
         msg = 'Running tests with no backend'
-        extra_args += ['-m', '"not vispy_app_test"']
+        extra_args += ['-m', 'not vispy_app_test']
     else:
         # check to make sure we actually have the backend of interest
         stdout, stderr, invalid = run_subprocess(


### PR DESCRIPTION
Tests on appveyor and Azure started failing all of a sudden and it seems to be related to how arguments are passed from vispy's `_runners.py` module to the python executable through `run_subprocess`.

```
_VISPY_TESTING_APP=nobackend C:\conda\envs\test\python.exe -m pytest -m "not vispy_app_test" --cov vispy --cov-report= -ra c:\projects\vispy\vispy
============================= test session starts =============================
platform win32 -- Python 3.7.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: c:\projects\vispy, configfile: pytest.ini
plugins: cov-2.10.1, sugar-0.9.3
collected 470 items
============================ no tests ran in 2.96s ============================
ERROR: Wrong expression passed to '-m': "not vispy_app_test": at column 1: unexpected character """
Failed: unit failure (4)
Testing failed (['nobackend'] failed, ['pyqt4', 'pyqt5', 'pyside', 'pyside2', 'pyglet', 'glfw', 'sdl2', 'wx', 'egl', 'osmesa', 'ipynb_webgl', '_test'] skipped) in 6.476 seconds
FAILURE
```

Basically we are calling `python -m pytest -m "not vispy_app_test"` to skip any tests marked as needed the application. However, it is now passing the quotation marks to python instead of the shell interpreting them.