### PR TITLE
Fix ImageVisual not updating color transform after texture update

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -487,6 +487,7 @@ class ImageVisual(Visual):
                 self._clim = (0, 1)
 
         self._texture_limits = np.array(self._clim)
+        self._need_colortransform_update = True
         self._texture.set_data(data)
         self._need_texture_upload = False
 


### PR DESCRIPTION
fixes a bug resulting from #1844  that can cause inconsistent contrast (only in specific cases) in when rebuilding an image texture with `ImageVisual._build_texture()`  (originally observed/described at napari/napari#1585)