### PR TITLE
Add totalRotationAngle and totalScaleFactor to touch (pinch) events.

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -517,13 +517,16 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
                 scale = gesture.scaleFactor()
                 last_scale = gesture.lastScaleFactor()
                 rotation = gesture.rotationAngle()
-                self._vispy_canvas.events.touch(type='pinch',
-                                                pos=(x, y),
-                                                last_pos=None,
-                                                scale=scale,
-                                                last_scale=last_scale,
-                                                rotation=rotation,
-                                                )
+                self._vispy_canvas.events.touch(
+                    type="pinch",
+                    pos=(x, y),
+                    last_pos=None,
+                    scale=scale,
+                    last_scale=last_scale,
+                    rotation=rotation,
+                    total_rotation_angle=gesture.totalRotationAngle(),
+                    total_scale_factor=gesture.totalScaleFactor(),
+                )
         # General touch event.
         elif (t == QtCore.QEvent.TouchUpdate):
             points = ev.touchPoints()


### PR DESCRIPTION
Those two are supposed to hold the total scale change and rotation
change since the beginning of the touch event, and are easier to
manipulate than to accumulate the delta changes.

Note that testing locally on MacOS 10.12 using a macbook pro with a
touchpad the rotation does not seem to follow the description of the Qt
framework. That is to say:

 - event.rotation: total rotation since begin event
 - event.scale: Change of scale since last event, generally between 0.95 and 1.05.
 - totalRotationAngle: Always 0 for me
 - totalScaleFactor: Total change of scale change since evt.type=begin event.

I still include those two, as in particular it seem on some devices you
can "interrupt" and "restart" a gesture; especially for rotation, and
even if totalRotationAngle seem broken on my end; totalScaleFactor is
useful.

Closes #1964