### PR TITLE
Fix ImportError on Python 3.9

### DIFF
--- a/vispy/geometry/torusknot.py
+++ b/vispy/geometry/torusknot.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import numpy as np
-from fractions import gcd
+from math import gcd
 
 
 class TorusKnot(object):


### PR DESCRIPTION
The `fractions.gcd()` function has been removed in Python 3.9. It was deprecated since Python 3.5: use math.gcd() instead. See https://docs.python.org/3.9/whatsnew/3.9.html#removed