### PR TITLE
Add website building to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,17 @@ matrix:
         apt:
           packages:
 
+    # Generate HTML website
+    # also tests file sizes, style, line endings
+    - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=website
+        CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 flake8 meshio sphinx"
+        CONDA_CHANNELS=conda-forge
+        CONDA_CHANNEL_PRIORITY=strict
+        PIP_DEPENDENCIES="numpydoc"
+      addons:
+        apt:
+          packages:
+
 
 before_install:
     - git clone https://github.com/astropy/ci-helpers.git
@@ -149,6 +160,7 @@ script:
     - if [ "${TEST}" == "standard" ]; then
         python make test unit --tb=short;
       fi;
+    # FIXME: This never actually runs examples for DEPS=minimal because there is no backend
     - if [ "${TEST}" == "examples" ] || [ "${DEPS}" == "minimal" ]; then
         make examples;
       fi;
@@ -157,6 +169,10 @@ script:
       fi;
     - if [ "${TEST}" == "osmesa" ]; then
         make osmesa;
+      fi;
+    # TODO: Fail is warnings from generation
+    - if [ "${TEST}" == "website" ]; then
+        python make website html;
       fi;
     # Each line must be run in a separate line to ensure exit code accuracy
     - if [ "${DEPS}" == "minimal" ]; then
@@ -178,3 +194,6 @@ after_success:
         mv .vispy-coverage .coverage;
         coveralls;
       fi;
+    - if [ "${TEST}" == "website" ]; then
+        echo "Upload website..."
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
+           MAMBA=True
       os: osx
       osx_image: xcode10.1
 
@@ -25,6 +26,7 @@ matrix:
            CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
+           MAMBA=True
       os: osx
       osx_image: xcode10.1
 
@@ -34,6 +36,7 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
+           MAMBA=True
       addons:
         apt:
           packages:
@@ -44,6 +47,7 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
+           MAMBA=True
       addons:
         apt:
           packages:
@@ -56,6 +60,7 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
+           MAMBA=True
       addons:
         apt:
           packages:
@@ -70,6 +75,7 @@ matrix:
            CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 mesalib libglu meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
+           MAMBA=True
       addons:
         apt:
           packages:
@@ -81,6 +87,7 @@ matrix:
         CONDA_CHANNELS=conda-forge
         CONDA_CHANNEL_PRIORITY=strict
         PIP_DEPENDENCIES="numpydoc"
+        MAMBA=True
       addons:
         apt:
           packages:
@@ -145,15 +152,8 @@ script:
     - if [ "${TEST}" == "osmesa" ]; then
         make osmesa;
       fi;
-    # TODO: Fail if warnings from generation
-    #       make html SPHINXOPTS="-W"
-    # Make "master" the tag so the website gets deployed (see below)
     - if [ "${TEST}" == "website" ]; then
-        TRAVIS_TAG="master";
-        cd doc;
-        make clean;
-        make html;
-        touch _build/html/.nojekyll;
+        source ./ci/build_website.sh;
       fi;
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 matrix:
   include:
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
@@ -22,7 +22,7 @@ matrix:
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
@@ -30,7 +30,7 @@ matrix:
 
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 flake8 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
@@ -40,7 +40,7 @@ matrix:
 
     # XXX eventually we need to support GLFW 3.3.1...
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -52,7 +52,7 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -67,7 +67,7 @@ matrix:
     # to avoid having the linker load the wrong libglapi.so which would cause
     # OSMesa to crash
     - env: PYTHON_VERSION=3.7 DEPS=osmesa TEST=osmesa
-           CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 mesalib libglu meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar mesalib libglu meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       addons:
@@ -77,7 +77,7 @@ matrix:
     # Generate HTML website
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=website
-        CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 flake8 meshio sphinx sphinx_bootstrap_theme"
+        CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar flake8 meshio sphinx sphinx_bootstrap_theme"
         CONDA_CHANNELS=conda-forge
         CONDA_CHANNEL_PRIORITY=strict
         PIP_DEPENDENCIES="numpydoc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
-           MAMBA=True
       os: osx
       osx_image: xcode10.1
 
@@ -26,7 +25,6 @@ matrix:
            CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
-           MAMBA=True
       os: osx
       osx_image: xcode10.1
 
@@ -36,7 +34,6 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="numpydoc"
-           MAMBA=True
       addons:
         apt:
           packages:
@@ -47,7 +44,6 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
-           MAMBA=True
       addons:
         apt:
           packages:
@@ -60,7 +56,6 @@ matrix:
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
-           MAMBA=True
       addons:
         apt:
           packages:
@@ -75,7 +70,6 @@ matrix:
            CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 mesalib libglu meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
-           MAMBA=True
       addons:
         apt:
           packages:
@@ -87,7 +81,6 @@ matrix:
         CONDA_CHANNELS=conda-forge
         CONDA_CHANNEL_PRIORITY=strict
         PIP_DEPENDENCIES="numpydoc"
-        MAMBA=True
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,9 +170,12 @@ script:
     - if [ "${TEST}" == "osmesa" ]; then
         make osmesa;
       fi;
-    # TODO: Fail is warnings from generation
+    # TODO: Fail if warnings from generation
+    #       make html SPHINXOPTS="-W" SPHINXBUILD="sphinx-multiversion"
     - if [ "${TEST}" == "website" ]; then
-        python make website html;
+        cd doc;
+        make clean;
+        make html;
       fi;
     # Each line must be run in a separate line to ensure exit code accuracy
     - if [ "${DEPS}" == "minimal" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
     # Generate HTML website
     # also tests file sizes, style, line endings
     - env: PYTHON_VERSION=3.7 DEPS=minimal TEST=website
-        CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 flake8 meshio sphinx"
+        CONDA_DEPENDENCIES="numpy scipy pytest<5.4 cython coveralls pytest-cov pytest-sugar!=0.9.3 flake8 meshio sphinx sphinx_bootstrap_theme"
         CONDA_CHANNELS=conda-forge
         CONDA_CHANNEL_PRIORITY=strict
         PIP_DEPENDENCIES="numpydoc"
@@ -90,31 +90,6 @@ before_install:
     - git clone https://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - SRC_DIR=$(pwd)
-    # file size checks run on minimal build for time
-    - if [ "${DEPS}" == "minimal" ]; then
-        if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-          GIT_TARGET_EXTRA="+refs/heads/${TRAVIS_BRANCH}";
-          GIT_SOURCE_EXTRA="+refs/pull/${TRAVIS_PULL_REQUEST}/merge";
-        else
-          GIT_TARGET_EXTRA="";
-          GIT_SOURCE_EXTRA="";
-        fi;
-        cd ~;
-        mkdir target-size-clone && cd target-size-clone;
-        git init && git remote add -t ${TRAVIS_BRANCH} origin git://github.com/${TRAVIS_REPO_SLUG}.git;
-        git fetch origin ${GIT_TARGET_EXTRA} && git checkout -qf FETCH_HEAD;
-        git tag travis-merge-target;
-        git gc --aggressive;
-        TARGET_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
-        git pull origin ${GIT_SOURCE_EXTRA};
-        git gc --aggressive;
-        MERGE_SIZE=`du -s . | sed -e "s/[[:space:]].*//"`;
-        if [ "${MERGE_SIZE}" != "${TARGET_SIZE}" ]; then
-          SIZE_DIFF=`expr \( ${MERGE_SIZE} - ${TARGET_SIZE} \)`;
-        else
-          SIZE_DIFF=0;
-        fi;
-      fi;
 
 
 install:
@@ -171,22 +146,14 @@ script:
         make osmesa;
       fi;
     # TODO: Fail if warnings from generation
-    #       make html SPHINXOPTS="-W" SPHINXBUILD="sphinx-multiversion"
+    #       make html SPHINXOPTS="-W"
+    # Make "master" the tag so the website gets deployed (see below)
     - if [ "${TEST}" == "website" ]; then
+        TRAVIS_TAG="master";
         cd doc;
         make clean;
         make html;
-      fi;
-    # Each line must be run in a separate line to ensure exit code accuracy
-    - if [ "${DEPS}" == "minimal" ]; then
-        echo "Size difference ${SIZE_DIFF} kB";
-        if git log --format=%B -n 2 | grep -q "\[size skip\]"; then
-          echo "Skipping size test";
-        elif git log --format=%B -n 2 | grep -q "\[skip size\]"; then
-          echo "Skipping size test";
-        else
-          test ${SIZE_DIFF} -lt 100;
-        fi;
+        touch _build/html/.nojekyll;
       fi;
 
 
@@ -197,6 +164,19 @@ after_success:
         mv .vispy-coverage .coverage;
         coveralls;
       fi;
-    - if [ "${TEST}" == "website" ]; then
-        echo "Upload website..."
-      fi
+
+
+deploy:
+  - provider: pages:git
+    repo: vispy/vispy.github.com
+    branch: master
+    fqdn: vispy.org
+    commit_message: "Deploy %{project_name} website for SHA:%{git_sha} (Tag: %{git_tag})"
+    edge: true
+    keep_history: true
+    cleanup: false
+    local_dir: doc/_build/html
+    on:
+      repo: vispy/vispy
+      tags: true
+      condition: $TEST == website

--- a/ci/build_website.sh
+++ b/ci/build_website.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build sphinx documentation
+
+# Make "master" the tag so the website gets deployed
+# The website deployment checks for any tags by checking
+# this variable.
+export TRAVIS_TAG="master"
+
+cd doc
+make clean
+# TODO: Fail if warnings from generation
+#       make html SPHINXOPTS="-W"
+# TODO: Switch to sphinx-multiversion
+make html
+touch _build/html/.nojekyll

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -120,7 +120,7 @@ def _unit(mode, extra_arg_string='', coverage=False):
 
 
 def _docs():
-    """test docstring paramters
+    """test docstring parameters
     using vispy/utils/tests/test_docstring_parameters.py"""
     dev = _get_import_dir()[1]
 


### PR DESCRIPTION
This is an attempt to get travis to build the vispy website and upload it to the vispy-website repository. It was recommended that we look at doctr for handling the upload and deploy key handling (https://github.com/drdoctr/doctr). One nice thing about that would be this extension that allows us to have multiple versions like readthedocs allows (https://github.com/goerz/doctr_versions_menu).

I can't promise I'll get to it (maybe a good hacktoberfest issue), but here are the current issues I see when I build the site locally:

```
/home/davidh/repos/git/vispy/_website/conf.py:352: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('css/font-mfizz.css')
/home/davidh/repos/git/vispy/_website/conf.py:353: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('css/font-awesome.css')
/home/davidh/repos/git/vispy/_website/conf.py:354: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('style.css')
...                                                                                                                                                                                                            
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                                            
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.imap:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.imap, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                                  
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.map:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.map, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                                    
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.rotate:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.rotate, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                              
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.scale:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.scale, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                                
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.set_frustum:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.set_frustum, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                    
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.set_mapping:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.set_mapping, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                    
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.set_ortho:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.set_ortho, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                        
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.set_perspective:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.set_perspective, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                            
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.shader_imap:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.shader_imap, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                    
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.shader_map:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.shader_map, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                      
/home/davidh/repos/git/vispy/vispy/visuals/transforms/linear.py:docstring of vispy.visuals.transforms.MatrixTransform.translate:1: WARNING: duplicate object description of vispy.visuals.transforms.MatrixTransform.translate, other instance in visuals, use :noindex: for one of them                                                                                                                                                                                                                        
...
checking consistency... /home/davidh/repos/git/vispy/_website/README.rst: WARNING: document isn't included in any toctree
```