### PR TITLE
Fix website deploy commit message references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
         cname: vispy.org
         allow_empty_commit: true
         external_repository: vispy/vispy.github.com
-        full_commit_message: "Deploy vispy.org website for SHA:$GITHUB_SHA (Tag: $GITHUB_REF)"
+        full_commit_message: "Deploy vispy.org website for  SHA:${{ github.sha }} (Ref: ${{ github.ref }})"
 
   # linux runs
   build_0:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
         cname: vispy.org
         allow_empty_commit: true
         external_repository: vispy/vispy.github.com
-        full_commit_message: "Deploy vispy.org website for  SHA:${{ github.sha }} (Ref: ${{ github.ref }})"
+        full_commit_message: "Deploy vispy.org website for SHA:${{ github.sha }} (Ref: ${{ github.ref }})"
 
   # linux runs
   build_0:


### PR DESCRIPTION
I noticed while working on another project and copying from VisPy that the commit messages weren't actually rendering the environment variables I was trying to use. I think this PR should fix these (currently testing with the geoxarray project).