### PR TITLE
[WIP] Implement weighted blended order-independent transparency

### DIFF
--- a/examples/basics/scene/transparency_weighted_oit.py
+++ b/examples/basics/scene/transparency_weighted_oit.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# vispy: gallery 2
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+"""Render transparent objects with approximate order-independent transparency.
+
+Using the method:
+
+    McGuire, Morgan, and Louis Bavoil. "Weighted blended order-independent
+    transparency." Journal of Computer Graphics Techniques 2.4 (2013).
+"""
+
+from vispy import app, scene
+from vispy.io import read_mesh, load_data_file
+from vispy.scene.visuals import Mesh, Plane
+from vispy.visuals import transforms
+
+
+mesh_file = load_data_file('orig/triceratops.obj.gz')
+vertices, faces, _, _ = read_mesh(mesh_file)
+center = vertices.mean(axis=0)
+vertices = [
+    vertices,
+    (vertices - center) * 0.66 + center,
+    vertices + [[0, 0, 0.75]],
+    vertices + [[0, 0, 1.50]],
+    vertices + [[0, 0, 2.25]],
+]
+scale = 1
+vertices = [scale * v for v in vertices]
+
+# shading = None
+# shading = 'flat'
+shading = 'smooth'
+meshes = [
+    Mesh(vertices[0], faces, shading=shading, color=(.2, .2, .5, .25)),
+    Mesh(vertices[1], faces, shading=shading, color=(.2, .5, .5, .25)),
+    Mesh(vertices[2], faces, shading=shading, color=(.2, .5, .2, .25)),
+    Mesh(vertices[3], faces, shading=shading, color=(.5, .2, .2, .25)),
+    Mesh(vertices[4], faces, shading=shading, color=(.5, .5, .2, 1)),
+]
+
+c = 0
+d = 1
+a = .25
+planes = [
+    Plane(color=(d, c, c, a)),
+    Plane(color=(c, d, c, a)),
+    Plane(color=(c, c, d, a)),
+    Plane(color=(c, d, d, 1)),
+]
+for plane in planes:
+    plane._mesh.shading = shading
+positions = [
+    (2, 0, 0.0),
+    (2, 0, 0.75),
+    (2, 0, 1.5),
+    (2, .25, 2.25),
+]
+for plane, position in zip(planes, positions):
+    plane.transform = transforms.STTransform(translate=position)
+meshes += planes
+
+bgcolor = 'white'
+canvas = scene.SceneCanvas(keys='interactive', bgcolor=bgcolor)
+view = canvas.central_widget.add_view()
+view.camera = 'arcball'
+view.camera.depth_value = 1e3
+for mesh in meshes:
+    view.add(mesh)
+
+canvas.show()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/basics/scene/transparency_weighted_oit.py
+++ b/examples/basics/scene/transparency_weighted_oit.py
@@ -64,7 +64,8 @@ for plane, position in zip(planes, positions):
 meshes += planes
 
 bgcolor = 'white'
-canvas = scene.SceneCanvas(keys='interactive', bgcolor=bgcolor)
+canvas = scene.SceneCanvas(keys='interactive', bgcolor=bgcolor,
+                           transparency='weighted')
 view = canvas.central_widget.add_view()
 view.camera = 'arcball'
 view.camera.depth_value = 1e3

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -215,8 +215,11 @@ class SceneCanvas(app.Canvas, Frozen):
         # Now that a draw event is going to be handled, open up the
         # scheduling of further updates
         self._update_pending = False
-        # self._draw_scene()
-        self._draw_scene_with_transparency()
+        import sys
+        if "--vispy-transparent" in sys.argv:
+            self._draw_scene_with_transparency(bgcolor=self._bgcolor)
+        else:
+            self._draw_scene()
 
     def render(self, region=None, size=None, bgcolor=None, crop=None):
         """Render the scene to an offscreen buffer and return the image array.

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -215,7 +215,8 @@ class SceneCanvas(app.Canvas, Frozen):
         # Now that a draw event is going to be handled, open up the
         # scheduling of further updates
         self._update_pending = False
-        self._draw_scene()
+        # self._draw_scene()
+        self._draw_scene_with_transparency()
 
     def render(self, region=None, size=None, bgcolor=None, crop=None):
         """Render the scene to an offscreen buffer and return the image array.
@@ -265,6 +266,14 @@ class SceneCanvas(app.Canvas, Frozen):
             bgcolor = self._bgcolor
         self.context.clear(color=bgcolor, depth=True)
         self.draw_visual(self.scene)
+
+    def _draw_scene_with_transparency(self, bgcolor=None):
+        if not hasattr(self, '_renderer'):
+            from .renderer import WeightedTransparencyRenderer
+            self.unfreeze()
+            self._renderer = WeightedTransparencyRenderer(self)
+            self.freeze()
+        self._renderer.render(bgcolor=bgcolor)
 
     def draw_visual(self, visual, event=None):
         """Draw a visual and its children to the canvas or currently active
@@ -501,6 +510,9 @@ class SceneCanvas(app.Canvas, Frozen):
 
         if len(self._vp_stack) == 0:
             self.context.set_viewport(0, 0, *self.physical_size)
+
+        if hasattr(self, '_renderer'):
+            self._renderer.resize(self.physical_size)
 
     def on_close(self, event):
         """Close event handler

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -276,7 +276,7 @@ class SceneCanvas(app.Canvas, Frozen):
             self.unfreeze()
             self._renderer = WeightedTransparencyRenderer(self)
             self.freeze()
-        self._renderer.render(bgcolor=bgcolor)
+        self._renderer.render(bgcolor)
 
     def draw_visual(self, visual, event=None):
         """Draw a visual and its children to the canvas or currently active

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -79,6 +79,8 @@ class SceneCanvas(app.Canvas, Frozen):
         allows the scale factor to be adjusted for testing.
     bgcolor : Color
         The background color to use.
+    transparency : {None, 'weighted'}, optional
+        Whether to render with transparency.
 
     See also
     --------
@@ -114,7 +116,10 @@ class SceneCanvas(app.Canvas, Frozen):
                  show=False, autoswap=True, app=None, create_native=True,
                  vsync=False, resizable=True, decorate=True, fullscreen=False,
                  config=None, shared=None, keys=None, parent=None, dpi=None,
-                 always_on_top=False, px_scale=1, bgcolor='black'):
+                 always_on_top=False, px_scale=1, bgcolor='black',
+                 transparency=None):
+        assert transparency in (None, 'weighted')
+
         self._scene = None
         # A default widget that follows the shape of the canvas
         self._central_widget = None
@@ -126,6 +131,7 @@ class SceneCanvas(app.Canvas, Frozen):
         self._mouse_handler = None
         self.transforms = TransformSystem(canvas=self)
         self._bgcolor = Color(bgcolor).rgba
+        self._transparency = transparency
 
         # Set to True to enable sending mouse events even when no button is
         # pressed. Disabled by default because it is very expensive. Also
@@ -215,8 +221,7 @@ class SceneCanvas(app.Canvas, Frozen):
         # Now that a draw event is going to be handled, open up the
         # scheduling of further updates
         self._update_pending = False
-        import sys
-        if "--vispy-transparent" in sys.argv:
+        if self._transparency == "weighted":
             self._draw_scene_with_transparency(bgcolor=self._bgcolor)
         else:
             self._draw_scene()

--- a/vispy/scene/renderer.py
+++ b/vispy/scene/renderer.py
@@ -1,0 +1,318 @@
+import numpy as np
+
+from vispy import gloo
+from vispy.visuals.shaders import Function, Varying
+
+
+vert_accumulate = """
+void compute_depth()
+{
+    vec3 a_position = $position;
+    $depth = -$visual_to_scene(vec4(a_position, 1.0)).z;
+}
+"""
+
+frag_accumulate = """
+void accumulate()
+{
+    float v_depth = $depth;
+    float z = abs(v_depth);
+    float alpha = gl_FragColor.a;
+
+    float weight;
+    weight = 3e-2 / (1e-5 + pow(z / 200.0, 4.0));
+    weight = alpha * clamp(weight, 1e-2, 3e-3);
+    //weight = 3e3 * (1 - pow(gl_FragCoord.z, 3.0));
+    //weight = alpha * max(1e-2, weight);
+    // XXX: Fix this weight.
+    //weight = 1.0;
+
+    float u_pass = $u_pass;
+    if(u_pass == 0.0) {
+        gl_FragColor *= weight;
+    } else if (u_pass == 1.0) {
+        gl_FragColor = vec4(alpha);
+    }
+}
+"""
+
+vert_compose = """
+attribute vec2 a_position;
+varying vec2 v_texcoord;
+
+void main(void)
+{
+    gl_Position = vec4(a_position, 0, 1);
+    v_texcoord = (a_position + 1.0) / 2.0;
+}
+"""
+
+frag_compose = """
+uniform sampler2D tex_accumulation;
+uniform sampler2D tex_revealage;
+
+varying vec2 v_texcoord;
+
+void main(void)
+{
+    vec4 accum = texture2D(tex_accumulation, v_texcoord);
+    float r = texture2D(tex_revealage, v_texcoord).r;
+    float a = clamp(accum.a, 1e-4, 5e4);
+    // XXX: Fix the weight. See accumulation shader.
+    //a = 1.0;
+    gl_FragColor = vec4(accum.rgb / a, r);
+}
+"""
+
+# vert_blit = """
+# attribute vec2 a_position;
+# varying vec2 v_texcoord;
+
+# void main(void)
+# {
+#     gl_Position = vec4(a_position, 0, 1);
+#     v_texcoord = (a_position + 1.0) / 2.0;
+# }
+# """
+
+# frag_blit = """
+# uniform sampler2D tex_color;
+
+# varying vec2 v_texcoord;
+
+# void main(void)
+# {
+#     gl_FragColor = texture2D(tex_color, v_texcoord);
+# }
+# """
+
+
+class WeightedTransparencyRenderer:
+    def __init__(self, canvas):
+        self.canvas = canvas
+
+        width, height = canvas.size
+        # XXX: Not sure if buffer formats need to be specified explicitly
+        # and/or matched to the format of the default frame buffer.
+        # self.color_buffer = gloo.RenderBuffer((height, width), 'color')
+        # self.color_buffer = gloo.Texture2D((height, width, 4), format='rgba')
+        # self.depth_buffer = gloo.RenderBuffer((height, width), 'depth')
+        # self.stencil_buffer = gloo.RenderBuffer((height, width), 'stencil')
+        # self.stencil_buffer = None
+        # self.framebuffer = gloo.FrameBuffer(depth=self.depth_buffer,
+        #                                     stencil=self.stencil_buffer)
+        # self.framebuffer = gloo.FrameBuffer()
+        # An RGBA32F float texture for accumulating the weighted colors.
+        accumulation = np.zeros((height, width, 4), np.float32)
+        self.accumulation_buffer = gloo.Texture2D(
+            accumulation,
+            # (height, width, 4),
+            format='rgba',
+            # Note: Must pass the format explicitly as gloo chooses a
+            # lower-precision one by default.
+            internalformat='rgba32f',
+        )
+        # A single-channel float texture (R32F) for the revealage.
+        # The revelage is the amount of background revealed per fragment, as
+        # opposed to coverage used in related blended order-independent
+        # transparency methods.
+        revealage = np.zeros((height, width), np.float32)
+        self.revealage_buffer = gloo.Texture2D(
+            revealage,
+            # (height, width),
+            format='red',
+            # Note: Must pass the format explicitly as gloo chooses a
+            # lower-precision one by default.
+            internalformat='r32f',
+        )
+
+        self.framebuffer = gloo.FrameBuffer()
+        # self.framebuffer.depth_buffer = self.depth_buffer
+
+        def iter_tree(node):
+            yield node
+            for child in node.children:
+                yield from iter_tree(child)
+
+        from vispy.scene.visuals import Mesh
+        visuals = [node for node in iter_tree(self.canvas.scene)
+                   if isinstance(node, Mesh)]
+        prog_visuals = []
+        for visual in visuals:
+            visual._prepare_draw(None)
+            visual.set_gl_state(preset=None)
+
+            vert_func = Function(vert_accumulate)
+            frag_func = Function(frag_accumulate)
+            prog_visuals.append(dict(vert=vert_func, frag=frag_func))
+
+            visual_to_scene = visual.get_transform('visual', 'scene')
+            vert_func['visual_to_scene'] = visual_to_scene
+            # vert_func['position'] = visual.shared_program.vert['position']
+            # print(visual.shared_program.vert['position'])
+            # print(visual.view_program.vert['position'])
+            # vert_func['position'] = visual.view_program.vert['position']
+            # vert_func['position'] = visual._vertices
+            vert_func['depth'] = Varying('depth', 'float')
+            frag_func['depth'] = vert_func['depth']
+            vert_func['position'] = visual.view_program.vert['position']
+            # vert_func['position'] = visual.shared_program.vert['position']
+
+            hook_vert = visual._get_hook('vert', 'post')
+            hook_frag = visual._get_hook('frag', 'post')
+            # Place this hook in last position.
+            # XXX: No guarantee that there is no hook with a higher position
+            # index, but unlikely. (If needed, list all hook positions and
+            # choose an higher index.)
+            position = 1000
+            hook_vert.add(vert_func(), position=position)
+            hook_frag.add(frag_func(), position=position)
+
+        self.prog_visuals = prog_visuals
+
+        # Post composition.
+        # A quad (two triangles) spanning the framebuffer area.
+        quad_corners = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
+        indices = np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32)
+        indices = gloo.IndexBuffer(indices)
+        self.indices = indices
+        prog_compose = gloo.Program(vert_compose, frag_compose)
+        prog_compose['tex_accumulation'] = self.accumulation_buffer
+        prog_compose['tex_revealage'] = self.revealage_buffer
+        prog_compose['a_position'] = quad_corners
+        self.prog_compose = prog_compose
+
+        # Blit the rendered scen onto the default frame buffer.
+        # prog_blit = gloo.Program(vert_blit, frag_blit)
+        # prog_blit['tex_color'] = self.color_buffer
+        # prog_blit['a_position'] = quad_corners
+        # self.prog_blit = prog_blit
+
+    def resize(self, size):
+        height_width = size[::-1]
+        # self.color_buffer.resize(height_width)
+        # self.depth_buffer.resize(height_width)
+        # XXX: resize doesn't preserve channel dimensions if not passed (reset
+        # to 1 channel). Bug or feature?
+        channels = self.accumulation_buffer.shape[2:]
+        self.accumulation_buffer.resize(height_width + channels)
+        self.revealage_buffer.resize(height_width)
+
+    def render(self, bgcolor=None):
+        if bgcolor is None:
+            bgcolor = (1, 1, 1, 1)
+            # bgcolor = (.5, .5, .5, 1)
+            # bgcolor = (0, 0, 0, 1)
+        canvas = self.canvas
+
+        # canvas.set_current()
+
+        offset = 0, 0
+        canvas_size = self.canvas.size
+
+        # def push_fbo(fbo):
+        #     canvas.push_fbo(fbo, offset, canvas_size)
+
+        # def pop_fbo():
+        #     canvas.pop_fbo()
+
+        # 1. Draw opaque objects.
+
+        # canvas.context.set_state(preset=None)
+        # canvas.context.set_state(
+        #     cull_face=True,
+        #     depth_test=True,
+        #     blend=False,
+        #     depth_mask=True,
+        # )
+        # # self.framebuffer.color_buffer = self.color_buffer
+        # push_fbo()
+        canvas.context.clear(color=bgcolor, depth=True)
+        # # TODO: Identify and draw opaque objects only.
+        # # canvas.draw_visual(canvas.scene_with_opaque_only)
+        # pop_fbo()
+
+        # 2. Draw transparent objects.
+
+        canvas.context.set_state(
+            preset=None,
+            cull_face=False,
+            blend=True,
+            depth_test=True,   # Read the depth for opaque objects.
+            # depth_test=False,   # XXX: Rendering opaque objects correctly.
+            depth_mask=False,  # Do not overwrite the depth.
+        )
+
+        # TODO: Add support for multiple render targets to gloo.
+        # TODO: Merge the two render passes into a single render pass with two
+        # render targets.
+
+        # 2.1 Accumulate contributions from all objects.
+
+        pass_ = 0
+        for prog in self.prog_visuals:
+            prog['frag']['u_pass'] = float(pass_)
+        self.framebuffer.color_buffer = self.accumulation_buffer
+        # push_fbo(self.framebuffer)
+        canvas.push_fbo(self.framebuffer, offset, canvas_size)
+        canvas.context.clear(
+            color=(0, 0, 0, 0),
+            depth=False,
+            stencil=False,
+        )
+        canvas.context.set_blend_equation('func_add')
+        canvas.context.set_blend_func('one', 'one')
+        # TODO: Only draw transparent objects.
+        # canvas.draw_visual(canvas.scene_with_transparent_only)
+        canvas.draw_visual(canvas.scene)
+        # pop_fbo()
+        canvas.pop_fbo()
+
+        pass_ = 1
+        for prog in self.prog_visuals:
+            prog['frag']['u_pass'] = float(pass_)
+        self.framebuffer.color_buffer = self.revealage_buffer
+        # push_fbo(self.framebuffer)
+        canvas.push_fbo(self.framebuffer, offset, canvas_size)
+        canvas.context.clear(
+            color=(1, 1, 1, 1),
+            depth=False,
+            stencil=False,
+        )
+        canvas.context.set_blend_func('zero', 'one_minus_src_alpha')
+        # TODO: Only draw transparent objects.
+        # canvas.draw_visual(canvas.scene_with_transparent_only)
+        canvas.draw_visual(canvas.scene)
+        # pop_fbo()
+        canvas.pop_fbo()
+
+        # 2.2 Composite accumulations.
+
+        # XXX: Check the settings for when rendering with opaque objects.
+        canvas.context.set_state(
+            preset=None,
+            depth_test=False,
+            blend=True,
+            depth_mask=False,
+        )
+        # self.framebuffer.color_buffer = self.color_buffer
+        # push_fbo()
+        # canvas.context.clear(color=bgcolor)
+        # canvas.context.set_blend_func('one_minus_src_alpha', 'src_alpha')
+        # self.prog_compose.draw('triangles', self.indices)
+        # pop_fbo()
+        # canvas.set_current()
+        canvas.context.clear(color=bgcolor)
+        canvas.context.set_blend_func('one_minus_src_alpha', 'src_alpha')
+        self.prog_compose.draw('triangles', self.indices)
+
+        # 3. Copy result to default frame buffer.
+        # TODO
+        # canvas.context.set_state(
+        #     depth_test=False,
+        #     blend=False,
+        #     depth_mask=False,
+        # )
+        # canvas.context.clear(color=bgcolor)
+        # # canvas.context.clear(color=(0, 0, 0, 1), depth=True, stencil=True)
+        # self.prog_blit.draw('triangles', self.indices)

--- a/vispy/scene/renderer.py
+++ b/vispy/scene/renderer.py
@@ -383,9 +383,7 @@ class WeightedTransparencyRenderer:
         )
         canvas.context.set_blend_equation('func_add')
         canvas.context.set_blend_func('one', 'one')
-        # TODO: Only draw transparent objects.
         self.draw_visual(canvas.scene, subset='transparent')
-        # canvas.draw_visual(canvas.scene)
         pop_fbo()
 
         pass_ = 1
@@ -399,7 +397,6 @@ class WeightedTransparencyRenderer:
             stencil=False,
         )
         canvas.context.set_blend_func('zero', 'one_minus_src_alpha')
-        # TODO: Only draw transparent objects.
         self.draw_visual(canvas.scene, subset='transparent')
         canvas.draw_visual(canvas.scene)
         pop_fbo()
@@ -414,11 +411,6 @@ class WeightedTransparencyRenderer:
             blend=True,
             depth_mask=False,
         )
-        # DEBUG: Render directly to the default frame buffer.
-        # canvas.context.clear(color=bgcolor)
-        # canvas.context.set_blend_func('one_minus_src_alpha', 'src_alpha')
-        # self.prog_compose.draw('triangles', self.indices)
-        # GOAL: Render to frame buffer object.
         self.framebuffer.color_buffer = self.color_buffer
         push_fbo()
         canvas.context.set_blend_func('one_minus_src_alpha', 'src_alpha')


### PR DESCRIPTION
Implement the algorithm in [[1]] based on a vispy demo [[2]] which is based on glumpy's implementation #984.
Addresses #1345

[1]: https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.1046.4883&rep=rep1&type=pdf
[2]: https://gist.github.com/liubenyuan/3739c343b3e6ca8117f7

The implementation must be validated for correctness.
Demo scene (`examples/basics/scene/transparency_weighted_oit.py`):
![oit-example](https://user-images.githubusercontent.com/830589/119856424-fd9a5a80-bf12-11eb-86e0-0efb7c45808a.png)
![oit-example-top](https://user-images.githubusercontent.com/830589/119856502-0c810d00-bf13-11eb-9897-d505d35552f9.png)

The implementation differs from the original vispy and glumpy demos above in that opaque objects are also supported and that they seem to implement this variant of the algorithm: https://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html, which didn't work out for me at first, so I followed the paper instead.

The rendering is delegated from the SceneCanvas to a WeightedTransparencyRenderer.
The renderer uses a FBO for offscreen rendering and then copies to the default framebuffer.
Outline of the steps:
0. scan the scene graphs for opaque and transparent renderable objects,
1. render opaque objects (pass 1)
2. render transparent objects with weight OIT (2 passes)
3. do compositing of transparent and opaque buffers (texture pass)
4. copy result to default frame buffer (texture pass)

Some current limitations:
- Restrict to mesh objects (should probably work with any drawable object but we must know if opaque or transparent to render in the right pass),
- ...

This is still a work in progress. Comments/suggestions welcome.