### PR TITLE
enforce same type for norm and renorm so that ufunc true_divide doesn't error

### DIFF
--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -340,6 +340,7 @@ class MeshData(object):
                 norm = norms.sum(axis=0)  # sum normals
                 renorm = (norm**2).sum()**0.5
                 if renorm > 0:
+                    norm = norm.astype(renorm.dtype)
                     norm /= renorm
                 self._vertex_normals[vindex] = norm
 

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -228,7 +228,7 @@ class MeshData(object):
         """
         if indexed is None:
             if verts is not None:
-                self._vertices = verts
+                self._vertices = verts.astype(np.float32)
             self._vertices_indexed_by_faces = None
         elif indexed == 'faces':
             self._vertices = None
@@ -340,7 +340,6 @@ class MeshData(object):
                 norm = norms.sum(axis=0)  # sum normals
                 renorm = (norm**2).sum()**0.5
                 if renorm > 0:
-                    # norm = norm.astype(renorm.dtype)
                     norm /= renorm
                 self._vertex_normals[vindex] = norm
 

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -340,7 +340,7 @@ class MeshData(object):
                 norm = norms.sum(axis=0)  # sum normals
                 renorm = (norm**2).sum()**0.5
                 if renorm > 0:
-                    norm = norm.astype(renorm.dtype)
+                    # norm = norm.astype(renorm.dtype)
                     norm /= renorm
                 self._vertex_normals[vindex] = norm
 


### PR DESCRIPTION
Hi! First, thanks for vispy 🥰 
I came across a bug when trying to use expose the different shading modes with meshes in napari, traceback below

```python
WARNING: Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/app/backends/_qt.py", line 825, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/util/event.py", line 455, in __call__
    self._invoke_callback(cb, event)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/util/event.py", line 473, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/util/event.py", line 471, in _invoke_callback
    cb(event)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/scene/canvas.py", line 217, in on_draw
    self._draw_scene()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/scene/canvas.py", line 266, in _draw_scene
    self.draw_visual(self.scene)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/scene/canvas.py", line 304, in draw_visual
    node.draw()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/scene/visuals.py", line 99, in draw
    self._visual_superclass.draw(self)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/visuals/mesh.py", line 519, in draw
    Visual.draw(self, *args, **kwds)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/visuals/visual.py", line 435, in draw
    if self._prepare_draw(view=self) is False:
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/visuals/mesh.py", line 514, in _prepare_draw
    if self._update_data() is False:
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/visuals/mesh.py", line 360, in _update_data
    self._normals.set_data(md.get_vertex_normals(), convert=True)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/napari/lib/python3.9/site-packages/vispy/geometry/meshdata.py", line 346, in get_vertex_normals
    norm /= renorm
TypeError: ufunc 'true_divide' output (typecode 'd') could not be coerced to provided output parameter (typecode 'l') according to the casting rule ''same_kind''
Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```

I guess this is happening because my inputs have dtype int64 (for a very simple test mesh)
```python
vertices = np.array([[0, 0, 0], [0, 20, 10], [10, 0, -10], [10, 10, -10]])
faces = np.array([[0, 1, 2], [1, 2, 3]])
```

I enforced the same type for `norm` and `renorm` in `MeshData.get_vertex_normals()` and the problem went away so here's a PR - can change if there's a different way you'd like to solve this issue though!