### PR TITLE
Use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,7 @@ requires = [
     # "setuptools_scm[toml]>=3.4",
     "setuptools_scm_git_archive",
     "Cython>=0.29.2",
-    "numpy; python_version=='2.7'",
-    "numpy==1.13.3; python_version=='3.5'",
-    "numpy==1.13.3; python_version=='3.6'",
-    "numpy==1.14.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
+    "oldest-supported-numpy"
 ]
 
 [tools.setuptools_scm]


### PR DESCRIPTION
I've switched the pyproject.toml file to use the [oldest-supported-numpy](https://github.com/scipy/oldest-supported-numpy) meta-package which is equivalent to specifying all the environment markers (see the README for that project) but means that the pyproject.toml file here doesn't need to be updated in future when a new version of Python is released since this just requires a new release of oldest-supported-numpy.