### PR TITLE
Add workaround for MacOS dlopen

### DIFF
--- a/vispy/ext/cocoapy.py
+++ b/vispy/ext/cocoapy.py
@@ -17,28 +17,25 @@ if sys.version_info[0] >= 3:
 else:
     string_types = basestring,  # noqa
 
+
 # handle dlopen cache changes in macOS 11 (Big Sur)
 # ref https://stackoverflow.com/questions/63475461/unable-to-import-opengl-gl-in-python-on-macos
 try:
-    import OpenGL as ogl
-    try:
-        import OpenGL.GL   # this fails in <=2020 versions of Python on OS X 11.x
-    except ImportError:
-        # print('Drat, patching for Big Sur')
-        from ctypes import util
-        orig_util_find_library = util.find_library
-        def new_util_find_library( name ):
-            res = orig_util_find_library( name )
-            if res: 
-                return res
-            lut = {
-                'objc': 'libobjc.dylib',
-                'quartz': 'Quartz.framework/Quartz'
-            }
-            return lut.get(name, name+'.framework/'+name)
-        util.find_library = new_util_find_library
+    import OpenGL.GL   # noqa
 except ImportError:
-    pass
+    # print('Drat, patching for Big Sur')
+    orig_util_find_library = util.find_library
+    
+    def new_util_find_library(name):
+        res = orig_util_find_library(name)
+        if res:
+            return res
+        lut = {
+            'objc': 'libobjc.dylib',
+            'quartz': 'Quartz.framework/Quartz'
+        }
+        return lut.get(name, name+'.framework/'+name)
+    util.find_library = new_util_find_library
 
 
 # Based on Pyglet code

--- a/vispy/ext/cocoapy.py
+++ b/vispy/ext/cocoapy.py
@@ -17,6 +17,30 @@ if sys.version_info[0] >= 3:
 else:
     string_types = basestring,  # noqa
 
+# handle dlopen cache changes in macOS 11 (Big Sur)
+# ref https://stackoverflow.com/questions/63475461/unable-to-import-opengl-gl-in-python-on-macos
+try:
+    import OpenGL as ogl
+    try:
+        import OpenGL.GL   # this fails in <=2020 versions of Python on OS X 11.x
+    except ImportError:
+        # print('Drat, patching for Big Sur')
+        from ctypes import util
+        orig_util_find_library = util.find_library
+        def new_util_find_library( name ):
+            res = orig_util_find_library( name )
+            if res: 
+                return res
+            lut = {
+                'objc': 'libobjc.dylib',
+                'quartz': 'Quartz.framework/Quartz'
+            }
+            return lut.get(name, name+'.framework/'+name)
+        util.find_library = new_util_find_library
+except ImportError:
+    pass
+
+
 # Based on Pyglet code
 
 ##############################################################################
@@ -106,7 +130,7 @@ if sizeof(c_void_p) == 4:
 elif sizeof(c_void_p) == 8:
     c_ptrdiff_t = c_int64
 
-objc = cdll.LoadLibrary(util.find_library('objc') or 'libobjc.dylib')
+objc = cdll.LoadLibrary(util.find_library('objc'))
 
 objc.class_addIvar.restype = c_bool
 objc.class_addIvar.argtypes = [c_void_p, c_char_p, c_size_t, c_uint8, c_char_p]
@@ -920,7 +944,7 @@ class ObjCSubclass(object):
 ##############################################################################
 # cocoalibs.py
 
-cf = cdll.LoadLibrary(util.find_library('CoreFoundation') or 'CoreFoundation.framework/CoreFoundation')
+cf = cdll.LoadLibrary(util.find_library('CoreFoundation'))
 
 kCFStringEncodingUTF8 = 0x08000100
 
@@ -1120,7 +1144,7 @@ cf.CFShow.argtypes = [c_void_p]
 
 # Even though we don't use this directly, it must be loaded so that
 # we can find the NSApplication, NSWindow, and NSView classes.
-appkit = cdll.LoadLibrary(util.find_library('AppKit') or 'AppKit.framework/AppKit')
+appkit = cdll.LoadLibrary(util.find_library('AppKit'))
 
 NSDefaultRunLoopMode = c_void_p.in_dll(appkit, 'NSDefaultRunLoopMode')
 NSEventTrackingRunLoopMode = c_void_p.in_dll(
@@ -1261,7 +1285,7 @@ NSApplicationActivationPolicyProhibited = 2
 
 # QUARTZ / COREGRAPHICS
 
-quartz = cdll.LoadLibrary(util.find_library('quartz') or 'Quartz.framework/Quartz')
+quartz = cdll.LoadLibrary(util.find_library('quartz'))
 
 CGDirectDisplayID = c_uint32     # CGDirectDisplay.h
 CGError = c_int32                # CGError.h
@@ -1431,7 +1455,7 @@ quartz.CGDisplayBounds.restype = CGRect
 ######################################################################
 
 # CORETEXT
-ct = cdll.LoadLibrary(util.find_library('CoreText') or 'CoreText.framework/CoreText')
+ct = cdll.LoadLibrary(util.find_library('CoreText'))
 
 # Types
 CTFontOrientation = c_uint32      # CTFontDescriptor.h

--- a/vispy/ext/cocoapy.py
+++ b/vispy/ext/cocoapy.py
@@ -106,7 +106,7 @@ if sizeof(c_void_p) == 4:
 elif sizeof(c_void_p) == 8:
     c_ptrdiff_t = c_int64
 
-objc = cdll.LoadLibrary(util.find_library('objc'))
+objc = cdll.LoadLibrary(util.find_library('objc') or 'libobjc.dylib')
 
 objc.class_addIvar.restype = c_bool
 objc.class_addIvar.argtypes = [c_void_p, c_char_p, c_size_t, c_uint8, c_char_p]
@@ -920,7 +920,7 @@ class ObjCSubclass(object):
 ##############################################################################
 # cocoalibs.py
 
-cf = cdll.LoadLibrary(util.find_library('CoreFoundation'))
+cf = cdll.LoadLibrary(util.find_library('CoreFoundation') or 'CoreFoundation.framework/CoreFoundation')
 
 kCFStringEncodingUTF8 = 0x08000100
 
@@ -1120,7 +1120,7 @@ cf.CFShow.argtypes = [c_void_p]
 
 # Even though we don't use this directly, it must be loaded so that
 # we can find the NSApplication, NSWindow, and NSView classes.
-appkit = cdll.LoadLibrary(util.find_library('AppKit'))
+appkit = cdll.LoadLibrary(util.find_library('AppKit') or 'AppKit.framework/AppKit')
 
 NSDefaultRunLoopMode = c_void_p.in_dll(appkit, 'NSDefaultRunLoopMode')
 NSEventTrackingRunLoopMode = c_void_p.in_dll(
@@ -1261,7 +1261,7 @@ NSApplicationActivationPolicyProhibited = 2
 
 # QUARTZ / COREGRAPHICS
 
-quartz = cdll.LoadLibrary(util.find_library('quartz'))
+quartz = cdll.LoadLibrary(util.find_library('quartz') or 'Quartz.framework/Quartz')
 
 CGDirectDisplayID = c_uint32     # CGDirectDisplay.h
 CGError = c_int32                # CGError.h
@@ -1431,7 +1431,7 @@ quartz.CGDisplayBounds.restype = CGRect
 ######################################################################
 
 # CORETEXT
-ct = cdll.LoadLibrary(util.find_library('CoreText'))
+ct = cdll.LoadLibrary(util.find_library('CoreText') or 'CoreText.framework/CoreText')
 
 # Types
 CTFontOrientation = c_uint32      # CTFontDescriptor.h


### PR DESCRIPTION
Adapted stackoverflow monkeypatch to ctypes.util.find_library for macOS 11 (Big Sur).
This gates off OpenGL.GL dlopen failure and uses a 2-entry lookup for quartz and objc exception cases. 
Should be backward compatible and is likely to work on both x86 and and m1 macOS.
Tested on x86 macOS 11.1 with `alpha-pyside2.py` test case.