### PR TITLE
Allow custom events (touch, pinch...) propagation

### DIFF
--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -125,6 +125,7 @@ class SceneCanvas(app.Canvas, Frozen):
         self._mouse_handler = None
         self.transforms = TransformSystem(canvas=self)
         self._bgcolor = Color(bgcolor).rgba
+        self._deliver_types = ['mouse_press', 'mouse_wheel']
         
         # Set to True to enable sending mouse events even when no button is
         # pressed. Disabled by default because it is very expensive. Also
@@ -334,7 +335,7 @@ class SceneCanvas(app.Canvas, Frozen):
 
     def _process_mouse_event(self, event):
         prof = Profiler()  # noqa
-        deliver_types = ['mouse_press', 'mouse_wheel']
+        deliver_types = self._deliver_types
         if self._send_hover_events:
             deliver_types += ['mouse_move']
 
@@ -356,12 +357,12 @@ class SceneCanvas(app.Canvas, Frozen):
             # receive the event
             if event.type == 'mouse_release':
                 self._mouse_handler = None
-            getattr(picked.events, event.type)(scene_event)
+            getattr(picked.events, event.type, lambda _:None)(scene_event)
         else:
             # If we don't have a mouse handler, then pass the event through
             # the chain of parents until a node accepts the event.
             while picked is not None:
-                getattr(picked.events, event.type)(scene_event)
+                getattr(picked.events, event.type, lambda _:None)(scene_event)
                 if scene_event.handled:
                     if event.type == 'mouse_press':
                         self._mouse_handler = picked


### PR DESCRIPTION
With this a custom canvas, with

    self._deliver_types.append('pinch')

And camera with for example

    def _viewbox_set(self, viewbox):
        super()._viewbox_set(viewbox)
        viewbox.events.add(pinch=Event)
        viewbox.events.pinch.connect(self.viewbox_pinch_event)

    def _viewbox_unset(self, viewbox):
        viewbox.events.pinch.disconnect(self.viewbox_pinch_event)
        super()._viewbox_unset(viewbox)

    def viewbox_pinch_event(self, event):
        if event.type == 'pinch':
            center = self._scene_transform.imap(event.pos)

Alternative is to reimplement most of the canvas process_mouse_event in
a _process_touch_event, or similar, while here we can simply in the
canvas:

   self.events.touch.connect(self._process_mouse_event)

----

I of course welcome suggestion of alternatives; as I'm still getting familiar with the code base. 

in particular this could be used to generalize :
```
if self._send_hover_events:
            deliver_types += ['mouse_move']
```
            

I would also understand why not; `touch` events do not always have the same structure as  mouse events, in particular they do not have `button` attribute. 

In napari this allowed me to implement panning and zooming using 2 finger gesture (scroll and pinch), without modifiers or click; which I find is a great improvement for user interface. I'm happy to also contribute (some of) those changes, directly to the pan/zoom camera is you think they are of interest. 

If course, 2 finger to pan is a "mouse_wheel" event, but touch/pinch will likely only trigger on compatible devices. 