### PR TITLE
Identify and expose Phong shading parameters in mesh ShadingFilter

### DIFF
--- a/examples/basics/scene/mesh_shading.py
+++ b/examples/basics/scene/mesh_shading.py
@@ -21,16 +21,18 @@ view = canvas.central_widget.add_view()
 view.camera = 'arcball'
 view.camera.depth_value = 1e3
 
-# Keep the shading off here to manually manage the shading filter below for
-# demonstration purposes. Otherwise, with `shading=flat` or `shading=smooth`,
-# the Mesh class would take care of managing the filter.
-mesh = Mesh(vertices, faces, color=(.5, .7, .5, 1), shading=None)
+# Create a colored `MeshVisual`.
+mesh = Mesh(vertices, faces, color=(.5, .7, .5, 1))
 view.add(mesh)
 
+# Use filters to affect the rendering of the mesh.
 wireframe_filter = WireframeFilter(width=args.wireframe_width)
+# Note: For convenience, this `ShadingFilter` would be created automatically by
+# the `MeshVisual with, e.g. `mesh = MeshVisual(..., shading='smooth')`. It is
+# created manually here for demonstration purposes.
 shading_filter = ShadingFilter(shininess=args.shininess)
-# Note: The wireframe filter is attached before the shading filter otherwise
-# the wireframe is not shaded.
+# The wireframe filter is attached before the shading filter otherwise the
+# wireframe is not shaded.
 mesh.attach(wireframe_filter)
 mesh.attach(shading_filter)
 

--- a/examples/basics/scene/mesh_shading.py
+++ b/examples/basics/scene/mesh_shading.py
@@ -24,10 +24,12 @@ view.camera.depth_value = 1e3
 mesh = Mesh(vertices, faces, color=(.5, .7, .5, 1))
 view.add(mesh)
 
-shading_filter = ShadingFilter(shininess=args.shininess)
-mesh.attach(shading_filter)
 wireframe_filter = WireframeFilter(width=args.wireframe_width)
+shading_filter = ShadingFilter(shininess=args.shininess)
+# Note: The wireframe filter is attached before the shading filter otherwise
+# the wireframe is not shaded.
 mesh.attach(wireframe_filter)
+mesh.attach(shading_filter)
 
 
 def attach_headlight(view):

--- a/examples/basics/scene/mesh_shading.py
+++ b/examples/basics/scene/mesh_shading.py
@@ -21,7 +21,10 @@ view = canvas.central_widget.add_view()
 view.camera = 'arcball'
 view.camera.depth_value = 1e3
 
-mesh = Mesh(vertices, faces, color=(.5, .7, .5, 1))
+# Keep the shading off here to manually manage the shading filter below for
+# demonstration purposes. Otherwise, with `shading=flat` or `shading=smooth`,
+# the Mesh class would take care of managing the filter.
+mesh = Mesh(vertices, faces, color=(.5, .7, .5, 1), shading=None)
 view.add(mesh)
 
 wireframe_filter = WireframeFilter(width=args.wireframe_width)

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -219,7 +219,7 @@ void shade() {
 
 
 class ShadingFilter(Filter):
-    """Filter to apply shading to a mesh.
+    """Apply lighting to a mesh with the Phong reflection model.
 
     To disable shading, either detach (ex. ``mesh.detach(filter_obj)``) or
     set the shading type to ``None`` (ex. ``filter_obj.shading = None``).
@@ -227,6 +227,33 @@ class ShadingFilter(Filter):
     The shading filter should be attached after the other filters that modify
     the colors to be shaded. For example, to include the wireframe in the
     shading, the shading filter must come before the wireframe filter.
+
+    The light and reflection parameters are defined as RGBA colors with the
+    alpha channel controlling the intensity of the light or reflection. The
+    default intensity is 1.
+
+    Parameters
+    ----------
+    mode : str
+        Lighting mode: None, 'flat' or 'smooth'. If None, the lighting is
+        disabled.
+    light_dir : array-like
+        Direction of the light. Assuming a directional light.
+    ambient_light : str or tuple or Color
+        Color and intensity of the ambient light
+    diffuse_light : str or tuple or Color
+        Color and intensity of the diffuse light
+    specular_light : str or tuple or Color
+        Color and intensity of the specular light
+    ambient_coefficient : str or tuple or Color
+        Color and intensity of the ambient reflection coefficient (Ka)
+    diffuse_coefficient : str or tuple or Color
+        Color and intensity of the diffuse reflection coefficient (Kd)
+    specular_coefficient : str or tuple or Color
+        Color and intensity of the specular reflection coefficient (Ks)
+    shininess : float
+        The higher the shininess, the more localized the specular highlight.
+        Must be greater of equal to zero.
 
     Examples
     --------

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -205,7 +205,10 @@ void shade() {
     }
     vec3 specular = specular_factor * specular_coeff * specular_light_intensity;
 
+    // XXX(asnt): Not sure if there is a physically more correct way of
+    // blending the base color with the lighting.
     vec3 color = base_color * (ambient + diffuse) + specular;
+    //vec3 color = base_color * (ambient + diffuse + specular);
     gl_FragColor.rgb = color;
 }
 """  # noqa

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
+import numbers
+
 import numpy as np
+
 from vispy.gloo import Texture2D, VertexBuffer
 from vispy.visuals.shaders import Function, Varying
 from vispy.visuals.filters import Filter
@@ -309,15 +312,20 @@ class ShadingFilter(Filter):
                  shininess=100):
         self._shading = shading
         self._light_dir = light_dir
-        # TODO: Accept a single float in [0, 1] instead of a full color for
-        # convenience. Set the color to (1, 1, 1) and the alpha channel to the
-        # float value.
-        self._ambient_light = Color(ambient_light)
-        self._diffuse_light = Color(diffuse_light)
-        self._specular_light = Color(specular_light)
-        self._ambient_coefficient = Color(ambient_coefficient)
-        self._diffuse_coefficient = Color(diffuse_coefficient)
-        self._specular_coefficient = Color(specular_coefficient)
+
+        def _as_rgba(intensity_or_color):
+            if isinstance(intensity_or_color, numbers.Number):
+                intensity = intensity_or_color
+                return Color((1, 1, 1, intensity))
+            color = intensity_or_color
+            return Color(color)
+
+        self._ambient_light = _as_rgba(ambient_light)
+        self._diffuse_light = _as_rgba(diffuse_light)
+        self._specular_light = _as_rgba(specular_light)
+        self._ambient_coefficient = _as_rgba(ambient_coefficient)
+        self._diffuse_coefficient = _as_rgba(diffuse_coefficient)
+        self._specular_coefficient = _as_rgba(specular_coefficient)
         self._shininess = shininess
 
         vfunc = Function(shading_vertex_template)

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -205,7 +205,7 @@ void shade() {
         specular_factor = pow(specular_factor, shininess);
     }
     vec3 specular = specular_factor * specular_coeff * specular_light.rgb
-                   * specular_light.a;
+                    * specular_light.a;
 
     // XXX(asnt): Not sure if there is a physically more correct way of
     // blending the base color with the lighting.

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -254,6 +254,47 @@ class ShadingFilter(Filter):
         The higher the shininess, the more localized the specular highlight.
         Must be greater of equal to zero.
 
+    Notes
+    -----
+
+    Under the Phong reflection model, the illumination `I` is computed as
+
+        `I = I_ambient + mesh_color * I_diffuse + I_specular`
+
+    for each color channel independently.
+    The mesh color is the base color of the mesh, possibly modified by the
+    filters applied before this one.
+    The ambient, diffuse and specular terms are defined as
+
+        `I_ambient = Ka * Ia`
+
+        `I_diffuse = Kd * Id * dot(L, N)`
+
+        `I_specular = Ks * Is * dot(R, V) ** s`
+
+    with
+
+    `L`
+        the light direction, assuming a directional light.
+    `N`
+        the normal to the surface at the reflection point,
+    `R`
+        the direction of the reflection,
+    `V`
+        the direction to the viewer,
+    `s`
+        the shininess factor s.
+
+    The `Ka`, `Kd` and `Ks` coefficients are defined as an RGBA color. The RGB
+    components define the color that the surface reflects, and the alpha
+    component (A) defines the intensity/attenuation of the reflection. When
+    applied in the per-channel illumation formulas above, the color component
+    is multiplied by the intensity to obtain the final coefficient, e.g.
+    `Kd = R * A` for the red channel.
+
+    Similarly, the light intensities, `Ia`, `Id` and `Is`, are defined by RGBA
+    colors, corresponding to the color of the light and its intensity.
+
     Examples
     --------
     See

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -231,7 +231,7 @@ class ShadingFilter(Filter):
     """
 
     def __init__(self, shading='flat', light_dir=(10, 5, -5),
-                 ambient_light=(1, 1, 1, .7),
+                 ambient_light=(1, 1, 1, .5),
                  diffuse_light=(1, 1, 1, .5),
                  specular_light=(1, 1, 1, .5),
                  ambient_coefficient=(1, 1, 1),

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -322,11 +322,7 @@ class ShadingFilter(Filter):
 
     @property
     def diffuse_coefficient(self):
-        """The diffuse reflection coefficient.
-
-        The diffuse reflection coefficient is multiplied with the mesh color.
-        With the defualt value (1, 1, 1), the mesh color is not modified.
-        """
+        """The diffuse reflection coefficient."""
         return self._diffuse_coefficient
 
     @diffuse_coefficient.setter

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -163,6 +163,7 @@ void shade() {
         return;
     }
 
+    vec3 base_color = gl_FragColor.rgb;
     vec3 ambient_coeff = $ambient_coefficient;
     vec3 diffuse_coeff = $diffuse_coefficient;
     vec3 specular_coeff = $specular_coefficient;
@@ -204,9 +205,8 @@ void shade() {
     }
     vec3 specular = specular_factor * specular_coeff * specular_light_intensity;
 
-    vec3 color = ambient + diffuse + specular;
+    vec3 color = base_color * (ambient + diffuse) + specular;
     gl_FragColor.rgb = color;
-
 }
 """  # noqa
 

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -252,7 +252,6 @@ class ShadingFilter(Filter):
 
     Notes
     -----
-
     Under the Phong reflection model, the illumination `I` is computed as
 
         `I = I_ambient + mesh_color * I_diffuse + I_specular`

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -274,6 +274,9 @@ class ShadingFilter(Filter):
         Color and intensity of the diffuse light.
     specular_light : str or tuple or Color
         Color and intensity of the specular light.
+    enabled : bool, default=True
+        Whether the filter is enabled at creation time. This can be changed at
+        run time with :obj:`~enabled`.
 
     Notes
     -----
@@ -366,7 +369,7 @@ class ShadingFilter(Filter):
                  ambient_coefficient=(1, 1, 1, 1),
                  diffuse_coefficient=(1, 1, 1, 1),
                  specular_coefficient=(1, 1, 1, 1),
-                 shininess=100):
+                 shininess=100, enabled=True):
         self._shading = shading
         self._light_dir = light_dir
 
@@ -378,6 +381,8 @@ class ShadingFilter(Filter):
         self._specular_coefficient = _as_rgba(specular_coefficient)
         self._shininess = shininess
 
+        self._enabled = enabled
+
         vfunc = Function(shading_vertex_template)
         ffunc = Function(shading_fragment_template)
 
@@ -385,6 +390,16 @@ class ShadingFilter(Filter):
         vfunc['normal'] = self._normals
 
         super().__init__(vcode=vfunc, fcode=ffunc)
+
+    @property
+    def enabled(self):
+        """True to enable the filter, False to disable."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+        self._update_data()
 
     @property
     def shading(self):
@@ -496,7 +511,9 @@ class ShadingFilter(Filter):
         self.fshader['shininess'] = self._shininess
 
         self.fshader['flat_shading'] = 1 if self._shading == 'flat' else 0
-        self.fshader['shading_enabled'] = 1 if self._shading is not None else 0
+        self.fshader['shading_enabled'] = (
+            1 if self._enabled and self._shading is not None else 0
+        )
 
         normals = self._visual.mesh_data.get_vertex_normals(indexed='faces')
         self._normals.set_data(normals, convert=True)

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -221,7 +221,7 @@ void shade() {
 
 
 class ShadingFilter(Filter):
-    """Apply lighting to a mesh with the Phong reflection model.
+    """Apply shading to a mesh with the Phong reflection model.
 
     To disable shading, either detach (ex. ``mesh.detach(filter_obj)``) or
     set the shading type to ``None`` (ex. ``filter_obj.shading = None``).
@@ -232,8 +232,8 @@ class ShadingFilter(Filter):
 
     Parameters
     ----------
-    mode : str
-        Lighting mode: None, 'flat' or 'smooth'. If None, the lighting is
+    shading : str
+        Shading mode: None, 'flat' or 'smooth'. If None, the shading is
         disabled.
     ambient_coefficient : str or tuple or Color
         Color and intensity of the ambient reflection coefficient (Ka).

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -411,7 +411,7 @@ class ShadingFilter(Filter):
 
     @property
     def shininess(self):
-        """The shininess."""
+        """The shininess controlling the spread of the specular highlight."""
         return self._shininess
 
     @shininess.setter

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -164,9 +164,9 @@ void shade() {
     }
 
     vec3 base_color = gl_FragColor.rgb;
-    vec3 ambient_coeff = $ambient_coefficient;
-    vec3 diffuse_coeff = $diffuse_coefficient;
-    vec3 specular_coeff = $specular_coefficient;
+    vec4 ambient_coeff = $ambient_coefficient;
+    vec4 diffuse_coeff = $diffuse_coefficient;
+    vec4 specular_coeff = $specular_coefficient;
     vec4 ambient_light = $ambient_light;
     vec4 diffuse_light = $diffuse_light;
     vec4 specular_light = $specular_light;
@@ -189,12 +189,14 @@ void shade() {
     vec3 light_vec = normalize(v_light_vec);
     vec3 eye_vec = normalize(v_eye_vec);
 
-    vec3 ambient = ambient_coeff * ambient_light.rgb * ambient_light.a;
+    vec3 ambient = ambient_coeff.rgb * ambient_coeff.a
+                   * ambient_light.rgb * ambient_light.a;
 
     float diffuse_factor = dot(light_vec, normal);
     diffuse_factor = max(diffuse_factor, 0.0);
-    vec3 diffuse = diffuse_factor * diffuse_coeff * diffuse_light.rgb
-                   * diffuse_light.a;
+    vec3 diffuse = diffuse_factor
+                   * diffuse_coeff.rgb * diffuse_coeff.a
+                   * diffuse_light.rgb * diffuse_light.a;
 
     float specular_factor = 0.0;
     bool is_illuminated = diffuse_factor > 0.0;
@@ -204,8 +206,9 @@ void shade() {
         specular_factor = max(specular_factor, 0.0);
         specular_factor = pow(specular_factor, shininess);
     }
-    vec3 specular = specular_factor * specular_coeff * specular_light.rgb
-                    * specular_light.a;
+    vec3 specular = specular_factor
+                    * specular_coeff.rgb * specular_coeff.a
+                    * specular_light.rgb * specular_light.a;
 
     // XXX(asnt): Not sure if there is a physically more correct way of
     // blending the base color with the lighting.
@@ -234,9 +237,9 @@ class ShadingFilter(Filter):
                  ambient_light=(1, 1, 1, .5),
                  diffuse_light=(1, 1, 1, .5),
                  specular_light=(1, 1, 1, .5),
-                 ambient_coefficient=(1, 1, 1),
-                 diffuse_coefficient=(1, 1, 1),
-                 specular_coefficient=(1, 1, 1),
+                 ambient_coefficient=(1, 1, 1, 1),
+                 diffuse_coefficient=(1, 1, 1, 1),
+                 specular_coefficient=(1, 1, 1, 1),
                  shininess=100):
         self._shading = shading
         self._light_dir = light_dir
@@ -360,9 +363,9 @@ class ShadingFilter(Filter):
         self.fshader['diffuse_light'] = self._diffuse_light.rgba
         self.fshader['specular_light'] = self._specular_light.rgba
 
-        self.fshader['ambient_coefficient'] = self._ambient_coefficient.rgb
-        self.fshader['diffuse_coefficient'] = self._diffuse_coefficient.rgb
-        self.fshader['specular_coefficient'] = self._specular_coefficient.rgb
+        self.fshader['ambient_coefficient'] = self._ambient_coefficient.rgba
+        self.fshader['diffuse_coefficient'] = self._diffuse_coefficient.rgba
+        self.fshader['specular_coefficient'] = self._specular_coefficient.rgba
         self.fshader['shininess'] = self._shininess
 
         self.fshader['flat_shading'] = 1 if self._shading == 'flat' else 0

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -207,8 +207,7 @@ void shade() {
 
     // XXX(asnt): Not sure if there is a physically more correct way of
     // blending the base color with the lighting.
-    vec3 color = base_color * (ambient + diffuse) + specular;
-    //vec3 color = base_color * (ambient + diffuse + specular);
+    vec3 color = base_color * (ambient + diffuse + specular);
     gl_FragColor.rgb = color;
 }
 """  # noqa

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -309,6 +309,9 @@ class ShadingFilter(Filter):
                  shininess=100):
         self._shading = shading
         self._light_dir = light_dir
+        # TODO: Accept a single float in [0, 1] instead of a full color for
+        # convenience. Set the color to (1, 1, 1) and the alpha channel to the
+        # float value.
         self._ambient_light = Color(ambient_light)
         self._diffuse_light = Color(diffuse_light)
         self._specular_light = Color(specular_light)

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -275,7 +275,7 @@ class ShadingFilter(Filter):
     with
 
     `L`
-        the light direction, assuming a directional light.
+        the light direction, assuming a directional light,
     `N`
         the normal to the surface at the reflection point,
     `R`

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -236,23 +236,23 @@ class ShadingFilter(Filter):
     mode : str
         Lighting mode: None, 'flat' or 'smooth'. If None, the lighting is
         disabled.
-    light_dir : array-like
+    ambient_coefficient : str or tuple or Color
+        Color and intensity of the ambient reflection coefficient (Ka).
+    diffuse_coefficient : str or tuple or Color
+        Color and intensity of the diffuse reflection coefficient (Kd).
+    specular_coefficient : str or tuple or Color
+        Color and intensity of the specular reflection coefficient (Ks).
+    shininess : float
+        The shininess controls the size of specular highlight. The higher, the
+        more localized.  Must be greater than or equal to zero.
+    light_dir : array_like
         Direction of the light. Assuming a directional light.
     ambient_light : str or tuple or Color
-        Color and intensity of the ambient light
+        Color and intensity of the ambient light.
     diffuse_light : str or tuple or Color
-        Color and intensity of the diffuse light
+        Color and intensity of the diffuse light.
     specular_light : str or tuple or Color
-        Color and intensity of the specular light
-    ambient_coefficient : str or tuple or Color
-        Color and intensity of the ambient reflection coefficient (Ka)
-    diffuse_coefficient : str or tuple or Color
-        Color and intensity of the diffuse reflection coefficient (Kd)
-    specular_coefficient : str or tuple or Color
-        Color and intensity of the specular reflection coefficient (Ks)
-    shininess : float
-        The higher the shininess, the more localized the specular highlight.
-        Must be greater of equal to zero.
+        Color and intensity of the specular light.
 
     Notes
     -----

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -362,24 +362,27 @@ class ShadingFilter(Filter):
     example script.
     """
 
-    def __init__(self, shading='flat', light_dir=(10, 5, -5),
-                 ambient_light=(1, 1, 1, 0),
-                 diffuse_light=(1, 1, 1, 1),
-                 specular_light=(1, 1, 1, .25),
+    def __init__(self, shading='flat',
                  ambient_coefficient=(1, 1, 1, 1),
                  diffuse_coefficient=(1, 1, 1, 1),
                  specular_coefficient=(1, 1, 1, 1),
-                 shininess=100, enabled=True):
+                 shininess=100,
+                 light_dir=(10, 5, -5),
+                 ambient_light=(1, 1, 1, 0),
+                 diffuse_light=(1, 1, 1, 1),
+                 specular_light=(1, 1, 1, .25),
+                 enabled=True):
         self._shading = shading
-        self._light_dir = light_dir
 
-        self._ambient_light = _as_rgba(ambient_light)
-        self._diffuse_light = _as_rgba(diffuse_light)
-        self._specular_light = _as_rgba(specular_light)
         self._ambient_coefficient = _as_rgba(ambient_coefficient)
         self._diffuse_coefficient = _as_rgba(diffuse_coefficient)
         self._specular_coefficient = _as_rgba(specular_coefficient)
         self._shininess = shininess
+
+        self._light_dir = light_dir
+        self._ambient_light = _as_rgba(ambient_light)
+        self._diffuse_light = _as_rgba(diffuse_light)
+        self._specular_light = _as_rgba(specular_light)
 
         self._enabled = enabled
 

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -227,10 +227,6 @@ class ShadingFilter(Filter):
     the colors to be shaded. For example, to include the wireframe in the
     shading, the shading filter must come before the wireframe filter.
 
-    The light and reflection parameters are defined as RGBA colors with the
-    alpha channel controlling the intensity of the light or reflection. The
-    default intensity is 1.
-
     Parameters
     ----------
     mode : str

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -211,9 +211,6 @@ void shade() {
                     * specular_coeff.rgb * specular_coeff.a
                     * specular_light.rgb * specular_light.a;
 
-    // XXX(asnt): Not sure if there is a physically more correct way of
-    // blending the base color with the lighting.
-    //vec3 color = base_color * (ambient + diffuse + specular);
     vec3 color = ambient + base_color * diffuse + specular;
     gl_FragColor.rgb = color;
 }

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -210,7 +210,8 @@ void shade() {
 
     // XXX(asnt): Not sure if there is a physically more correct way of
     // blending the base color with the lighting.
-    vec3 color = base_color * (ambient + diffuse + specular);
+    //vec3 color = base_color * (ambient + diffuse + specular);
+    vec3 color = ambient + base_color * diffuse + specular;
     gl_FragColor.rgb = color;
 }
 """  # noqa
@@ -263,9 +264,9 @@ class ShadingFilter(Filter):
     """
 
     def __init__(self, shading='flat', light_dir=(10, 5, -5),
-                 ambient_light=(1, 1, 1, .5),
-                 diffuse_light=(1, 1, 1, .5),
-                 specular_light=(1, 1, 1, .5),
+                 ambient_light=(1, 1, 1, 0),
+                 diffuse_light=(1, 1, 1, 1),
+                 specular_light=(1, 1, 1, .25),
                  ambient_coefficient=(1, 1, 1, 1),
                  diffuse_coefficient=(1, 1, 1, 1),
                  specular_coefficient=(1, 1, 1, 1),

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -184,7 +184,7 @@ void shade() {
 
     // Specular light component.
     float speculark = 0.0;
-    if ($shininess > 0) {
+    if (diffusek > 0.0 && $shininess > 0.0) {
         vec3 reflexion = reflect(light_vec, normal);
         speculark = dot(reflexion, v_eye_vec);
         speculark = max(speculark, 0.0);

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -134,12 +134,12 @@ void prepare_shading() {
     v_normal_vec = normal; //VARYING COPY
 
     vec4 pos_front = $scene2doc(pos_scene);
-    pos_front.z += 0.01;
+    pos_front.z += 1e-6;
     pos_front = $doc2scene(pos_front);
     pos_front /= pos_front.w;
 
     vec4 pos_back = $scene2doc(pos_scene);
-    pos_back.z -= 0.01;
+    pos_back.z -= 1e-6;
     pos_back = $doc2scene(pos_back);
     pos_back /= pos_back.w;
 

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -224,6 +224,10 @@ class ShadingFilter(Filter):
     To disable shading, either detach (ex. ``mesh.detach(filter_obj)``) or
     set the shading type to ``None`` (ex. ``filter_obj.shading = None``).
 
+    The shading filter should be attached after the other filters that modify
+    the colors to be shaded. For example, to include the wireframe in the
+    shading, the shading filter must come before the wireframe filter.
+
     Examples
     --------
     See
@@ -442,6 +446,9 @@ void draw_wireframe() {
 
 class WireframeFilter(Filter):
     """Add wireframe to a mesh.
+
+    The wireframe filter should be attached before the shading filter for the
+    wireframe to be shaded.
 
     Parameters
     ----------

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -190,18 +190,18 @@ void shade() {
     vec3 light_vec = normalize(v_light_vec);
     vec3 eye_vec = normalize(v_eye_vec);
 
-    # Ambient illumination.
+    // Ambient illumination.
     vec3 ambient = ambient_coeff.rgb * ambient_coeff.a
                    * ambient_light.rgb * ambient_light.a;
 
-    # Diffuse illumination.
+    // Diffuse illumination.
     float diffuse_factor = dot(light_vec, normal);
     diffuse_factor = max(diffuse_factor, 0.0);
     vec3 diffuse = diffuse_factor
                    * diffuse_coeff.rgb * diffuse_coeff.a
                    * diffuse_light.rgb * diffuse_light.a;
 
-    # Specular illumination.
+    // Specular illumination.
     float specular_factor = 0.0;
     bool is_illuminated = diffuse_factor > 0.0;
     if (is_illuminated && shininess > 0.0) {
@@ -214,7 +214,7 @@ void shade() {
                     * specular_coeff.rgb * specular_coeff.a
                     * specular_light.rgb * specular_light.a;
 
-    # Blend the base color and combine the illuminations.
+    // Blend the base color and combine the illuminations.
     vec3 color = ambient + base_color * diffuse + specular;
 
     gl_FragColor.rgb = color;

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -332,7 +332,7 @@ class ShadingFilter(Filter):
 
     @property
     def specular_coefficient(self):
-        """The specular light coefficient."""
+        """The specular reflection coefficient."""
         return self._specular_coefficient
 
     @specular_coefficient.setter

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -190,15 +190,18 @@ void shade() {
     vec3 light_vec = normalize(v_light_vec);
     vec3 eye_vec = normalize(v_eye_vec);
 
+    # Ambient illumination.
     vec3 ambient = ambient_coeff.rgb * ambient_coeff.a
                    * ambient_light.rgb * ambient_light.a;
 
+    # Diffuse illumination.
     float diffuse_factor = dot(light_vec, normal);
     diffuse_factor = max(diffuse_factor, 0.0);
     vec3 diffuse = diffuse_factor
                    * diffuse_coeff.rgb * diffuse_coeff.a
                    * diffuse_light.rgb * diffuse_light.a;
 
+    # Specular illumination.
     float specular_factor = 0.0;
     bool is_illuminated = diffuse_factor > 0.0;
     if (is_illuminated && shininess > 0.0) {
@@ -211,7 +214,9 @@ void shade() {
                     * specular_coeff.rgb * specular_coeff.a
                     * specular_light.rgb * specular_light.a;
 
+    # Blend the base color and combine the illuminations.
     vec3 color = ambient + base_color * diffuse + specular;
+
     gl_FragColor.rgb = color;
 }
 """  # noqa

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -295,11 +295,46 @@ class ShadingFilter(Filter):
 
     Examples
     --------
-    See
+    The :class:`vispy.visuals.mesh.MeshVisual` creates and embeds a shading
+    filter when constructed with an explicit `shading` parameter, e.g.
+    `shading='smooth'`. The filter is accessible through the property
+    `shading_filter` for further configuration:
+
+    >>> # A triangle.
+    >>> vertices = np.array([(0, 0, 0), (1, 1, 1), (0, 1, 0)], dtype=float)
+    >>> faces = np.array([(0, 1, 2)], dtype=int)
+    >>> # Request explicitly to create a filter with smooth shading:
+    >>> mesh = MeshVisual(vertices, faces, shading='smooth')
+    >>> # Configure the filter afterwards.
+    >>> mesh.shading_filter.shininess = 64
+    >>> mesh.shading_filter.specular_coefficient = 0.3
+
+    Create the shading filter manually and attach it to a
+    :class:`vispy.visuals.mesh.MeshVisual`:
+
+    >>> # With the default shading parameters.
+    >>> shading_filter = ShadingFilter()
+    >>> # Or, with some custom parameters:
+    >>> shading_filter = ShadingFilter(
+    ...     # A shiny surface (small specular highlight).
+    ...     shininess=250,
+    ...     # A blue higlight, at half intensity.
+    ...     specular_coefficient=(0, 0, 1, 0.5),
+    ...     # Equivalent to `(0.7, 0.7, 0.7, 1.0)`.
+    ...     diffuse_coefficient=0.7,
+    ...     # Same as `(0.2, 0.3, 0.3, 1.0)`.
+    ...     ambient_coefficient=(0.2, 0.3, 0.3),
+    ... )
+    >>> mesh = MeshVisual(vertices, faces)
+    >>> mesh.attach(shading_filter)
+    >>> # Further configure the filter through the custom instance:
+    >>> shading_filter.shininess = 64
+    >>> shading_filter.specular_coefficient = 0.3
+
+    See also
     `examples/basics/scene/mesh_shading.py
     <https://github.com/vispy/vispy/blob/main/examples/basics/scene/mesh_shading.py>`_
     example script.
-
     """
 
     def __init__(self, shading='flat', light_dir=(10, 5, -5),

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -220,6 +220,28 @@ void shade() {
 """  # noqa
 
 
+def _as_rgba(intensity_or_color, default_rgb=(1.0, 1.0, 1.0)):
+    """Create an RGBA color from a color or a scalar intensity.
+
+    Examples
+    --------
+    >>> # Specify the full RGBA color.
+    >>> _as_rgba((0.2, 0.3, 0.4, 0.25))
+    ... <Color: (0.2, 0.3, 0.4, 0.25)>
+    >>> # Specify an RGB color. (Default intensity `1.0` is used.)
+    >>> _as_rgba((0.2, 0.3, 0.4))
+    ... <Color: (0.2, 0.3, 0.4, 1.0)>
+    >>> # Specify an intensity only. (Default color `(1.0, 1.0, 1.0)` is used.)
+    >>> _as_rgba(0.25)
+    ... <Color: (1.0, 1.0, 1.0, 0.25)>
+    """
+    if isinstance(intensity_or_color, numbers.Number):
+        intensity = intensity_or_color
+        return Color(default_rgb, alpha=intensity)
+    color = intensity_or_color
+    return Color(color)
+
+
 class ShadingFilter(Filter):
     """Apply shading to a mesh with the Phong reflection model.
 
@@ -348,13 +370,6 @@ class ShadingFilter(Filter):
         self._shading = shading
         self._light_dir = light_dir
 
-        def _as_rgba(intensity_or_color):
-            if isinstance(intensity_or_color, numbers.Number):
-                intensity = intensity_or_color
-                return Color((1, 1, 1, intensity))
-            color = intensity_or_color
-            return Color(color)
-
         self._ambient_light = _as_rgba(ambient_light)
         self._diffuse_light = _as_rgba(diffuse_light)
         self._specular_light = _as_rgba(specular_light)
@@ -402,7 +417,7 @@ class ShadingFilter(Filter):
 
     @ambient_light.setter
     def ambient_light(self, light_color):
-        self._ambient_light = Color(light_color)
+        self._ambient_light = _as_rgba(light_color)
         self._update_data()
 
     @property
@@ -412,7 +427,7 @@ class ShadingFilter(Filter):
 
     @diffuse_light.setter
     def diffuse_light(self, light_color):
-        self._diffuse_light = Color(light_color)
+        self._diffuse_light = _as_rgba(light_color)
         self._update_data()
 
     @property
@@ -422,7 +437,7 @@ class ShadingFilter(Filter):
 
     @specular_light.setter
     def specular_light(self, light_color):
-        self._specular_light = Color(light_color)
+        self._specular_light = _as_rgba(light_color)
         self._update_data()
 
     @property
@@ -432,7 +447,7 @@ class ShadingFilter(Filter):
 
     @ambient_coefficient.setter
     def ambient_coefficient(self, color):
-        self._ambient_coefficient = Color(color)
+        self._ambient_coefficient = _as_rgba(color)
         self._update_data()
 
     @property
@@ -442,7 +457,7 @@ class ShadingFilter(Filter):
 
     @diffuse_coefficient.setter
     def diffuse_coefficient(self, diffuse_coefficient):
-        self._diffuse_coefficient = Color(diffuse_coefficient)
+        self._diffuse_coefficient = _as_rgba(diffuse_coefficient)
         self._update_data()
 
     @property
@@ -452,7 +467,7 @@ class ShadingFilter(Filter):
 
     @specular_coefficient.setter
     def specular_coefficient(self, specular_coefficient):
-        self._specular_coefficient = Color(specular_coefficient)
+        self._specular_coefficient = _as_rgba(specular_coefficient)
         self._update_data()
 
     @property

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -121,17 +121,15 @@ varying vec3 v_eye_vec;
 varying vec4 v_pos_scene;
 
 void prepare_shading() {
-    // TODO: Find a way to get the original position from the main vertex
-    //       shader instead of inversing the transformation.
     vec4 pos_scene = $render2scene(gl_Position);
-    v_pos_scene = pos_scene; // Used in the fragment for flat shading.
+    v_pos_scene = pos_scene;
 
     vec4 normal_scene = $visual2scene(vec4($normal, 1.0));
     vec4 origin_scene = $visual2scene(vec4(0.0, 0.0, 0.0, 1.0));
     normal_scene /= normal_scene.w;
     origin_scene /= origin_scene.w;
     vec3 normal = normalize(normal_scene.xyz - origin_scene.xyz);
-    v_normal_vec = normal; //VARYING COPY
+    v_normal_vec = normal;
 
     vec4 pos_front = $scene2doc(pos_scene);
     pos_front.z += 1e-6;
@@ -144,10 +142,10 @@ void prepare_shading() {
     pos_back /= pos_back.w;
 
     vec3 eye = normalize(pos_front.xyz - pos_back.xyz);
-    v_eye_vec = eye; //VARYING COPY
+    v_eye_vec = eye;
 
     vec3 light = normalize($light_dir.xyz);
-    v_light_vec = light; //VARYING COPY
+    v_light_vec = light;
 }
 """
 

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -162,13 +162,17 @@ void shade() {
         return;
     }
 
-    vec3 normal;
+    vec3 normal = v_normal_vec;
     if ($flat_shading == 1) {
         vec3 u = dFdx(v_pos_scene.xyz);
         vec3 v = dFdy(v_pos_scene.xyz);
         normal = normalize(cross(u, v));
-    } else {
-        normal = v_normal_vec;
+        // Note(asnt): The normal calculated above always points in the
+        // direction of the camera. Reintroduce the original orientation of the
+        // face.
+        if (!gl_FrontFacing) {
+            normal = -normal;
+        }
     }
 
     vec3 light_vec = v_light_vec;

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -278,7 +278,7 @@ class ShadingFilter(Filter):
     `V`
         the direction to the viewer,
     `s`
-        the shininess factor s.
+        the shininess factor.
 
     The `Ka`, `Kd` and `Ks` coefficients are defined as an RGBA color. The RGB
     components define the color that the surface reflects, and the alpha

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -158,6 +158,10 @@ varying vec3 v_eye_vec;
 varying vec4 v_pos_scene;
 
 void shade() {
+    if ($shading_enabled != 1) {
+        return;
+    }
+
     vec3 normal;
     if ($flat_shading == 1) {
         vec3 u = dFdx(v_pos_scene.xyz);
@@ -184,10 +188,8 @@ void shade() {
     }
     vec3 specular_color = $light_color * $specular_color * speculark;
 
-    if ($shading_enabled == 1) {
-        vec3 color = $ambient_color + diffuse_color + specular_color;
-        gl_FragColor *= vec4(color, 1.0);
-    }
+    vec3 color = $ambient_color + diffuse_color + specular_color;
+    gl_FragColor *= vec4(color, 1.0);
 }
 """  # noqa
 

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -87,7 +87,8 @@ def test_mesh_shading_filter_enabled(shading):
         rendered_with_shading = c.render()
 
         if shading is None:
-            # No shading applied, regardless of the value of `enabled`.
+            # There should be no shading applied, regardless of the value of
+            # `enabled`.
             assert np.allclose(rendered_without_shading, rendered_with_shading)
         else:
             # The result should be different with shading applied.

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -36,15 +36,12 @@ def test_mesh_shading_filter(shading):
     size = (45, 40)
     with TestingCanvas(size=size, bgcolor="k") as c:
         v = c.central_widget.add_view(border_width=0)
-        # Create visual
-        mdata = create_sphere(20, 40, radius=20)
+        v.camera = 'arcball'
+        mdata = create_sphere(20, 30, radius=1)
         mesh = scene.visuals.Mesh(meshdata=mdata,
                                   shading=shading,
-                                  color=(0.2, 0.3, 0.7, 0.9))
+                                  color=(0.2, 0.3, 0.7, 1.0))
         v.add(mesh)
-        from vispy.visuals.transforms import STTransform
-        mesh.transform = STTransform(translate=(20, 20))
-        mesh.transforms.scene_transform = STTransform(scale=(1, 1, 0.01))
 
         rendered = c.render()[..., 0]  # R channel only
         if shading in ("flat", "smooth"):

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -40,7 +40,7 @@ def test_mesh_shading_filter(shading):
         mdata = create_sphere(20, 40, radius=20)
         mesh = scene.visuals.Mesh(meshdata=mdata,
                                   shading=shading,
-                                  color=(0.1, 0.3, 0.7, 0.9))
+                                  color=(0.2, 0.3, 0.7, 0.9))
         v.add(mesh)
         from vispy.visuals.transforms import STTransform
         mesh.transform = STTransform(translate=(20, 20))

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -3,10 +3,12 @@
 import numpy as np
 from vispy import scene
 
+from vispy.color import Color
 from vispy.geometry import create_cube, create_sphere
 from vispy.testing import (TestingCanvas, requires_application,
                            run_tests_if_main, requires_pyopengl)
 from vispy.visuals.filters import WireframeFilter
+from vispy.visuals.filters.mesh import _as_rgba
 
 import pytest
 
@@ -54,6 +56,12 @@ def test_mesh_shading_filter(shading):
             assert (np.diff(invest_row[:29]) >= -1).all()
         else:
             assert np.unique(rendered).size == 2
+
+
+def test_intensity_or_color_as_rgba():
+    assert _as_rgba(0.3) == Color((1.0, 1.0, 1.0, 0.3))
+    assert _as_rgba((0.3, 0.2, 0.1)) == Color((0.3, 0.2, 0.1, 1.0))
+    assert _as_rgba((0.3, 0.2, 0.1, 0.5)) == Color((0.3, 0.2, 0.1, 0.5))
 
 
 @requires_pyopengl()


### PR DESCRIPTION
Expose the Phong model coefficients with reasonable defaults and allowing for fine-grained control:
- `shading='flat'`
- `light_dir=(10, 5, -5)`
- `ambient_light=(1, 1, 1, 0)`
- `diffuse_light=(1, 1, 1, 1)`
- `specular_light=(1, 1, 1, .25)`
- `ambient_coefficient=(1, 1, 1, 1)`
- `diffuse_coefficient=(1, 1, 1, 1)`
- `specular_coefficient=(1, 1, 1, 1)`
- `shininess=100`

The light and reflection coefficients are RGBA where A controls the intensity. In most cases, one will only adjust the intensity (e.g. dimming the (white) light and modulating the strength of the reflection).

TODO:
- [x] Implement the Phong reflection model in [[1]].
- [x] Allow a single scalar to specify the intensity of a reflection coefficient. Reflected color defaults to white. Example: `ambient_coefficient=0.1` is transformed into `ambient_coefficient=(1.0, 1.0, 1.0, 0.1)`.
- [x] Add tests.
- [x] Add inline examples.
- ~~[RFC @djhoese ] Require light position, `light_pos`, as input parameter instead of light direction, `light_dir`. This will allow different types of lights in the future. Deprecate `light_dir`.~~ EDIT: Forget that. `light_dir` seems needed in any case. `light_pos` would be an additional parameter, for example for a point light.

Ideas, maybe for the future:
- Rename to PhongShadingFilter?  (ShadingFilter could be an alias for it if we introduce other shading models (e.g. BRDF).
- Maybe a list of basic Phong materials would be convenient
```python
standard_matrials = {
    "plastic_like": dict(ambient_coefficient=(...), diffuse_coefficient=(...), specular_coefficient=(...),...),
    "metal_like": dict(...),
    ...
}
```
- For the API, maybe something like this:
```python
material = standard_materials["plastic_like"]
filter = PhongShadingFilter(..., **material)
mesh = MeshVisual(..., material=material)
```

[1]: https://en.wikipedia.org/wiki/Phong_reflection_model