### PR TITLE
Add setter for colorbar label text

### DIFF
--- a/examples/basics/visuals/colorbar_visual.py
+++ b/examples/basics/visuals/colorbar_visual.py
@@ -95,7 +95,7 @@ def get_vertical_bar(pos, size):
     """
     vertical = ColorBarVisual(pos=pos,
                               size=size,
-                              label_str="iterations to escape",
+                              label="iterations to escape",
                               cmap=colormap, orientation="left")
 
     vertical.label.font_size = 15

--- a/examples/basics/visuals/colorbar_visual_types.py
+++ b/examples/basics/visuals/colorbar_visual_types.py
@@ -37,7 +37,7 @@ def get_left_orientation_bar():
     size = 400, 10
 
     colorbar = ColorBarVisual(pos=pos, size=size,
-                              label_str="orientation left",
+                              label="orientation left",
                               cmap=colormap, orientation="left")
 
     return style_colorbar(colorbar)
@@ -48,7 +48,7 @@ def get_right_orientation_bar():
     size = 400, 10
 
     colorbar = ColorBarVisual(pos=pos, size=size,
-                              label_str="orientation right",
+                              label="orientation right",
                               cmap=colormap, orientation="right")
 
     return style_colorbar(colorbar)
@@ -59,7 +59,7 @@ def get_top_orientation_bar():
     size = 300, 10
 
     colorbar = ColorBarVisual(pos=pos, size=size,
-                              label_str="orientation top",
+                              label="orientation top",
                               cmap=colormap, orientation="top")
 
     return style_colorbar(colorbar)
@@ -70,7 +70,7 @@ def get_bottom_orientation_bar():
     size = 300, 10
 
     colorbar = ColorBarVisual(pos=pos, size=size,
-                              label_str="orientation bottom",
+                              label="orientation bottom",
                               cmap=colormap, orientation="bottom")
 
     return style_colorbar(colorbar)

--- a/vispy/scene/widgets/colorbar.py
+++ b/vispy/scene/widgets/colorbar.py
@@ -65,7 +65,6 @@ class ColorBarWidget(Widget):
     axis_ratio : float
         ratio of minor axis to major axis
     """
-
     def __init__(self, cmap, orientation,
                  label="", label_color='black', clim=("", ""),
                  border_width=0.0, border_color="black",
@@ -78,7 +77,7 @@ class ColorBarWidget(Widget):
 
         self._colorbar = ColorBarVisual(size=dummy_size, cmap=cmap,
                                         orientation=orientation,
-                                        label_str=label, clim=clim,
+                                        label_text=label, clim=clim,
                                         label_color=label_color,
                                         border_width=border_width,
                                         border_color=border_color, **kwargs)
@@ -103,7 +102,8 @@ class ColorBarWidget(Widget):
         self._colorbar.size = self._calc_size()
 
     def _calc_size(self):
-        """Calculate a size"""
+        """Calculate a size
+        """
         (total_halfx, total_halfy) = (self.rect.right, self.rect.top)
         if self._colorbar.orientation in ["bottom", "top"]:
             (total_major_axis, total_minor_axis) = (total_halfx, total_halfy)
@@ -155,7 +155,8 @@ class ColorBarWidget(Widget):
 
     @property
     def border_color(self):
-        """The color of the border around the ColorBar in pixels"""
+        """ The color of the border around the ColorBar in pixels
+        """
         return self._colorbar.border_color
 
     @border_color.setter
@@ -164,7 +165,8 @@ class ColorBarWidget(Widget):
 
     @property
     def border_width(self):
-        """The width of the border around the ColorBar in pixels"""
+        """ The width of the border around the ColorBar in pixels
+        """
         return self._colorbar.border_width
 
     @border_width.setter

--- a/vispy/scene/widgets/colorbar.py
+++ b/vispy/scene/widgets/colorbar.py
@@ -78,7 +78,7 @@ class ColorBarWidget(Widget):
 
         self._colorbar = ColorBarVisual(size=dummy_size, cmap=cmap,
                                         orientation=orientation,
-                                        label_text=label, clim=clim,
+                                        label=label, clim=clim,
                                         label_color=label_color,
                                         border_width=border_width,
                                         border_color=border_color, **kwargs)

--- a/vispy/scene/widgets/colorbar.py
+++ b/vispy/scene/widgets/colorbar.py
@@ -65,6 +65,7 @@ class ColorBarWidget(Widget):
     axis_ratio : float
         ratio of minor axis to major axis
     """
+
     def __init__(self, cmap, orientation,
                  label="", label_color='black', clim=("", ""),
                  border_width=0.0, border_color="black",
@@ -102,8 +103,7 @@ class ColorBarWidget(Widget):
         self._colorbar.size = self._calc_size()
 
     def _calc_size(self):
-        """Calculate a size
-        """
+        """Calculate a size"""
         (total_halfx, total_halfy) = (self.rect.right, self.rect.top)
         if self._colorbar.orientation in ["bottom", "top"]:
             (total_major_axis, total_minor_axis) = (total_halfx, total_halfy)
@@ -155,8 +155,7 @@ class ColorBarWidget(Widget):
 
     @property
     def border_color(self):
-        """ The color of the border around the ColorBar in pixels
-        """
+        """The color of the border around the ColorBar in pixels"""
         return self._colorbar.border_color
 
     @border_color.setter
@@ -165,8 +164,7 @@ class ColorBarWidget(Widget):
 
     @property
     def border_width(self):
-        """ The width of the border around the ColorBar in pixels
-        """
+        """The width of the border around the ColorBar in pixels"""
         return self._colorbar.border_width
 
     @border_width.setter

--- a/vispy/scene/widgets/tests/test_colorbar.py
+++ b/vispy/scene/widgets/tests/test_colorbar.py
@@ -8,7 +8,7 @@ All images are of size (100,100) to keep a small file size
 
 from vispy.scene.widgets import ColorBarWidget
 from vispy.testing import (requires_application, TestingCanvas,
-                           run_tests_if_main, raises)
+                           run_tests_if_main)
 from vispy.testing.image_tester import assert_image_approved
 
 
@@ -43,3 +43,5 @@ def test_colorbar_widget():
         assert_image_approved(c.render(), 'visuals/colorbar/top.png')
         assert colorbar_top.label.text == "my label"
 
+
+run_tests_if_main()

--- a/vispy/scene/widgets/tests/test_colorbar.py
+++ b/vispy/scene/widgets/tests/test_colorbar.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for ColorbarVWidget.
+
+All images are of size (100,100) to keep a small file size
+
+"""
+
+from vispy.scene.widgets import ColorBarWidget
+from vispy.testing import (requires_application, TestingCanvas,
+                           run_tests_if_main, raises)
+from vispy.testing.image_tester import assert_image_approved
+
+
+def create_colorbar(pos, orientation, label='label string here'):
+    colorbar = ColorBarWidget(pos=pos,
+                              orientation=orientation,
+                              label=label,
+                              cmap='autumn',
+                              border_color='white',
+                              border_width=2)
+
+    colorbar.label.color = 'white'
+    colorbar.label.font_size = 5
+
+    colorbar.ticks[0].color = 'white'
+    colorbar.ticks[0].font_size = 5
+
+    colorbar.ticks[1].color = 'white'
+    colorbar.ticks[1].font_size = 5
+
+    return colorbar
+
+
+@requires_application()
+def test_colorbar_widget():
+    with TestingCanvas() as c:
+        colorbar_top = create_colorbar(pos=(50, 50),
+                                       label="my label",
+                                       orientation='top')
+
+        c.draw_visual(colorbar_top)
+        assert_image_approved(c.render(), 'visuals/colorbar/top.png')
+        assert colorbar_top.label.text == "my label"
+

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -598,10 +598,10 @@ class ColorBarVisual(CompoundVisual):
 
     @label.setter
     def label(self, label):
-        if isinstance(label, str):
-            self._label.text = label
-        else:
+        if isinstance(label, TextVisual):
             self._label = label
+        else:
+            self._label.text = label
         self._update()
 
     @property

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -253,7 +253,7 @@ class ColorBarVisual(CompoundVisual):
     pos : tuple (x, y)
         Position where the colorbar is to be placed with
         respect to the center of the colorbar
-    label_text : str
+    label : str
         The label that is to be drawn with the colorbar
         that provides information about the colorbar.
     label_color : str | vispy.color.Color
@@ -269,6 +269,11 @@ class ColorBarVisual(CompoundVisual):
     border_color : str | vispy.color.Color
         The color of the border of the colormap. This can either be a
         str as the color's name or an actual instace of a vipy.color.Color
+
+    .. versionchanged:: 0.7
+
+        Keyword argument ``label_str`` renamed to `label`.
+
     """
 
     # The padding multiplier that's used to place the text
@@ -278,7 +283,7 @@ class ColorBarVisual(CompoundVisual):
 
     def __init__(self, cmap, orientation, size,
                  pos=[0, 0],
-                 label_text="",
+                 label="",
                  label_color='black',
                  clim=(0.0, 1.0),
                  border_width=1.0,
@@ -292,7 +297,7 @@ class ColorBarVisual(CompoundVisual):
         self._size = size
         self._orientation = orientation
 
-        self._label = TextVisual(label_text, color=self._label_color)
+        self._label = TextVisual(label, color=self._label_color)
 
         self._ticks = []
         self._ticks.append(TextVisual(str(self._clim[0]),

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -82,6 +82,7 @@ class _CoreColorBarVisual(Visual):
     --------
     vispy.visuals.ColorBarVisual
     """
+
     def __init__(self, pos, halfdim,
                  cmap,
                  orientation,
@@ -115,10 +116,7 @@ class _CoreColorBarVisual(Visual):
         self._update()
 
     def _update(self):
-        """Rebuilds the shaders, and repositions the objects
-           that are used internally by the ColorBarVisual
-        """
-
+        """Rebuilds the shaders, and repositions the objects that are used internally by the ColorBarVisual"""
         x, y = self._pos
         halfw, halfh = self._halfdim
 
@@ -133,11 +131,11 @@ class _CoreColorBarVisual(Visual):
         # test that the given width and height is consistent
         # with the orientation
         if (self._orientation == "bottom" or self._orientation == "top"):
-                if halfw < halfh:
-                    raise ValueError("half-width(%s) < half-height(%s) for"
-                                     "%s orientation,"
-                                     " expected half-width >= half-height" %
-                                     (halfw, halfh, self._orientation, ))
+            if halfw < halfh:
+                raise ValueError("half-width(%s) < half-height(%s) for"
+                                 "%s orientation,"
+                                 " expected half-width >= half-height" %
+                                 (halfw, halfh, self._orientation, ))
         else:  # orientation == left or orientation == right
             if halfw > halfh:
                 raise ValueError("half-width(%s) > half-height(%s) for"
@@ -157,12 +155,15 @@ class _CoreColorBarVisual(Visual):
 
         self.shared_program['a_position'] = vertices
 
+        self.shared_program['texture2D_LUT'] = self._cmap.texture_lut() \
+            if (hasattr(self._cmap, 'texture_lut')) else None
+
     @staticmethod
     def _get_orientation_error(orientation):
-            return ValueError("orientation must"
-                              " be one of 'top', 'bottom', "
-                              "'left', or 'right', "
-                              "not '%s'" % (orientation, ))
+        return ValueError("orientation must"
+                          " be one of 'top', 'bottom', "
+                          "'left', or 'right', "
+                          "not '%s'" % (orientation, ))
 
     @property
     def pos(self):
@@ -183,8 +184,7 @@ class _CoreColorBarVisual(Visual):
 
     @property
     def cmap(self):
-        """ The colormap of the Colorbar
-        """
+        """The colormap of the Colorbar"""
         return self._cmap
 
     @cmap.setter
@@ -270,6 +270,7 @@ class ColorBarVisual(CompoundVisual):
         The color of the border of the colormap. This can either be a
         str as the color's name or an actual instace of a vipy.color.Color
     """
+
     # The padding multiplier that's used to place the text
     # next to the Colorbar. Makes sure the text isn't
     # visually "sticking" to the Colorbar
@@ -323,9 +324,7 @@ class ColorBarVisual(CompoundVisual):
         self._update()
 
     def _update(self):
-        """Rebuilds the shaders, and repositions the objects
-           that are used internally by the ColorBarVisual
-        """
+        """Rebuilds the shaders, and repositions the objects that are used internally by the ColorBarVisual"""
         self._colorbar.halfdim = self._halfdim
         self._border.halfdim = self._halfdim
 
@@ -338,10 +337,7 @@ class ColorBarVisual(CompoundVisual):
         self._border._update()
 
     def _update_positions(self):
-        """
-        updates the positions of the colorbars and labels
-
-        """
+        """Updates the positions of the colorbars and labels"""
         self._colorbar.pos = self._pos
         self._border.pos = self._pos
 
@@ -557,8 +553,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def pos(self):
-        """ The position of the text anchor in the local coordinate frame
-        """
+        """The position of the text anchor in the local coordinate frame"""
         return self._pos
 
     @pos.setter
@@ -568,8 +563,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def cmap(self):
-        """ The colormap of the Colorbar
-        """
+        """The colormap of the Colorbar"""
         return self._colorbar._cmap
 
     @cmap.setter
@@ -578,13 +572,12 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def clim(self):
-        """ The data limits of the Colorbar
+        """The data limits of the Colorbar
 
         Returns
         -------
         clim: tuple(min, max)
         """
-
         return self._clim
 
     @clim.setter
@@ -594,8 +587,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def label(self):
-        """ The vispy.visuals.TextVisual associated with the label
-        """
+        """The vispy.visuals.TextVisual associated with the label"""
         return self._label
 
     @label.setter
@@ -608,7 +600,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def ticks(self):
-        """ The vispy.visuals.TextVisual associated with the ticks
+        """The vispy.visuals.TextVisual associated with the ticks
 
         Returns
         -------
@@ -624,8 +616,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def border_width(self):
-        """ The width of the border around the ColorBar in pixels
-        """
+        """The width of the border around the ColorBar in pixels"""
         return self._border.border_width
 
     @border_width.setter
@@ -635,8 +626,7 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def border_color(self):
-        """ The color of the border around the ColorBar in pixels
-        """
+        """The color of the border around the ColorBar in pixels"""
         return self._border.border_color
 
     @border_color.setter
@@ -646,13 +636,12 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def orientation(self):
-        """ The orientation of the ColorBar
-        """
+        """The orientation of the ColorBar"""
         return self._orientation
 
     @property
     def size(self):
-        """ The size of the ColorBar
+        """The size of the ColorBar
 
         Returns
         -------

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -82,7 +82,6 @@ class _CoreColorBarVisual(Visual):
     --------
     vispy.visuals.ColorBarVisual
     """
-
     def __init__(self, pos, halfdim,
                  cmap,
                  orientation,
@@ -117,8 +116,9 @@ class _CoreColorBarVisual(Visual):
 
     def _update(self):
         """Rebuilds the shaders, and repositions the objects
-        that are used internally by the ColorBarVisual
+           that are used internally by the ColorBarVisual
         """
+
         x, y = self._pos
         halfw, halfh = self._halfdim
 
@@ -133,11 +133,11 @@ class _CoreColorBarVisual(Visual):
         # test that the given width and height is consistent
         # with the orientation
         if (self._orientation == "bottom" or self._orientation == "top"):
-            if halfw < halfh:
-                raise ValueError("half-width(%s) < half-height(%s) for"
-                                 "%s orientation,"
-                                 " expected half-width >= half-height" %
-                                 (halfw, halfh, self._orientation, ))
+                if halfw < halfh:
+                    raise ValueError("half-width(%s) < half-height(%s) for"
+                                     "%s orientation,"
+                                     " expected half-width >= half-height" %
+                                     (halfw, halfh, self._orientation, ))
         else:  # orientation == left or orientation == right
             if halfw > halfh:
                 raise ValueError("half-width(%s) > half-height(%s) for"
@@ -157,15 +157,12 @@ class _CoreColorBarVisual(Visual):
 
         self.shared_program['a_position'] = vertices
 
-        self.shared_program['texture2D_LUT'] = self._cmap.texture_lut() \
-            if (hasattr(self._cmap, 'texture_lut')) else None
-
     @staticmethod
     def _get_orientation_error(orientation):
-        return ValueError("orientation must"
-                          " be one of 'top', 'bottom', "
-                          "'left', or 'right', "
-                          "not '%s'" % (orientation, ))
+            return ValueError("orientation must"
+                              " be one of 'top', 'bottom', "
+                              "'left', or 'right', "
+                              "not '%s'" % (orientation, ))
 
     @property
     def pos(self):
@@ -186,7 +183,8 @@ class _CoreColorBarVisual(Visual):
 
     @property
     def cmap(self):
-        """The colormap of the Colorbar"""
+        """ The colormap of the Colorbar
+        """
         return self._cmap
 
     @cmap.setter
@@ -255,7 +253,7 @@ class ColorBarVisual(CompoundVisual):
     pos : tuple (x, y)
         Position where the colorbar is to be placed with
         respect to the center of the colorbar
-    label_str : str
+    label_text : str
         The label that is to be drawn with the colorbar
         that provides information about the colorbar.
     label_color : str | vispy.color.Color
@@ -272,7 +270,6 @@ class ColorBarVisual(CompoundVisual):
         The color of the border of the colormap. This can either be a
         str as the color's name or an actual instace of a vipy.color.Color
     """
-
     # The padding multiplier that's used to place the text
     # next to the Colorbar. Makes sure the text isn't
     # visually "sticking" to the Colorbar
@@ -280,14 +277,13 @@ class ColorBarVisual(CompoundVisual):
 
     def __init__(self, cmap, orientation, size,
                  pos=[0, 0],
-                 label_str="",
+                 label_text="",
                  label_color='black',
                  clim=(0.0, 1.0),
                  border_width=1.0,
                  border_color="black",
                  **kwargs):
 
-        self._label_str = label_str
         self._label_color = label_color
         self._cmap = get_colormap(cmap)
         self._clim = clim
@@ -295,7 +291,7 @@ class ColorBarVisual(CompoundVisual):
         self._size = size
         self._orientation = orientation
 
-        self._label = TextVisual(self._label_str, color=self._label_color)
+        self._label = TextVisual(label_text, color=self._label_color)
 
         self._ticks = []
         self._ticks.append(TextVisual(str(self._clim[0]),
@@ -328,7 +324,7 @@ class ColorBarVisual(CompoundVisual):
 
     def _update(self):
         """Rebuilds the shaders, and repositions the objects
-        that are used internally by the ColorBarVisual
+           that are used internally by the ColorBarVisual
         """
         self._colorbar.halfdim = self._halfdim
         self._border.halfdim = self._halfdim
@@ -342,7 +338,10 @@ class ColorBarVisual(CompoundVisual):
         self._border._update()
 
     def _update_positions(self):
-        """Updates the positions of the colorbars and labels"""
+        """
+        updates the positions of the colorbars and labels
+
+        """
         self._colorbar.pos = self._pos
         self._border.pos = self._pos
 
@@ -558,7 +557,8 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def pos(self):
-        """The position of the text anchor in the local coordinate frame"""
+        """ The position of the text anchor in the local coordinate frame
+        """
         return self._pos
 
     @pos.setter
@@ -568,7 +568,8 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def cmap(self):
-        """The colormap of the Colorbar"""
+        """ The colormap of the Colorbar
+        """
         return self._colorbar._cmap
 
     @cmap.setter
@@ -577,12 +578,13 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def clim(self):
-        """The data limits of the Colorbar
+        """ The data limits of the Colorbar
 
         Returns
         -------
         clim: tuple(min, max)
         """
+
         return self._clim
 
     @clim.setter
@@ -592,17 +594,21 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def label(self):
-        """The vispy.visuals.TextVisual associated with the label"""
+        """ The vispy.visuals.TextVisual associated with the label
+        """
         return self._label
 
     @label.setter
     def label(self, label):
-        self._label = label
+        if isinstance(label, str):
+            self._label.text = label
+        else:
+            self._label = label
         self._update()
 
     @property
     def ticks(self):
-        """The vispy.visuals.TextVisual associated with the ticks
+        """ The vispy.visuals.TextVisual associated with the ticks
 
         Returns
         -------
@@ -618,7 +624,8 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def border_width(self):
-        """The width of the border around the ColorBar in pixels"""
+        """ The width of the border around the ColorBar in pixels
+        """
         return self._border.border_width
 
     @border_width.setter
@@ -628,7 +635,8 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def border_color(self):
-        """The color of the border around the ColorBar in pixels"""
+        """ The color of the border around the ColorBar in pixels
+        """
         return self._border.border_color
 
     @border_color.setter
@@ -638,12 +646,13 @@ class ColorBarVisual(CompoundVisual):
 
     @property
     def orientation(self):
-        """The orientation of the ColorBar"""
+        """ The orientation of the ColorBar
+        """
         return self._orientation
 
     @property
     def size(self):
-        """The size of the ColorBar
+        """ The size of the ColorBar
 
         Returns
         -------

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -258,7 +258,7 @@ class ColorBarVisual(CompoundVisual):
         that provides information about the colorbar.
         If a TextVisual object then 'label_color' is ignored.
     label_color : str | vispy.color.Color
-        The color of the labels. This can either be a
+        The color of the label and tick labels. This can either be a
         str as the color's name or an actual instace of a vipy.color.Color
     clim : tuple (min, max)
         the minimum and maximum values of the data that

--- a/vispy/visuals/colorbar.py
+++ b/vispy/visuals/colorbar.py
@@ -253,9 +253,10 @@ class ColorBarVisual(CompoundVisual):
     pos : tuple (x, y)
         Position where the colorbar is to be placed with
         respect to the center of the colorbar
-    label : str
+    label : str | vispy.visuals.TextVisual
         The label that is to be drawn with the colorbar
         that provides information about the colorbar.
+        If a TextVisual object then 'label_color' is ignored.
     label_color : str | vispy.color.Color
         The color of the labels. This can either be a
         str as the color's name or an actual instace of a vipy.color.Color
@@ -287,23 +288,23 @@ class ColorBarVisual(CompoundVisual):
                  label_color='black',
                  clim=(0.0, 1.0),
                  border_width=1.0,
-                 border_color="black",
-                 **kwargs):
+                 border_color="black"):
 
-        self._label_color = label_color
         self._cmap = get_colormap(cmap)
         self._clim = clim
         self._pos = pos
         self._size = size
         self._orientation = orientation
 
-        self._label = TextVisual(label, color=self._label_color)
+        if not isinstance(label, TextVisual):
+            label = TextVisual(label, color=label_color)
+        self._label = label
 
         self._ticks = []
         self._ticks.append(TextVisual(str(self._clim[0]),
-                                      color=self._label_color))
+                                      color=label_color))
         self._ticks.append(TextVisual(str(self._clim[1]),
-                                      color=self._label_color))
+                                      color=label_color))
 
         if orientation in ["top", "bottom"]:
             (width, height) = size

--- a/vispy/visuals/tests/test_colorbar.py
+++ b/vispy/visuals/tests/test_colorbar.py
@@ -15,7 +15,7 @@ def create_colorbar(pos, size, orientation):
     colorbar = visuals.ColorBar(pos=pos,
                                 size=size,
                                 orientation=orientation,
-                                label_str='label string here',
+                                label='label string here',
                                 cmap='autumn',
                                 border_color='white',
                                 border_width=2)
@@ -144,5 +144,20 @@ def test_attributes():
             create_colorbar(pos=(50, 50),
                             size=(60, 4),
                             orientation='top-invalid')
+
+
+def test_colorbar_label_change():
+    with TestingCanvas() as c:
+        colorbar = create_colorbar(pos=(50, 50),
+                                   size=(60, 4),
+                                   orientation='top')
+        colorbar.cmap = "ice"
+        orig_text_vis = colorbar.label
+        colorbar.label = "New Label"
+        assert colorbar.label.text == "New Label"
+        assert colorbar.label is orig_text_vis
+
+        c.draw_visual(colorbar)
+
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_colorbar.py
+++ b/vispy/visuals/tests/test_colorbar.py
@@ -146,6 +146,7 @@ def test_attributes():
                             orientation='top-invalid')
 
 
+@requires_application()
 def test_colorbar_label_change():
     with TestingCanvas() as c:
         colorbar = create_colorbar(pos=(50, 50),

--- a/vispy/visuals/tests/test_colorbar.py
+++ b/vispy/visuals/tests/test_colorbar.py
@@ -11,11 +11,11 @@ from vispy.testing import (requires_application, TestingCanvas,
 from vispy.testing.image_tester import assert_image_approved
 
 
-def create_colorbar(pos, size, orientation):
+def create_colorbar(pos, size, orientation, label='label string here'):
     colorbar = visuals.ColorBar(pos=pos,
                                 size=size,
                                 orientation=orientation,
-                                label='label string here',
+                                label=label,
                                 cmap='autumn',
                                 border_color='white',
                                 border_width=2)
@@ -157,6 +157,21 @@ def test_colorbar_label_change():
         colorbar.label = "New Label"
         assert colorbar.label.text == "New Label"
         assert colorbar.label is orig_text_vis
+
+        c.draw_visual(colorbar)
+
+
+@requires_application()
+def test_colorbar_label_as_textvisual():
+    with TestingCanvas() as c:
+        label = visuals.Text("my label")
+        colorbar = create_colorbar(pos=(50, 50),
+                                   size=(60, 4),
+                                   orientation='top',
+                                   label=label)
+        colorbar.cmap = "ice"
+        assert colorbar.label.text == "my label"
+        assert colorbar.label is label
 
         c.draw_visual(colorbar)
 


### PR DESCRIPTION
Let's try this again. This is a replacement for #2056 which after trying to rebase and merge just got too ugly with commit history. I instead copied the current state of #1292 into a new branch and committed with @macrocosme as the author of the commit.

Updates .label property so it can be provided a TextVisual or a new string to update the existing TextVisual of a ColorbarVisual.

This is a replacement for #1292 so that I can actually make commits to it (compared to the original fork's master branch).

I'll need to reapply the style fixes from `main`.