### PR TITLE
Fix EGL docstring copy/paste error

### DIFF
--- a/vispy/ext/egl.py
+++ b/vispy/ext/egl.py
@@ -255,7 +255,7 @@ def eglInitialize(display):
 
 
 def eglTerminate(display):
-    """ Initialize EGL and return EGL version tuple.
+    """ Terminate an EGL display connection.
     """
     _lib.eglTerminate(display)
 


### PR DESCRIPTION
eglTerminate had the docstring of eglInitialize. Now replaced with the docstring as used in https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglTerminate.xhtml