### PR TITLE
Enable Python 3.9 wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
 variables:
   CIBW_BUILDING: "true"
-  CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp27-* pp36-* pp37-*"
+  CIBW_SKIP: "cp27-* cp34-* cp35-* pp27-* pp36-* pp37-*"
   CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow"
   CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
   CIBW_BUILD_VERBOSITY: "2"


### PR DESCRIPTION
If this works, we could backport to maint/0.6 and do a quick 0.6.7 release which includes 3.9 wheels?