### PR TITLE
Fix glfw not sizing visuals correctly on initial draw

### DIFF
--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -289,6 +289,7 @@ class CanvasBackend(BaseCanvasBackend):
         self._next_key_text = {}
         self._vispy_canvas.set_current()
         self._vispy_canvas.events.initialize()
+        self._on_resize(self._id, size[0], size[1])
 
     def _vispy_warmup(self):
         etime = time() + 0.25


### PR DESCRIPTION
Closes #1465 

This is the simplest fix or workaround I could find for the various bugs related to glfw not handling the initial size of a window properly. As mentioned in #1465 I don't think this should break anyone's workflow as it shouldn't have worked before anyway and is just an extra vispy resize event. I'm not sure how to test this as it seems using `canvas.render()` which is used in all our tests that actually render something puts things into a proper state because it push/pops viewports which makes calls to `self.context.set_viewport` and `self._update_transforms` and makes the visuals draw correctly. These same methods are called from the `on_resize` method and is the only reason other backends like pyqt work properly. If I turn off the resize handling and run with pyqt I get the same result as glfw.

Given that other backends work as-is, I think modifying only the glfw backend here is the right choice.