### PR TITLE
make agg lines write correct depth value

### DIFF
--- a/vispy/glsl/lines/agg.vert
+++ b/vispy/glsl/lines/agg.vert
@@ -99,19 +99,13 @@ void main()
     v_color.a = min(v_linewidth, v_color.a);
     v_linewidth = max(v_linewidth, 1.0);
 
-    // If color is fully transparent we just will discard the fragment anyway
-//    if( v_color.a <= 0.0 )
-//    {
-//        gl_Position = vec4(0.0,0.0,0.0,1.0);
-//        return;
-//    }
-
     // This is the actual half width of the line
     // TODO: take care of logical - physical pixel difference here.
     float w = ceil(1.25*v_antialias+v_linewidth)/2.0;
 
-    //vec2 position = $transform(vec4(a_position,0.,1.)).xy*u_scale;
-    vec2 position = $transform(vec4(a_position,0.,1.)).xy;
+    vec4 doc_pos = $transform(vec4(a_position,0.,1.));
+    //vec2 position = doc_pos.xy * u_scale;
+    vec2 position = doc_pos.xy;
     // At this point, position must be in _doc_ coordinates because the line
     // width will be added to it.
 
@@ -242,6 +236,6 @@ void main()
     }
 
     v_texcoord = vec2( u, v*w );
-    gl_Position = $px_ndc_transform($doc_px_transform(vec4(position,
-                                                           0.0, 1.0)));
+
+    gl_Position = $px_ndc_transform($doc_px_transform(vec4(position, doc_pos.z, 1.0)));
 }

--- a/vispy/visuals/line/line.py
+++ b/vispy/visuals/line/line.py
@@ -418,6 +418,8 @@ class _AggLineVisual(Visual):
         Visual.__init__(self, vcode=self.VERTEX_SHADER,
                         fcode=self.FRAGMENT_SHADER)
         self._index_buffer = gloo.IndexBuffer()
+        # The depth_test being disabled prevents z-ordering, but if
+        # we turn it on the blending of the aa edges produces artifacts.
         self.set_gl_state('translucent', depth_test=False)
         self._draw_mode = 'triangles'
 
@@ -425,7 +427,6 @@ class _AggLineVisual(Visual):
         data_doc = view.get_transform('visual', 'document')
         doc_px = view.get_transform('document', 'framebuffer')
         px_ndc = view.get_transform('framebuffer', 'render')
-
         vert = view.view_program.vert
         vert['transform'] = data_doc
         vert['doc_px_transform'] = doc_px


### PR DESCRIPTION
Closes #1441. This changes the agg-line vert shader so that it writes the correct value to the depth-buffer. However, 
we can't really turn on depth testing by default because it will cause weird artifacts at the edges. This is part of the general problem of blending translucent objects ...

Neverthertheless, when needed the depth test can be turned on. The example in #1441 then becomes:
```py
import sys
from vispy import scene
from vispy import app
from vispy.io import load_data_file, read_png

import numpy as np
from vispy.visuals.transforms import STTransform

canvas = scene.SceneCanvas(keys='interactive')
canvas.size = 800, 600
canvas.show()

# Set up a viewbox to display the image with interactive pan/zoom
view = canvas.central_widget.add_view()

# Create the image
img_data = read_png(load_data_file('mona_lisa/mona_lisa_sm.png'))
interpolation = 'nearest'

# Add other visuals to main_view
pos = np.zeros((2, 2)).astype(np.float32)
pos[:, 0] = np.array([-10, 600]).astype(np.float32)
pos[:, 1] = np.array([-10, 600]).astype(np.float32)
line_pre = scene.visuals.Line(pos=pos, parent=view.scene, color='red', width=40, method='agg')
line_pre_z_ind = 0
line_pre.transform = STTransform(translate=[0, 0, line_pre_z_ind])
line_pre.set_gl_state(depth_test=True)

image = scene.visuals.Image(img_data, interpolation=interpolation, parent=view.scene, method='subdivide')
image.transform = STTransform(translate=[0, 0, 0])

canvas.title = 'Spatial Filtering using %s Filter' % interpolation

# Set 2D camera (the camera will scale to the contents in the scene)
view.camera = scene.PanZoomCamera(aspect=1)
# flip y-axis to have correct aligment
view.camera.flip = (0, 1, 0)
view.camera.set_range()
view.camera.zoom(0.1, (250, 200))

# get interpolation functions from Image
names = image.interpolation_functions
names = list(names)
names.sort()
act = 17

# Add other visuals to main_view
pos = np.zeros((2, 2)).astype(np.float32)
pos[:, 0] = np.array([-10, 600]).astype(np.float32)
pos[:, 1] = np.array([-9, 601]).astype(np.float32)
line_post = scene.visuals.Line(pos=pos, parent=view.scene, color='blue', width=40, method='agg')
line_post.transform = STTransform(translate=[0, 0, 0])

view.camera.set_range(x=(-10,10), y=(-10,10))

# Implement key presses
@canvas.events.key_press.connect
def on_key_press(event):
    global act, line_pre_z_ind
    if event.key in ['Left', 'Right']:
        if event.key == 'Right':
            step = 1
            line_pre.transform = STTransform(translate=[0, -5, line_pre_z_ind])
        else:
            step = -1
            line_pre.transform = STTransform(translate=[0, 5, line_pre_z_ind])
        act = (act + step) % len(names)
        interpolation = names[act]
        image.interpolation = interpolation
        canvas.title = 'Spatial Filtering using %s Filter' % interpolation
        canvas.update()
    if event.key in ['Down', 'Up']:
        if event.key == 'Down':
            line_pre_z_ind = -10
            print( event.key, 'New z-indx for red line', line_pre_z_ind)
            line_pre.transform = STTransform(translate=[0, 0, line_pre_z_ind])
        if event.key == 'Up':
            line_pre_z_ind = 10
            print( event.key, 'New z-indx for red line', line_pre_z_ind)
            line_pre.transform = STTransform(translate=[0, 0, line_pre_z_ind])
        act = (act) % len(names)
        interpolation = names[act]
        canvas.title = 'Spatial Filtering using {:} Filter, z_ind={:d}'.format(interpolation, line_pre_z_ind)
        canvas.update()


if __name__ == '__main__' and sys.flags.interactive == 0:
    app.run()
``` 

(I only added `line_pre.set_gl_state(depth_test=True)`)