### PR TITLE
Adapt mesh examples for gallery image generation

### DIFF
--- a/examples/basics/scene/mesh_shading.py
+++ b/examples/basics/scene/mesh_shading.py
@@ -19,7 +19,7 @@ default_mesh = load_data_file('orig/triceratops.obj.gz')
 parser.add_argument('--mesh', default=default_mesh)
 parser.add_argument('--shininess', default=100)
 parser.add_argument('--wireframe-width', default=1)
-args = parser.parse_args()
+args, _ = parser.parse_known_args()
 
 vertices, faces, normals, texcoords = read_mesh(args.mesh)
 
@@ -97,6 +97,7 @@ def on_key_press(event):
 
 
 canvas.show()
+
 
 if __name__ == "__main__":
     app.run()

--- a/examples/basics/scene/mesh_texture.py
+++ b/examples/basics/scene/mesh_texture.py
@@ -19,7 +19,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--shading', default='smooth',
                     choices=['none', 'flat', 'smooth'],
                     help="shading mode")
-args = parser.parse_args()
+args, _ = parser.parse_known_args()
 
 mesh_path = load_data_file('spot/spot.obj.gz')
 texture_path = load_data_file('spot/spot.png')
@@ -65,6 +65,7 @@ attach_headlight(mesh, view, canvas)
 
 
 canvas.show()
+
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
The command line parsing in the examples was failing because it was receiving
the arguments from `python make image gallery`.