### PR TITLE
Add Tkinter backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ matrix:
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio pyopengltk"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
+           PIP_DEPENDENCIES="pyopengltk"
       os: osx
       osx_image: xcode10.1
 
@@ -40,10 +41,10 @@ matrix:
 
     # XXX eventually we need to support GLFW 3.3.1...
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio pyopengltk"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES="husl pypng cassowary"
+           PIP_DEPENDENCIES="husl pypng cassowary pyopengltk"
       addons:
         apt:
           packages:
@@ -52,10 +53,10 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio pyopengltk"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
-           PIP_DEPENDENCIES="husl pypng cassowary"
+           PIP_DEPENDENCIES="husl pypng cassowary pyopengltk"
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       osx_image: xcode10.1
 
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 scikit-image meshio pyopengltk"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
       os: osx
@@ -40,7 +40,7 @@ matrix:
 
     # XXX eventually we need to support GLFW 3.3.1...
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=standard
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio pyopengltk"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"
@@ -52,7 +52,7 @@ matrix:
 
     # test examples
     - env: PYTHON_VERSION=3.7 DEPS=full TEST=examples
-           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio"
+           CONDA_DEPENDENCIES="numpy scipy pytest cython coveralls pytest-cov pytest-sugar pyopengl networkx pysdl2 matplotlib jupyter pyqt=5 pillow decorator six scikit-image glfw!=3.3.1 freetype-py imageio freetype<2.10.0 meshio pyopengltk"
            CONDA_CHANNELS=conda-forge
            CONDA_CHANNEL_PRIORITY=strict
            PIP_DEPENDENCIES="husl pypng cassowary"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   matrix:
       - PYTHON_VERSION: "3.7"
         CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls freetype-py numpydoc meshio"
-        PIP_DEPENDENCIES: "pyopengltk"
+        PIP_DEPENDENCIES: ""
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   matrix:
       - PYTHON_VERSION: "3.7"
         CONDA_DEPENDENCIES: "numpy scipy setuptools pytest coverage pytest-cov pytest-sugar pytest-faulthandler cython coveralls freetype-py numpydoc meshio"
-        PIP_DEPENDENCIES: ""
+        PIP_DEPENDENCIES: "pyopengltk"
 
 platform:
     -x64

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ setup(
         'pyside2': ['PySide2'],
         'sdl2': ['PySDL2'],
         'wx': ['wxPython'],
-        'tk': ['pyopengltk']
+        'tk': ['pyopengltk'],
         'doc': ['sphinx_bootstrap_theme', 'numpydoc'],
         'io': ['meshio'],
     },

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,7 @@ setup(
         'pyside2': ['PySide2'],
         'sdl2': ['PySDL2'],
         'wx': ['wxPython'],
+        'tk': ['pyopengltk']
         'doc': ['sphinx_bootstrap_theme', 'numpydoc'],
         'io': ['meshio'],
     },

--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -23,6 +23,7 @@ CORE_BACKENDS = [
     ('wx', '_wx', 'wx'),
     ('EGL', '_egl', 'vispy.ext.egl'),
     ('osmesa', '_osmesa', 'vispy.ext.osmesa'),
+    ('tkinter', '_tk', 'tkinter'),
 ]
 
 # Whereas core backends really represents libraries that can create a

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -263,7 +263,7 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
 
         OpenGLFrame.__init__(self, parent, **kwargs)
         if not hasattr(self, "_native_context") or self._native_context is None:
-            self.tkCreateContext()
+            self.tkMap(None)
             # Workaround to get OpenGLFrame.__context for reference here
             # if access would ever be needed from self._native_context.
             self._native_context = vars(self).get("_CanvasBackend__context", None)

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -53,94 +53,6 @@ else:
     class OpenGLFrame(object):
         pass
 
-
-def _fix_tcl_lib():
-    """
-    It is possible that the Tcl library cannot be found when the Python environment
-    does not have the proper variables, so we force them here (mostly when running tests).
-    From: https://github.com/enthought/Python-2.7.3/blob/master/Lib/lib-tk/FixTk.py
-    (This is rarely encountered in conjunction with PyInstaller.)
-    """
-    # Delay import _tkinter until we have set TCL_LIBRARY,
-    # so that Tcl_FindExecutable has a chance to locate its
-    # encoding directory.
-
-    # Unfortunately, we cannot know the TCL_LIBRARY directory
-    # if we don't know the tcl version, which we cannot find out
-    # without import Tcl. Fortunately, Tcl will itself look in
-    # <TCL_LIBRARY>\..\tcl<TCL_VERSION>, so anything close to
-    # the real Tcl library will do.
-
-    # Expand symbolic links on Vista
-    try:
-        import ctypes
-        ctypes.windll.kernel32.GetFinalPathNameByHandleW
-    except (ImportError, AttributeError):
-        def convert_path(s):
-            return s
-    else:
-        def convert_path(s):
-            use_dec = hasattr(s, "decode")
-            udir = s.decode("mbcs") if use_dec else s
-            hdir = ctypes.windll.kernel32.\
-                CreateFileW(udir, 0x80,  # FILE_READ_ATTRIBUTES
-                            1,           # FILE_SHARE_READ
-                            None, 3,     # OPEN_EXISTING
-                            0x02000000,  # FILE_FLAG_BACKUP_SEMANTICS
-                            None)
-            if hdir == -1:
-                # Cannot open directory, give up
-                return s
-            buf = ctypes.create_unicode_buffer(u"", 32768)
-            res = ctypes.windll.kernel32.\
-                GetFinalPathNameByHandleW(hdir, buf, len(buf),
-                                          0)  # VOLUME_NAME_DOS
-            ctypes.windll.kernel32.CloseHandle(hdir)
-            if res == 0:
-                # Conversion failed (e.g. network location)
-                return s
-            s = buf[:res].encode("mbcs") if use_dec else buf[:res]
-            # Ignore leading \\?\
-            if s.startswith("\\\\?\\"):
-                s = s[4:]
-            if s.startswith("UNC"):
-                s = "\\" + s[3:]
-            return s
-
-    prefix = os.path.join(sys.prefix, "tcl")
-    if not os.path.exists(prefix):
-        # devdir/../tcltk/lib
-        prefix = os.path.join(sys.prefix, os.path.pardir, "tcltk", "lib")
-        prefix = os.path.abspath(prefix)
-
-    # if this does not exist, no further search is needed
-    if os.path.exists(prefix):
-        prefix = convert_path(prefix)
-
-        if "TCL_LIBRARY" not in os.environ:
-            for name in os.listdir(prefix):
-                if name.startswith("tcl"):
-                    tcldir = os.path.join(prefix, name)
-                    if os.path.isdir(tcldir):
-                        os.environ["TCL_LIBRARY"] = tcldir
-
-        # Compute TK_LIBRARY, knowing that it has the same version as Tcl
-        import _tkinter
-        ver = str(_tkinter.TCL_VERSION)
-        if "TK_LIBRARY" not in os.environ:
-            v = os.path.join(prefix, 'tk'+ver)
-            if os.path.exists(os.path.join(v, "tclIndex")):
-                os.environ['TK_LIBRARY'] = v
-
-        # We don't know the Tix version, so we must search the entire directory
-        if "TIX_LIBRARY" not in os.environ:
-            for name in os.listdir(prefix):
-                if name.startswith("tix"):
-                    tixdir = os.path.join(prefix, name)
-                    if os.path.isdir(tixdir):
-                        os.environ["TIX_LIBRARY"] = tixdir
-
-
 # Map native keys to vispy keys
 # e.keysym_num -> vispy
 KEYMAP = {
@@ -341,7 +253,6 @@ class ApplicationBackend(BaseApplicationBackend):
                 _tk_inst_owned = False
             else:
                 # Create our own top level Tk instance
-                _fix_tcl_lib()
                 _tk_inst = tk.Tk()
                 _tk_inst.withdraw()
                 _tk_inst_owned = True

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -1,0 +1,498 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+"""
+vispy backend for Tkinter.
+"""
+
+from __future__ import division
+
+from ..base import (BaseApplicationBackend, BaseCanvasBackend,
+                    BaseTimerBackend)
+from ...util import keys
+from ... import config
+
+USE_EGL = config['gl_backend'].lower().startswith('es')
+
+
+# -------------------------------------------------------------------- init ---
+
+# Import
+try:
+    import tkinter as tk
+    from OpenGL import GL
+    from pyopengltk import OpenGLFrame
+except:
+    available, testable, why_not = False, False, "Import error"
+else:
+    available, testable, why_not = True, True, None
+
+
+# Map native keys to vispy keys
+# keysym_num -> vispy
+KEYMAP = {
+    65505: keys.SHIFT,
+    65506: keys.SHIFT,
+    65507: keys.CONTROL,
+    65508: keys.CONTROL,
+    65513: keys.ALT,
+    65514: keys.ALT,
+    65371: keys.META,
+    65372: keys.META,
+
+    65361: keys.LEFT,
+    65362: keys.UP,
+    65363: keys.RIGHT,
+    65364: keys.DOWN,
+    65365: keys.PAGEUP,
+    65366: keys.PAGEDOWN,
+
+    65379: keys.INSERT,
+    65535: keys.DELETE,
+    65360: keys.HOME,
+    65367: keys.END,
+
+    65307: keys.ESCAPE,
+    65288: keys.BACKSPACE,
+
+       32: keys.SPACE,
+    65293: keys.ENTER,
+    65289: keys.TAB,
+
+    65470: keys.F1,
+    65471: keys.F2,
+    65472: keys.F3,
+    65473: keys.F4,
+    65474: keys.F5,
+    65475: keys.F6,
+    65476: keys.F7,
+    65477: keys.F8,
+    65478: keys.F9,
+    65479: keys.F10,
+    65480: keys.F11,
+    65481: keys.F12,
+}
+
+
+# -------------------------------------------------------------- capability ---
+
+# These are all booleans. Note that they mirror many of the kwargs to
+# the initialization of the Canvas class.
+capability = dict(
+    # if True they mean:
+    title=True,           # can set title on the fly
+    size=True,            # can set size on the fly
+    position=True,        # can set position on the fly
+    show=True,            # can show/hide window XXX ?
+    vsync=False,          # can set window to sync to blank
+    resizable=True,       # can toggle resizability (e.g., no user resizing)
+    decorate=True,        # can toggle decorations
+    fullscreen=True,      # fullscreen window support
+    context=True,         # can share contexts between windows
+    multi_window=True,    # can use multiple windows at once
+    scroll=True,          # scroll-wheel events are supported
+    parent=True,          # can pass native widget backend parent
+    always_on_top=True,   # can be made always-on-top
+)
+
+
+# ------------------------------------------------------- set_configuration ---
+def _set_config(c):
+    """Set gl configuration for template"""
+    raise NotImplementedError
+
+
+# ------------------------------------------------------------- application ---
+
+_tk_toplevel = None
+
+class ApplicationBackend(BaseApplicationBackend):
+
+    def __init__(self):
+        BaseApplicationBackend.__init__(self)
+
+    def _vispy_get_backend_name(self):
+        return tk.__name__
+
+    def _vispy_process_events(self):
+        app = self._vispy_get_native_app()
+        app.update_idletasks()
+
+    def _vispy_run(self):
+        self._vispy_get_native_app().mainloop()
+
+    def _vispy_quit(self):
+        global _tk_toplevel
+        self._vispy_get_native_app().quit()
+        self._vispy_get_native_app().destroy()
+        _tk_toplevel = None
+
+    def _vispy_get_native_app(self):
+        global _tk_toplevel
+        if _tk_toplevel is None:
+            fr = tk.Frame(None)
+            _tk_toplevel = fr.master
+            fr.destroy()
+        return _tk_toplevel
+
+
+# ------------------------------------------------------------------ canvas ---
+
+class Coord:
+    def __init__(self, tup):
+        self.x, self.y = tup
+        self.width, self.height = tup
+
+
+# You can mix this class with the native widget
+class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
+    """Template backend
+
+    Events to emit are shown below. Most backends will probably
+    have one method for each event:
+
+        self._vispy_canvas.events.initialize()
+        self._vispy_canvas.events.resize(size=(w, h))
+        self._vispy_canvas.events.draw(region=None)
+        self._vispy_canvas.close()
+        self._vispy_canvas.events.mouse_press(pos=(x, y), button=1,
+                                              modifiers=())
+        self._vispy_canvas.events.mouse_release(pos=(x, y), button=1,
+                                                modifiers=())
+        self._vispy_canvas.events.mouse_double_click(pos=(x, y), button=1,
+                                                     modifiers=())
+        self._vispy_canvas.events.mouse_move(pos=(x, y), modifiers=())
+        self._vispy_canvas.events.mouse_wheel(pos=(x, y), delta=(0, 0),
+                                              modifiers=())
+        self._vispy_canvas.events.key_press(key=key, text=text, modifiers=())
+        self._vispy_canvas.events.key_release(key=key, text=text, modifiers=())
+
+    In most cases, if the window-cross is clicked, a native close-event is
+    generated, which should then call canvas.close(). The Canvas class is
+    responsible for firing the close event and calling
+    backend_canvas._vispy_close, which closes the native widget.
+    If this happens to result in a second close event, canvas.close() gets
+    called again, but Canvas knows it is closing so it stops there.
+
+    If canvas.close() is called (by the user), it calls
+    backend_canvas._vispy_close, which closes the native widget,
+    and we get the same stream of actions as above. This deviation from
+    having events come from the CanvasBackend is necessitated by how
+    different backends handle close events, and the various ways such
+    events can be triggered.
+    """
+
+    # args are for BaseCanvasBackend, kwargs are for us.
+    def __init__(self, *args, **kwargs):
+        BaseCanvasBackend.__init__(self, *args)
+        # We use _process_backend_kwargs() to "serialize" the kwargs
+        # and to check whether they match this backend's capability
+        p = self._process_backend_kwargs(kwargs)
+        
+        self._double_click_supported = True
+
+        # Deal with config
+        # ... use context.config
+        # Deal with context
+        p.context.shared.add_ref('tkinter', self)
+        if p.context.shared.ref is self:
+            self._native_context = None  # ...
+        else:
+            self._native_context = p.context.shared.ref._native_context
+
+        kwargs.pop("parent")
+        kwargs.pop("title")
+        kwargs.pop("size")
+        kwargs.pop("show")
+        kwargs.pop("vsync")
+        kwargs.pop("resizable")
+        kwargs.pop("decorate")
+        kwargs.pop("always_on_top")
+        kwargs.pop("fullscreen")
+        kwargs.pop("context")
+        
+        if p.parent is None:
+            self.top = tk.Tk()
+            self.top.withdraw()
+            
+            if p.title:    self._vispy_set_title(p.title)
+            if p.size:     self._vispy_set_size(p.size[0], p.size[1])
+            if p.position: self._vispy_set_position(p.position[0], p.position[1])
+            
+            self.top.update_idletasks()
+
+            if not p.resizable:
+                self.top.resizable(False, False)
+            if not p.decorate:
+                self.top.overrideredirect(True)
+            if p.always_on_top:
+                self.top.wm_attributes("-topmost", "True")
+            self._fullscreen = p.fullscreen
+                
+            self.top.protocol("WM_DELETE_WINDOW", self._vispy_close)
+            parent = self.top
+        else:
+            self.top = p.parent.winfo_toplevel()
+            parent   = p.parent
+            self._fullscreen = False
+        
+        self._init = False
+
+        OpenGLFrame.__init__(self, parent, **kwargs)
+        if not hasattr(self, "_native_context") or self._native_context is None:
+            self.tkCreateContext()
+            # Why can't I access __context?
+            # self._native_context = self.__context
+            self._native_context = vars(self).get("_CanvasBackend__context", None)
+        
+        self.bind("<Enter>"            , self._on_mouse_enter)
+        self.bind("<Motion>"           , self._on_mouse_move)
+        self.bind("<MouseWheel>"       , self._on_mouse_wheel)
+        self.bind("<Any-Button>"       , self._on_mouse_button_press)
+        self.bind("<Double-Any-Button>", self._on_mouse_double_button_press)
+        self.bind("<Any-ButtonRelease>", self._on_mouse_button_release)
+        self.bind("<Configure>"        , self._on_configure)
+        # self.bind("<Expose>"           , self._on_draw)
+        # self.bind("<Map>"              , self._on_draw)
+        self.bind("<Any-KeyPress>"     , self._on_key_down)
+        self.bind("<Any-KeyRelease>"   , self._on_key_up)
+
+        self._vispy_set_visible(p.show)
+        self.focus_force()
+
+    def initgl(self):
+        # For the user code
+        GL.glViewport(0, 0, self.winfo_width(), self.winfo_height())
+        GL.glClearColor(0.0, 1.0, 0.0, 0.0)
+        # self.animate = 1
+
+    def redraw(self):
+        # For the user code
+        # GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+        self._on_draw(None)
+
+    """
+    event.state:
+        0x0001	Shift.
+        0x0002	Caps Lock.
+        0x0004	Control.
+        0x0008	Left-hand Alt.
+        0x0010	Num Lock.
+        0x0080	Right-hand Alt.
+        0x0100	Mouse button 1.
+        0x0200	Mouse button 2.
+        0x0400	Mouse button 3.
+    """
+    def _parse_state(self, e):
+        mods = []
+        if e.state & 0x0001: mods.append(keys.SHIFT)
+        # if e.state & 0x0002: mods.append(keys.?)
+        if e.state & 0x0004: mods.append(keys.CONTROL)
+        if e.state & 0x0008: mods.append(keys.ALT)
+        # if e.state & 0x0010: mods.append(keys.?)
+        if e.state & 0x0080: mods.append(keys.ALT)
+        # if e.state & 0x0100: mods.append(keys.?)
+        # if e.state & 0x0200: mods.append(keys.?)
+        # if e.state & 0x0400: mods.append(keys.?)
+        return mods
+        
+    def _parse_keys(self, e):
+        if e.keysym_num in KEYMAP:
+            return KEYMAP[e.keysym_num], ""
+        # e.char, e.keycode, e.keysym, e.keysym_num
+        key = e.keycode
+        if 97 <= key <= 122:
+            key -= 32
+        if key >= 32 and key <= 127:
+            return keys.Key(chr(key)), chr(key)
+        else:
+            return None, None
+
+    def _on_mouse_enter(self, e):
+        if self._vispy_canvas is None:
+            return
+        self._vispy_mouse_move(
+            pos=(e.x, e.y), modifiers=self._parse_state(e))
+        
+    def _on_mouse_move(self, e):
+        if self._vispy_canvas is None:
+            return
+        self._vispy_mouse_move(
+            pos=(e.x, e.y), modifiers=self._parse_state(e))
+        
+    def _on_mouse_wheel(self, e):
+        if self._vispy_canvas is None:
+            return
+        # e.num: 4 when up, 5 when down
+        # Scroll up: e.delta > 0
+        # Scroll down: e.delta < 0
+        self._vispy_canvas.events.mouse_wheel(
+            delta=(0.0, float(e.delta)), 
+            pos=(e.x, e.y), modifiers=self._parse_state(e))
+        
+    def _on_mouse_button_press(self, e):
+        if self._vispy_canvas is None:
+            return
+        # [ left=1, middle, right]
+        btn = { 1:1, 2:3, 3:2}
+        self._vispy_mouse_press(
+            pos=(e.x, e.y), button=btn[e.num], modifiers=self._parse_state(e))
+        
+    def _on_mouse_double_button_press(self, e):
+        if self._vispy_canvas is None:
+            return
+        # [ left=1, middle, right]
+        btn = { 1:1, 2:3, 3:2}
+        pos, button, modifiers = \
+            (e.x, e.y), btn[e.num], self._parse_state(e)
+        self._vispy_mouse_press(
+            pos=pos, button=button, modifiers=modifiers)
+        self._vispy_mouse_double_click(
+            pos=pos, button=button, modifiers=modifiers)
+
+    def _on_mouse_button_release(self, e):
+        if self._vispy_canvas is None:
+            return
+        # [ left=1, middle, right]
+        btn = { 1:1, 2:3, 3:2}
+        self._vispy_mouse_release(
+            pos=(e.x, e.y), button=btn[e.num], modifiers=self._parse_state(e))
+    
+    def _on_configure(self, e):
+        print("_on_configure")
+        if self._vispy_canvas is None or not self._init:
+            return
+        self.update()
+        self.tkResize(e)
+        self._vispy_canvas.events.resize(size=(e.width, e.height))
+    
+    def _on_draw(self, e):
+        if self._vispy_canvas is None:
+            return
+        if not self._init:
+            self._initialize()
+        self._vispy_canvas.set_current()
+        self._vispy_canvas.events.draw(region=None)
+    
+    def _initialize(self):
+        print("_initialize")
+        self.initgl()
+        
+        if self._vispy_canvas is None:
+            return
+        self._init = True
+        self._vispy_canvas.set_current()
+        self._vispy_canvas.events.initialize()
+        if self.top: self.top.update_idletasks()
+        self._on_configure(Coord(self._vispy_get_size()))
+    
+    def _on_key_down(self, e):
+        if self._vispy_canvas is None:
+            return
+        key, text = self._parse_keys(e)
+        self._vispy_canvas.events.key_press(
+            key=key, text=text, modifiers=self._parse_state(e))
+        
+    def _on_key_up(self, e):
+        if self._vispy_canvas is None:
+            return
+        key, text = self._parse_keys(e)
+        self._vispy_canvas.events.key_release(
+            key=key, text=text, modifiers=self._parse_state(e))
+
+    def _vispy_warmup(self):
+        etime = time() + 0.3
+        while time() < etime:
+            sleep(0.01)
+            self._vispy_canvas.set_current()
+            self._vispy_canvas.app.process_events()
+
+    def _vispy_set_current(self):
+        # Make this the current context
+        self.tkMakeCurrent()
+
+    def _vispy_swap_buffers(self):
+        # Swap front and back buffer
+        self._vispy_canvas.set_current()
+        self.tkSwapBuffers()
+
+    def _vispy_set_title(self, title):
+        # Set the window title. Has no effect for widgets
+        if self.top:
+            self.top.title(title)
+
+    def _vispy_set_size(self, w, h):
+        # Set size of the widget or window
+        if self.top:
+            self.top.geometry(f"{w}x{h}")
+
+    def _vispy_set_position(self, x, y):
+        # Set location of the widget or window. May have no effect for widgets
+        if self.top:
+            self.top.geometry(f"+{x}+{y}")
+
+    def _vispy_set_visible(self, visible):
+        # Show or hide the window or widget
+        if self.top:
+            if visible:
+                self.top.wm_deiconify()
+                self.top.lift()
+                self.top.attributes('-fullscreen', self._fullscreen)
+            else:
+                self.top.withdraw()
+
+    def _vispy_set_fullscreen(self, fullscreen):
+        # Set the current fullscreen state
+        self._fullscreen = bool(fullscreen)
+        if self.top:
+            self._vispy_set_visible(True)
+
+    def _vispy_update(self):
+        # Invoke a redraw
+        self.tkExpose(None)
+
+    def _vispy_close(self):
+        # Force the window or widget to shut down
+        self._vispy_canvas.close()
+        self.destroy()
+
+    def _vispy_get_size(self):
+        # Should return widget size
+        if self.top: self.top.update_idletasks()
+        return self.winfo_reqwidth(), self.winfo_reqheight()
+
+    def _vispy_get_position(self):
+        # Should return widget position
+        return w.winfo_x(), w.winfo_y()
+
+    def _vispy_get_fullscreen(self):
+        # Should return the current fullscreen state
+        return self._fullscreen
+
+    def _vispy_get_native_canvas(self):
+        # Should return the native widget object.
+        # If this is self, this method can be omitted.
+        return self
+
+
+# ------------------------------------------------------------------- timer ---
+
+class TimerBackend(BaseTimerBackend):  # Can be mixed with native timer class
+
+    def __init__(self, vispy_timer):
+        BaseTimerBackend.__init__(self, vispy_timer)
+
+    def _vispy_start(self, interval):
+        raise NotImplementedError()
+
+    def _vispy_stop(self):
+        raise NotImplementedError()
+
+    def _vispy_timeout(self):
+        raise NotImplementedError()
+
+    def _vispy_get_native_timer(self):
+        # Should return the native widget object.
+        # If this is self, this method can be omitted.
+        return self

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -29,6 +29,9 @@ try:
     from pyopengltk import OpenGLFrame
 except:
     available, testable, why_not, which = False, False, "Import error", None
+    
+    class OpenGLFrame(object):
+        pass
 else:
     available, testable, why_not = True, True, None
     which = "Tkinter " + str(tk.TkVersion)
@@ -62,7 +65,7 @@ def _fix_tcl_lib():
     else:
         def convert_path(s):
             assert isinstance(s, str)   # sys.prefix contains only bytes
-            udir = s.decode("mbcs")
+            udir = s.decode("mbcs") if hasattr(s, "decode") else s
             hdir = ctypes.windll.kernel32.\
                 CreateFileW(udir, 0x80, # FILE_READ_ATTRIBUTES
                             1,          # FILE_SHARE_READ

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -14,7 +14,6 @@ from ..base import (BaseApplicationBackend, BaseCanvasBackend,
                     BaseTimerBackend)
 from ...util import keys
 from ...util.ptime import time
-from ... import config
 
 
 # -------------------------------------------------------------------- init ---
@@ -23,18 +22,21 @@ from ... import config
 try:
     try:
         import tkinter as tk  # Python >= 3
-    except:
+    except ModuleNotFoundError:
         import Tkinter as tk  # Python < 3
     from OpenGL import GL
-    from pyopengltk import OpenGLFrame
-except:
-    available, testable, why_not, which = False, False, "Import error", None
-    
+    import pyopengltk
+    OpenGLFrame = pyopengltk.OpenGLFrame
+except ModuleNotFoundError:
+    available, testable, why_not, which = \
+        False, False, "Could not import Tkinter or pyopengltk, module(s) not found.", None
+
     class OpenGLFrame(object):
         pass
 else:
     available, testable, why_not = True, True, None
-    which = "Tkinter " + str(tk.TkVersion)
+    which_pyopengltk = getattr(pyopengltk, "__version__", "???")
+    which = "Tkinter " + str(tk.TkVersion) + " (with pyopengltk " + which_pyopengltk + ")"
 
 
 def _fix_tcl_lib():
@@ -43,7 +45,8 @@ def _fix_tcl_lib():
     does not have the proper variables, so we force them here (mostly when running tests).
     From: https://github.com/enthought/Python-2.7.3/blob/master/Lib/lib-tk/FixTk.py
     """
-    import sys, os
+    import sys
+    import os
 
     # Delay import _tkinter until we have set TCL_LIBRARY,
     # so that Tcl_FindExecutable has a chance to locate its
@@ -67,10 +70,10 @@ def _fix_tcl_lib():
             use_dec = hasattr(s, "decode")
             udir = s.decode("mbcs") if use_dec else s
             hdir = ctypes.windll.kernel32.\
-                CreateFileW(udir, 0x80, # FILE_READ_ATTRIBUTES
-                            1,          # FILE_SHARE_READ
-                            None, 3,    # OPEN_EXISTING
-                            0x02000000, # FILE_FLAG_BACKUP_SEMANTICS
+                CreateFileW(udir, 0x80,  # FILE_READ_ATTRIBUTES
+                            1,           # FILE_SHARE_READ
+                            None, 3,     # OPEN_EXISTING
+                            0x02000000,  # FILE_FLAG_BACKUP_SEMANTICS
                             None)
             if hdir == -1:
                 # Cannot open directory, give up
@@ -78,7 +81,7 @@ def _fix_tcl_lib():
             buf = ctypes.create_unicode_buffer(u"", 32768)
             res = ctypes.windll.kernel32.\
                 GetFinalPathNameByHandleW(hdir, buf, len(buf),
-                                          0) # VOLUME_NAME_DOS
+                                          0)  # VOLUME_NAME_DOS
             ctypes.windll.kernel32.CloseHandle(hdir)
             if res == 0:
                 # Conversion failed (e.g. network location)
@@ -91,34 +94,36 @@ def _fix_tcl_lib():
                 s = "\\" + s[3:]
             return s
 
-    prefix = os.path.join(sys.prefix,"tcl")
+    prefix = os.path.join(sys.prefix, "tcl")
     if not os.path.exists(prefix):
         # devdir/../tcltk/lib
         prefix = os.path.join(sys.prefix, os.path.pardir, "tcltk", "lib")
         prefix = os.path.abspath(prefix)
+
     # if this does not exist, no further search is needed
     if os.path.exists(prefix):
         prefix = convert_path(prefix)
+
         if "TCL_LIBRARY" not in os.environ:
             for name in os.listdir(prefix):
                 if name.startswith("tcl"):
-                    tcldir = os.path.join(prefix,name)
+                    tcldir = os.path.join(prefix, name)
                     if os.path.isdir(tcldir):
                         os.environ["TCL_LIBRARY"] = tcldir
-        # Compute TK_LIBRARY, knowing that it has the same version
-        # as Tcl
+
+        # Compute TK_LIBRARY, knowing that it has the same version as Tcl
         import _tkinter
         ver = str(_tkinter.TCL_VERSION)
         if "TK_LIBRARY" not in os.environ:
             v = os.path.join(prefix, 'tk'+ver)
             if os.path.exists(os.path.join(v, "tclIndex")):
                 os.environ['TK_LIBRARY'] = v
-        # We don't know the Tix version, so we must search the entire
-        # directory
+
+        # We don't know the Tix version, so we must search the entire directory
         if "TIX_LIBRARY" not in os.environ:
             for name in os.listdir(prefix):
                 if name.startswith("tix"):
-                    tixdir = os.path.join(prefix,name)
+                    tixdir = os.path.join(prefix, name)
                     if os.path.isdir(tixdir):
                         os.environ["TIX_LIBRARY"] = tixdir
 
@@ -150,7 +155,7 @@ KEYMAP = {
     65307: keys.ESCAPE,
     65288: keys.BACKSPACE,
 
-       32: keys.SPACE,
+    32:    keys.SPACE,
     65293: keys.ENTER,
     65289: keys.TAB,
 
@@ -185,9 +190,9 @@ KEY_STATE_MAP = {
 
 # e.num -> vispy
 MOUSE_BUTTON_MAP = {
-    1:1, # Mouse Left   == 1 -> Mouse Left
-    2:3, # Mouse Middle == 2 -> Mouse Middle
-    3:2, # Mouse Right  == 3 -> Mouse Right
+    1: 1,  # Mouse Left   == 1 -> Mouse Left
+    2: 3,  # Mouse Middle == 2 -> Mouse Middle
+    3: 2,  # Mouse Right  == 3 -> Mouse Right
 }
 
 # -------------------------------------------------------------- capability ---
@@ -199,7 +204,7 @@ capability = dict(
     title=True,           # can set title on the fly
     size=True,            # can set size on the fly
     position=True,        # can set position on the fly
-    show=True,            # can show/hide window XXX ?
+    show=True,            # can show/hide window
     vsync=False,          # can set window to sync to blank
     resizable=True,       # can toggle resizability (e.g., no user resizing)
     decorate=True,        # can toggle decorations
@@ -214,7 +219,9 @@ capability = dict(
 
 # ------------------------------------------------------- set_configuration ---
 def _set_config(c):
-    """Set gl configuration for template"""
+    """Set gl configuration for template.
+    Currently not used for Tkinter backend.
+    """
     return []
 
 
@@ -226,7 +233,13 @@ _tk_toplevels = []      # References to created CanvasBackend Toplevels
 
 
 def _new_toplevel(self, *args, **kwargs):
-    """Create and return a new withdrawn Toplevel."""
+    """
+    Create and return a new withdrawn Toplevel.
+    Create a tk.Toplevel with the given args and kwargs,
+    minimize it and add it to the global list before returning.
+
+    :return: Return the created tk.Toplevel
+    """
     global _tk_inst, _tk_toplevels
     tl = tk.Toplevel(_tk_inst, *args, **kwargs)
     tl.withdraw()
@@ -238,6 +251,8 @@ def _del_toplevel(tl=None):
     """
     Destroy the given Toplevel, and if it was the last one,
     also destroy the global Tk instance if we created it.
+
+    :param tl: The Toplevel to destroy, defaults to None
     """
     global _tk_inst, _tk_inst_owned, _tk_toplevels
 
@@ -245,7 +260,8 @@ def _del_toplevel(tl=None):
         try:
             tl.destroy()
             _tk_toplevels.remove(tl)
-        except: pass
+        except Exception:
+            pass
 
     # If there are no Toplevels left, quit the mainloop.
     if _tk_inst and not _tk_toplevels and _tk_inst_owned:
@@ -262,6 +278,11 @@ class ApplicationBackend(BaseApplicationBackend):
         return tk.__name__
 
     def _vispy_process_events(self):
+        """Process events related to the spawned Tk application window.
+        First, update the global tk.Tk() instance, then call `_delayed_update`
+        on every created Toplevel (to force a redraw), and process some Tkinter
+        GUI events by calling the Tk.mainloop and immediately exiting.
+        """
         # Update idle tasks first (probably not required)
         app = self._vispy_get_native_app()
         app.update_idletasks()
@@ -276,15 +297,23 @@ class ApplicationBackend(BaseApplicationBackend):
         app.mainloop()
 
     def _vispy_run(self):
+        """Start the Tk.mainloop. This will block until all Tk windows are destroyed."""
         self._vispy_get_native_app().mainloop()
 
     def _vispy_quit(self):
-        global _tk_inst_windows
+        """Destroy each created Toplevel by calling _vispy_close on it.
+        If there are no Toplevels left, also destroy the global Tk instance.
+        """
+        global _tk_toplevels
         for c in _tk_toplevels:
             c._vispy_close()
         _del_toplevel()
 
     def _vispy_get_native_app(self):
+        """Get or create the global Tk instance.
+
+        :return: Returns the instance.
+        """
         global _tk_inst, _tk_inst_owned
         if _tk_inst is None:
             if tk._default_root:
@@ -303,13 +332,18 @@ class ApplicationBackend(BaseApplicationBackend):
 # ------------------------------------------------------------------ canvas ---
 
 class Coord:
+    """Helper to provide x, y, width, height subscripting on the same tuple."""
     def __init__(self, tup):
         self.x, self.y = tup
         self.width, self.height = tup
 
 
 class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
-    """ Tkinter backend for Canvas abstract class."""
+    """ Tkinter backend for Canvas abstract class.
+    Uses pyopengltk.OpenGLFrame as the internal tk.Frame instance that
+    is able to receive OpenGL draw commands and display the results,
+    while also being placeable in another Toplevel window.
+    """
 
     # args are for BaseCanvasBackend, kwargs are for us.
     def __init__(self, *args, **kwargs):
@@ -344,9 +378,13 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             # Create native window and master
             self.top = _new_toplevel(self)
 
-            if p.title:    self._vispy_set_title(p.title)
-            if p.size:     self._vispy_set_size(p.size[0], p.size[1])
-            if p.position: self._vispy_set_position(p.position[0], p.position[1])
+            # Check input args and call appropriate set-up functions.
+            if p.title:
+                self._vispy_set_title(p.title)
+            if p.size:
+                self._vispy_set_size(p.size[0], p.size[1])
+            if p.position:
+                self._vispy_set_position(p.position[0], p.position[1])
 
             self.top.update_idletasks()
 
@@ -363,18 +401,18 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
         else:
             # Use given parent as master
             self.top = None
-            parent   = p.parent
+            parent = p.parent
             self._fullscreen = False
 
         self._init = False
         self.is_destroyed = False
 
-        c = OpenGLFrame.__init__(self, parent, **kwargs)
+        OpenGLFrame.__init__(self, parent, **kwargs)
         if not hasattr(self, "_native_context") or self._native_context is None:
             self.tkMap(None)
             # Workaround to get OpenGLFrame.__context for reference here
             # if access would ever be needed from self._native_context.
-            # ERROR: Context sharing this way seems unsupported.
+            # WARNING: Context sharing this way seems unsupported.
             self._native_context = vars(self).get("_CanvasBackend__context", None)
 
         if self.top:
@@ -383,33 +421,39 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             self.pack(fill=tk.BOTH, expand=True)
 
             # Also bind the key events to the top window instead.
-            self.top.bind("<Any-KeyPress>"  , self._on_key_down)
+            self.top.bind("<Any-KeyPress>",   self._on_key_down)
             self.top.bind("<Any-KeyRelease>", self._on_key_up)
         else:
             # If no top, bind key events to the canvas itself.
-            self.bind("<Any-KeyPress>"  , self._on_key_down)
+            self.bind("<Any-KeyPress>",   self._on_key_down)
             self.bind("<Any-KeyRelease>", self._on_key_up)
 
-        self.bind("<Enter>"            , self._on_mouse_enter)
-        self.bind("<Motion>"           , self._on_mouse_move)
-        self.bind("<MouseWheel>"       , self._on_mouse_wheel)
-        self.bind("<Any-Button>"       , self._on_mouse_button_press)
+        # Bind the other events to our internal methods.
+        self.bind("<Enter>",             self._on_mouse_enter)
+        self.bind("<Motion>",            self._on_mouse_move)
+        self.bind("<MouseWheel>",        self._on_mouse_wheel)
+        self.bind("<Any-Button>",        self._on_mouse_button_press)
         self.bind("<Double-Any-Button>", self._on_mouse_double_button_press)
         self.bind("<Any-ButtonRelease>", self._on_mouse_button_release)
-        self.bind("<Configure>"        , self._on_configure, add='+')
+        self.bind("<Configure>",         self._on_configure, add='+')
 
         self._vispy_set_visible(p.show)
         self.focus_force()
 
-
     def initgl(self):
-        # Overridden from OpenGLFrame
+        """Overridden from OpenGLFrame
+        Gets called on init or when the frame is remapped into its container.
+        """
         self.update_idletasks()
         GL.glClear(GL.GL_COLOR_BUFFER_BIT)
         GL.glClearColor(0.0, 0.0, 0.0, 0.0)
 
     def redraw(self, *args):
-        # Overridden from OpenGLFrame
+        """Overridden from OpenGLFrame
+        Gets called when the OpenGLFrame redraws itself.
+        It will set the current buffer, call self.redraw() and
+        swap buffers afterwards.
+        """
         if self._vispy_canvas is None:
             return
         if not self._init:
@@ -420,9 +464,11 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
     def _delayed_update(self):
         """
         Expose a new frame to the canvas. This will call self.redraw() internally.
+
         The self.animate sets the refresh rate in milliseconds. Using this is not
         necessary because VisPy will use the TimerBackend to periodically call
         self._vispy_update, resulting in the exact same behaviour.
+        So we set it to `0` to tell OpenGLFrame not to redraw itself on its own.
         """
         if self.is_destroyed:
             return
@@ -430,11 +476,13 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
         self.tkExpose(None)
 
     def _on_configure(self, e):
+        """Called when the frame get configured or resized."""
         if self._vispy_canvas is None or not self._init:
             return
         self._vispy_canvas.events.resize(size=(e.width, e.height))
 
     def _initialize(self):
+        """Initialise the Canvas for drawing."""
         self.initgl()
         if self._vispy_canvas is None:
             return
@@ -445,17 +493,36 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
         self._on_configure(Coord(self._vispy_get_size()))
 
     def _vispy_warmup(self):
+        """Provided for VisPy tests, so they can 'warm the canvas up'.
+        Mostly taken from the wxWidgets backend.
+        """
+        global _tk_inst
+
         etime = time() + 0.3
         while time() < etime:
             sleep(0.01)
             self._vispy_canvas.set_current()
             self._vispy_canvas.app.process_events()
 
+            _tk_inst.after(0, lambda: _tk_inst.quit())
+            _tk_inst.mainloop()
+
     def _parse_state(self, e):
-        return [ key for mask, key in KEY_STATE_MAP.items() \
-                    if e.state & mask]
+        """Helper to parse event.state into modifier keys.
+
+        :param e:   A Tk.Event instance.
+        :return:    Returns a list of modifier keys that are active (from vispy's keys)
+        """
+        return [key for mask, key in KEY_STATE_MAP.items() if e.state & mask]
 
     def _parse_keys(self, e):
+        """Helper to parse key states into Vispy keys.
+
+        :param e:   A Tk.Event instance.
+        :return:    Return a tuple (key.Key(), chr(key)),
+                    which has the vispy key object and the
+                    character representation if available.
+        """
         if e.keysym_num in KEYMAP:
             return KEYMAP[e.keysym_num], ""
         # e.char, e.keycode, e.keysym, e.keysym_num
@@ -468,18 +535,21 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             return None, None
 
     def _on_mouse_enter(self, e):
+        """Event callback when the mouse enters the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_mouse_move(
             pos=(e.x, e.y), modifiers=self._parse_state(e))
 
     def _on_mouse_move(self, e):
+        """Event callback when the mouse is moved within the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_mouse_move(
             pos=(e.x, e.y), modifiers=self._parse_state(e))
 
     def _on_mouse_wheel(self, e):
+        """Event callback when the mouse wheel changes within the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_canvas.events.mouse_wheel(
@@ -487,32 +557,37 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             pos=(e.x, e.y), modifiers=self._parse_state(e))
 
     def _on_mouse_button_press(self, e):
+        """Event callback when a mouse button is pressed within the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_mouse_press(
             pos=(e.x, e.y), button=MOUSE_BUTTON_MAP[e.num], modifiers=self._parse_state(e))
 
     def _vispy_detect_double_click(self, e):
-        # Override base class function
-        # since double click handling is native in Tk.
+        """Override base class function
+        since double click handling is native in Tk."""
         pass
 
     def _on_mouse_double_button_press(self, e):
+        """Event callback when a mouse button is double clicked within the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_mouse_double_click(
             pos=(e.x, e.y), button=MOUSE_BUTTON_MAP[e.num], modifiers=self._parse_state(e))
 
     def _on_mouse_button_release(self, e):
+        """Event callback when a mouse button is released within the canvas."""
         if self._vispy_canvas is None:
             return
         self._vispy_mouse_release(
             pos=(e.x, e.y), button=MOUSE_BUTTON_MAP[e.num], modifiers=self._parse_state(e))
 
     def _on_key_down(self, e):
-        """Handle key press events.
+        """Event callback when a key is pressed within the canvas or window.
+
         Ignore keys.ESCAPE if this is an embedded canvas,
-        as this would make it unresponsive, while still being updateable.
+        as this would make it unresponsive (because it won't close the entire window),
+        while still being updateable.
         """
         if self._vispy_canvas is None:
             return
@@ -523,9 +598,11 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             key=key, text=text, modifiers=self._parse_state(e))
 
     def _on_key_up(self, e):
-        """Handle release events.
+        """Event callback when a key is released within the canvas or window.
+
         Ignore keys.ESCAPE if this is an embedded canvas,
-        as this would make it unresponsive, while still being updateable.
+        as this would make it unresponsive (because it won't close the entire window),
+        while still being updateable.
         """
         if self._vispy_canvas is None:
             return
@@ -536,31 +613,31 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             key=key, text=text, modifiers=self._parse_state(e))
 
     def _vispy_set_current(self):
-        # Make this the current context
+        """Make this the current context."""
         if not self.is_destroyed:
             self.tkMakeCurrent()
 
     def _vispy_swap_buffers(self):
-        # Swap front and back buffer
+        """Swap front and back buffer. This is done internally inside OpenGLFrame."""
         self._vispy_canvas.set_current()
 
     def _vispy_set_title(self, title):
-        # Set the window title. Has no effect for widgets
+        """Set the window title. Has no effect for widgets."""
         if self.top:
             self.top.title(title)
 
     def _vispy_set_size(self, w, h):
-        # Set size of the window. Has no effect for widgets
+        """Set size of the window. Has no effect for widgets."""
         if self.top:
             self.top.geometry(f"{w}x{h}")
 
     def _vispy_set_position(self, x, y):
-        # Set location of the window. Has no effect for widgets
+        """Set location of the window. Has no effect for widgets."""
         if self.top:
             self.top.geometry(f"+{x}+{y}")
 
     def _vispy_set_visible(self, visible):
-        # Show or hide the window. Has no effect for widgets
+        """Show or hide the window. Has no effect for widgets."""
         if self.top:
             if visible:
                 self.top.wm_deiconify()
@@ -570,24 +647,28 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
                 self.top.withdraw()
 
     def _vispy_set_fullscreen(self, fullscreen):
-        # Set the current fullscreen state.
-        # Has no effect for widgets. If you want it to become fullscreen,
-        # while embedded in another Toplevel window, you should make that
-        # window fullscreen instead.
+        """Set the current fullscreen state.
+
+        Has no effect for widgets. If you want it to become fullscreen,
+        while embedded in another Toplevel window, you should make that
+        window fullscreen instead.
+        """
         self._fullscreen = bool(fullscreen)
         if self.top:
             self._vispy_set_visible(True)
 
     def _vispy_update(self):
-        # Invoke a redraw
-        # Delay this by letting Tk call it later, even a delay of 0 will do.
-        # Doing this, prevents EventEmitter loops that are caused
-        # by wanting to draw too fast.
+        """Invoke a redraw
+
+        Delay this by letting Tk call it later, even a delay of 0 will do.
+        Doing this, prevents EventEmitter loops that are caused
+        by wanting to draw too fast.
+        """
         self.after(0, self._delayed_update)
 
     def _vispy_close(self):
-        """
-        Force the window to close, destroying the canvas in the process.
+        """Force the window to close, destroying the canvas in the process.
+
         When this was the last VisPy window, also quit the global Tk instance.
         This will not interfere if there is already another user window,
         unrelated top VisPy open.
@@ -598,19 +679,27 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             _del_toplevel(self)
 
     def destroy(self):
+        """Callback when the window gets closed.
+        Destroy the VisPy canvas by calling close on it.
+        """
         self._vispy_canvas.close()
 
     def _vispy_get_size(self):
-        # Should return widget size
-        if self.top: self.top.update_idletasks()
+        """Return the actual size of the frame."""
+        if self.top:
+            self.top.update_idletasks()
         return self.winfo_width(), self.winfo_height()
 
     def _vispy_get_position(self):
-        # Should return widget position
+        """Return the widget or window position."""
         return self.winfo_x(), self.winfo_y()
 
     def _vispy_get_fullscreen(self):
-        # Should return the current fullscreen state
+        """Return the last set full screen state, regardless if it's actually in that state.
+
+        When using the canvas as a widget, it will not go into fullscreen.
+        See _vispy_set_fullscreen
+        """
         return self._fullscreen
 
 
@@ -627,17 +716,24 @@ class TimerBackend(BaseTimerBackend):
         self.last_interval = 1
 
     def _vispy_start(self, interval):
-        """Use Tk.after to schedule timer events."""
+        """Start the timer.
+        Use Tk.after to schedule timer events.
+        """
         self._vispy_stop()
         self.last_interval = max(0, int(round(interval * 1000)))
         self._id = self._tk.after(self.last_interval, self._vispy_timeout)
 
     def _vispy_stop(self):
-        """Unschedule the previous callback if it exists."""
+        """Stop the timer.
+        Unschedule the previous callback if it exists.
+        """
         if self._id is not None:
             self._tk.after_cancel(self._id)
             self._id = None
 
     def _vispy_timeout(self):
+        """Callback when the timer finishes.
+        Also reschedules the next callback.
+        """
         self._vispy_timer._timeout()
         self._id = self._tk.after(self.last_interval, self._vispy_timeout)

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -64,8 +64,8 @@ def _fix_tcl_lib():
             return s
     else:
         def convert_path(s):
-            assert isinstance(s, str)   # sys.prefix contains only bytes
-            udir = s.decode("mbcs") if hasattr(s, "decode") else s
+            use_dec = hasattr(s, "decode")
+            udir = s.decode("mbcs") if use_dec else s
             hdir = ctypes.windll.kernel32.\
                 CreateFileW(udir, 0x80, # FILE_READ_ATTRIBUTES
                             1,          # FILE_SHARE_READ
@@ -83,11 +83,11 @@ def _fix_tcl_lib():
             if res == 0:
                 # Conversion failed (e.g. network location)
                 return s
-            s = buf[:res].encode("mbcs")
+            s = buf[:res].encode("mbcs") if use_dec else buf[:res]
             # Ignore leading \\?\
             if s.startswith("\\\\?\\"):
                 s = s[4:]
-            if s.startswith("UNC"):
+            if s.startswith(b"UNC"):
                 s = "\\" + s[3:]
             return s
 

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -27,6 +27,8 @@ try:
     _tk_pyopengltk_imported = False
 
     import tkinter as tk
+
+    # Explicitely use OpenGL here instead of gloo since pyopengltk will import it anyway.
     from OpenGL import GL
     import pyopengltk
 except (ModuleNotFoundError, ImportError):

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -87,7 +87,7 @@ def _fix_tcl_lib():
             # Ignore leading \\?\
             if s.startswith("\\\\?\\"):
                 s = s[4:]
-            if s.startswith(b"UNC"):
+            if s.startswith("UNC"):
                 s = "\\" + s[3:]
             return s
 

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -117,6 +117,32 @@ def _test_callbacks(canvas):
     elif 'osmesa' in backend_name.lower():
         # No events for osmesa backend
         pass
+    elif 'tk' in backend_name.lower():
+        event = namedtuple("event", [
+            "serial", "time", "type", "widget", 
+            "width", "height", 
+            "char", "keycode", "keysym", "keysym_num", "state",
+            "x", "y", "x_root", "y_root", "num", "delta"
+        ])
+
+        event.width, event.height = 10, 20
+        backend._on_configure(event)        # RESIZE
+        
+        event.x, event.y, event.state = 1, 1, 0x0
+        backend._on_mouse_enter(event)
+        backend._on_mouse_move(event)
+        
+        event.x, event.y, event.num = 1, 1, 1
+        backend._on_mouse_button_press(event)
+        backend._on_mouse_button_release(event)
+        backend._on_mouse_double_button_press(event)
+        
+        event.delta = 120
+        backend._on_mouse_wheel(event)
+        
+        event.keysym_num, event.keycode, event.state = 65362, 0, 0x0001 # SHIFT+UP
+        backend._on_key_down(event)
+        backend._on_key_up(event)
     else:
         raise ValueError
 
@@ -336,7 +362,7 @@ def test_fs():
     assert_equal(len(emit_list), 0)
     with use_log_level('warning', record=True, print_msg=False):
         # some backends print a warning b/c fullscreen can't be specified
-        with Canvas(fullscreen=0) as c:
+        with Canvas(fullscreen=True) as c:
             assert_equal(c.fullscreen, True)
 
 

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -140,7 +140,7 @@ def _test_callbacks(canvas):
         event.delta = 120
         backend._on_mouse_wheel(event)
         
-        event.keysym_num, event.keycode, event.state = 65362, 0, 0x0001 # SHIFT+UP
+        event.keysym_num, event.keycode, event.state = 65362, 0, 0x0001  # SHIFT+UP
         backend._on_key_down(event)
         backend._on_key_up(event)
     else:

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -74,6 +74,10 @@ def test_context_sharing():
         if 'pyqt5' in c1.app.backend_name.lower():
             pytest.xfail("Context sharing is not supported in PyQt5 at this time.")
 
+        # Tkinter does not currently support context sharing
+        if 'tk' in c1.app.backend_name.lower():
+            pytest.xfail("Context sharing is not supported in Tkinter at this time.")
+
         # Check while c2 is active (with different context)
         with Canvas() as c2:
             # pyglet always shares

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -41,10 +41,10 @@ def test_context_properties():
                 props = get_gl_configuration()
             assert len(config) == n_items
             for key, val in config.items():
-                # XXX knownfail for windows samples, and wx (all platforms)
+                # XXX knownfail for windows samples, and wx/tkinter (all platforms)
                 if key == 'samples':
-                    iswx = a.backend_name.lower() == 'wx'
-                    if not (sys.platform.startswith('win') or iswx):
+                    will_fail_backend = a.backend_name.lower() in ('wx', 'tkinter')
+                    if not (sys.platform.startswith('win') or will_fail_backend):
                         assert val == props[key], key
     assert_raises(TypeError, Canvas, config='foo')
     assert_raises(KeyError, Canvas, config=dict(foo=True))


### PR DESCRIPTION
For my current project, it would be beneficial to be able to use VisPy within a Tkinter context, i.e. an OpenGL canvas controlled by VisPy embedded inside a Tkinter widget (tk.Frame).

For this purpose, I attempted to create a new backend to target Tkinter. However, it needs more work to to actually draw something.

The implementation tries to use [Jon Wright's pyopengltk](https://github.com/jonwright/pyopengltk) `OpenGLFrame`.

You can refer to [this Gist with example code](https://gist.github.com/Wosser1sProductions/620d2422a8a2f2529d01bf34e229d7ca) that shows how I might use it. For reference, everything works as expected using the Glfw backend, but this creates a new window naturally.
Using the tkinter backend, creates the frame that can be embedded, but it seems to stay black. Running `vispy.app.process_events()` is doing *something* as the GPU gets used, but the canvas stays black.

Any help would be appreciated, and would of course benefit the community as well.