### PR TITLE
Fix various numpy deprecation warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
 variables:
   CIBW_BUILDING: "true"
-  CIBW_SKIP: "cp27-* cp34-* cp35-* pp27-* pp36-*"
+  CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp27-* pp36-*"
   CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -57,7 +57,7 @@ def pack_ieee(value):
     pack: array
         packed interpolation kernel
     """
-    return np.fromstring(value.tostring(),
+    return np.fromstring(value.tobytes(),
                          np.ubyte).reshape((value.shape + (4,)))
 
 

--- a/vispy/io/image.py
+++ b/vispy/io/image.py
@@ -45,13 +45,13 @@ def _make_png(data, level=6):
         else:
             size = len(data)
         chunk = np.empty(size + 12, dtype=np.ubyte)
-        chunk.data[0:4] = np.array(size, '>u4').tostring()
+        chunk.data[0:4] = np.array(size, '>u4').tobytes()
         chunk.data[4:8] = name.encode('ASCII')
         chunk.data[8:8 + size] = data
         # and-ing may not be necessary, but is done for safety:
         # https://docs.python.org/3/library/zlib.html#zlib.crc32
         chunk.data[-4:] = np.array(zlib.crc32(chunk[4:-4]) & 0xffffffff,
-                                   '>u4').tostring()
+                                   '>u4').tobytes()
         return chunk
 
     if data.dtype != np.ubyte:

--- a/vispy/io/tests/test_io.py
+++ b/vispy/io/tests/test_io.py
@@ -51,7 +51,7 @@ def test_wavefront_non_triangular():
                          [2., 1.625, 0.]])
 
     faces = np.array([[1, 0, 7, 6, 5, 3],
-                      [4, 5, 6, 8, 2]])
+                      [4, 5, 6, 8, 2]], dtype=object)
     fname_out = op.join(temp_dir, 'temp.obj')
     write_mesh(fname_out, vertices=vertices,
                faces=faces, normals=None,


### PR DESCRIPTION
I inspected the latest azure CI run on master and saw the same issues related to `numpy`. I fixed what was reported in `vispy/io/image.py` and `vispy/io/tests/test_io.py`. I also found a usage of `tostring()` in `vispy/io/datasets.py`.

Closes https://github.com/vispy/vispy/issues/1909