### PR TITLE
Change builtin colormaps to all be instances

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1084,12 +1084,12 @@ _colormaps = dict(
     GrBu_d=Diverging(255, 133, 0.75, 0.6, "dark"),
     RdBu=Diverging(220, 20, 0.75, 0.5),
 
-    cubehelix=CubeHelixColormap,
-    single_hue=SingleHue,
-    hsl=HSL,
-    husl=HSLuv,
-    diverging=Diverging,
-    RdYeBuCy=RedYellowBlueCyan,
+    cubehelix=CubeHelixColormap(),
+    single_hue=SingleHue(),
+    hsl=HSL(),
+    husl=HSLuv(),
+    diverging=Diverging(),
+    RdYeBuCy=RedYellowBlueCyan(),
 )
 
 
@@ -1129,7 +1129,6 @@ def get_colormap(name, *args, **kwargs):
         warnings.warn(f"Colormap '{name}' has been deprecated. "
                       f"Please import and create 'vispy.color.colormap.{cls.__name__}' "
                       "directly instead.", DeprecationWarning)
-        return cls()
 
     if isinstance(name, BaseColormap):
         return name

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -763,7 +763,7 @@ class _Diverging(Colormap):
 
 
 class _RedYellowBlueCyan(Colormap):
-    """A colormap which is goes red-yellow positive and blue-cyan negative
+    """A colormap which goes red-yellow positive and blue-cyan negative
 
     Parameters
     ---------
@@ -1085,48 +1085,56 @@ _colormaps = dict(
     GrBu_d=_Diverging(255, 133, 0.75, 0.6, "dark"),
     RdBu=_Diverging(220, 20, 0.75, 0.5),
 
-    # Configurable colormaps
-    cubehelix=CubeHelixColormap,
-    single_hue=_SingleHue,
-    hsl=_HSL,
-    husl=_HUSL,
-    hsluv=_HSLuv,
-    diverging=_Diverging,
-    RdYeBuCy=_RedYellowBlueCyan,
+    cubehelix=CubeHelixColormap(),
+    single_hue=_SingleHue(),
+    hsl=_HSL(),
+    husl=_HSLuv(),
+    hsluv=_HSLuv(),
+    diverging=_Diverging(),
+    RdYeBuCy=_RedYellowBlueCyan(),
 )
 
 
-def get_colormap(name, *args, **kwargs):
-    """Obtain a colormap
-    Some colormaps can have additional configuration parameters. Refer to
-    their corresponding documentation for more information.
+def get_colormap(name):
+    """Obtain a colormap.
+
     Parameters
     ----------
     name : str | Colormap
         Colormap name. Can also be a Colormap for pass-through.
+
     Examples
     --------
         >>> get_colormap('autumn')
-        >>> get_colormap('single_hue', hue=10)
+        >>> get_colormap('single_hue')
+
+    .. versionchanged: 0.7
+
+        Additional args/kwargs are no longer accepted. Colormap classes are
+        no longer created on the fly.
+
     """
+    if name == "single_hue":
+        warnings.warn("Colormap 'single_hue' has been deprecated. "
+                      "Please use 'light_blues' instead.", DeprecationWarning)
+    if name == "husl":
+        warnings.warn("Colormap 'husl' has been deprecated. "
+                      "Please use 'hsluv' instead.", DeprecationWarning)
+
     if isinstance(name, BaseColormap):
-        cmap = name
-    else:
-        if not isinstance(name, str):
-            raise TypeError('colormap must be a Colormap or string name')
-        if name in _colormaps:  # vispy cmap
-            cmap = _colormaps[name]
-        elif has_matplotlib():  # matplotlib cmap
-            try:
-                cmap = MatplotlibColormap(name)
-            except ValueError:
-                raise KeyError('colormap name %s not found' % name)
-        else:
+        return name
+
+    if not isinstance(name, str):
+        raise TypeError('colormap must be a Colormap or string name')
+    if name in _colormaps:  # vispy cmap
+        cmap = _colormaps[name]
+    elif has_matplotlib():  # matplotlib cmap
+        try:
+            cmap = MatplotlibColormap(name)
+        except ValueError:
             raise KeyError('colormap name %s not found' % name)
-
-        if inspect.isclass(cmap):
-            cmap = cmap(*args, **kwargs)
-
+    else:
+        raise KeyError('colormap name %s not found' % name)
     return cmap
 
 

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -607,7 +607,7 @@ class _Winter(BaseColormap):
                            np.sqrt(t))
 
 
-class _SingleHue(Colormap):
+class SingleHue(Colormap):
     """A colormap which is solely defined by the given hue and value.
 
     Given the color hue and value, this color map increases the saturation
@@ -643,10 +643,10 @@ class _SingleHue(Colormap):
             (hue, saturation_range[0], value),
             (hue, saturation_range[1], value)
         ], color_space='hsv')
-        super(_SingleHue, self).__init__(colors)
+        super(SingleHue, self).__init__(colors)
 
 
-class _HSL(Colormap):
+class HSL(Colormap):
     """A colormap which is defined by n evenly spaced points in a circular color space.
 
     This means that we change the hue value while keeping the
@@ -685,11 +685,11 @@ class _HSL(Colormap):
         colors = ColorArray([(hue, saturation, value) for hue in hues],
                             color_space='hsv')
 
-        super(_HSL, self).__init__(colors, controls=controls,
-                                   interpolation=interpolation)
+        super(HSL, self).__init__(colors, controls=controls,
+                                  interpolation=interpolation)
 
 
-class _HSLuv(Colormap):
+class HSLuv(Colormap):
     """A colormap which is defined by n evenly spaced points in the HSLuv space.
 
     Parameters
@@ -733,19 +733,19 @@ class _HSLuv(Colormap):
             [hsluv_to_rgb([hue, saturation, value]) for hue in hues],
         )
 
-        super(_HSLuv, self).__init__(colors, controls=controls,
-                                     interpolation=interpolation)
+        super(HSLuv, self).__init__(colors, controls=controls,
+                                    interpolation=interpolation)
 
 
-class _HUSL(_HSLuv):
+class _HUSL(HSLuv):
     """Deprecated."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("_HUSL Colormap is deprecated. Please use '_HSLuv' instead.")
+        warnings.warn("_HUSL Colormap is deprecated. Please use 'HSLuv' instead.")
         super().__init__(*args, **kwargs)
 
 
-class _Diverging(Colormap):
+class Diverging(Colormap):
 
     def __init__(self, h_pos=20, h_neg=250, saturation=1.0, value=0.7,
                  center="light"):
@@ -759,10 +759,10 @@ class _Diverging(Colormap):
 
         colors = ColorArray([start, mid, end])
 
-        super(_Diverging, self).__init__(colors)
+        super(Diverging, self).__init__(colors)
 
 
-class _RedYellowBlueCyan(Colormap):
+class RedYellowBlueCyan(Colormap):
     """A colormap which goes red-yellow positive and blue-cyan negative
 
     Parameters
@@ -783,7 +783,7 @@ class _RedYellowBlueCyan(Colormap):
         colors = [(0., 1., 1., 1.), (0., 0., 1., 1.), (0., 0., 1., 0.),
                   (1., 0., 0., 0.), (1., 0., 0., 1.), (1., 1., 0., 1.)]
         colors = ColorArray(colors)
-        super(_RedYellowBlueCyan, self).__init__(
+        super(RedYellowBlueCyan, self).__init__(
             colors, controls=controls, interpolation='linear')
 
 
@@ -1068,8 +1068,8 @@ _colormaps = dict(
     hot=_Hot(),
     ice=_Ice(),
     winter=_Winter(),
-    light_blues=_SingleHue(),
-    orange=_SingleHue(hue=35),
+    light_blues=SingleHue(),
+    orange=SingleHue(hue=35),
     viridis=Colormap(ColorArray(_viridis_data)),
     # Diverging presets
     coolwarm=Colormap(ColorArray(
@@ -1080,28 +1080,31 @@ _colormaps = dict(
         ],
         color_space="hsv"
     )),
-    PuGr=_Diverging(145, 280, 0.85, 0.30),
-    GrBu=_Diverging(255, 133, 0.75, 0.6),
-    GrBu_d=_Diverging(255, 133, 0.75, 0.6, "dark"),
-    RdBu=_Diverging(220, 20, 0.75, 0.5),
+    PuGr=Diverging(145, 280, 0.85, 0.30),
+    GrBu=Diverging(255, 133, 0.75, 0.6),
+    GrBu_d=Diverging(255, 133, 0.75, 0.6, "dark"),
+    RdBu=Diverging(220, 20, 0.75, 0.5),
 
-    cubehelix=CubeHelixColormap(),
-    single_hue=_SingleHue(),
-    hsl=_HSL(),
-    husl=_HSLuv(),
-    hsluv=_HSLuv(),
-    diverging=_Diverging(),
-    RdYeBuCy=_RedYellowBlueCyan(),
+    cubehelix=CubeHelixColormap,
+    single_hue=SingleHue,
+    hsl=HSL,
+    husl=HSLuv,
+    diverging=Diverging,
+    RdYeBuCy=RedYellowBlueCyan,
 )
 
 
-def get_colormap(name):
+def get_colormap(name, *args, **kwargs):
     """Obtain a colormap.
 
     Parameters
     ----------
     name : str | Colormap
         Colormap name. Can also be a Colormap for pass-through.
+    *args:
+        Deprecated.
+    **kwargs
+        Deprecated.
 
     Examples
     --------
@@ -1111,15 +1114,22 @@ def get_colormap(name):
     .. versionchanged: 0.7
 
         Additional args/kwargs are no longer accepted. Colormap classes are
-        no longer created on the fly.
+        no longer created on the fly. To create a ``cubehelix``
+        (``CubeHelixColormap``), ``single_hue`` (``SingleHue``), ``hsl``
+        (``HSL``), ``husl`` (``HSLuv``), ``diverging`` (``Diverging``), or
+        ``RdYeBuCy`` (``RedYellowBlueCyan``) colormap you must import and
+        instantiate it directly from the ``vispy.color.colormap`` module.
 
     """
-    if name == "single_hue":
-        warnings.warn("Colormap 'single_hue' has been deprecated. "
-                      "Please use 'light_blues' instead.", DeprecationWarning)
-    if name == "husl":
-        warnings.warn("Colormap 'husl' has been deprecated. "
-                      "Please use 'hsluv' instead.", DeprecationWarning)
+    if args or kwargs:
+        warnings.warn("Creating a Colormap instance with 'get_colormap' is "
+                      "no longer supported. No additional arguments or "
+                      "keyword arguments should be passed.", DeprecationWarning)
+    if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
+        cls = _colormaps.get(name, "<deprecated>")
+        warnings.warn(f"Colormap '{name}' has been deprecated. "
+                      f"Please import and create 'vispy.color.colormap.{cls.__name__}' "
+                      "directly instead.", DeprecationWarning)
 
     if isinstance(name, BaseColormap):
         return name

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -3,7 +3,6 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 from __future__ import division  # just to be safe...
-import inspect
 import warnings
 
 import numpy as np

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1124,12 +1124,6 @@ def get_colormap(name, *args, **kwargs):
         warnings.warn("Creating a Colormap instance with 'get_colormap' is "
                       "no longer supported. No additional arguments or "
                       "keyword arguments should be passed.", DeprecationWarning)
-    if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
-        cls = _colormaps.get(name, "<deprecated>")
-        warnings.warn(f"Colormap '{name}' has been deprecated. "
-                      f"Please import and create 'vispy.color.colormap.{cls.__name__}' "
-                      "directly instead.", DeprecationWarning)
-
     if isinstance(name, BaseColormap):
         return name
 
@@ -1137,6 +1131,11 @@ def get_colormap(name, *args, **kwargs):
         raise TypeError('colormap must be a Colormap or string name')
     if name in _colormaps:  # vispy cmap
         cmap = _colormaps[name]
+        if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
+            warnings.warn(f"Colormap '{name}' has been deprecated. "
+                          f"Please import and create 'vispy.color.colormap.{cmap.__class__.__name__}' "
+                          "directly instead.", DeprecationWarning)
+
     elif has_matplotlib():  # matplotlib cmap
         try:
             cmap = MatplotlibColormap(name)

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1130,6 +1130,7 @@ def get_colormap(name, *args, **kwargs):
         warnings.warn(f"Colormap '{name}' has been deprecated. "
                       f"Please import and create 'vispy.color.colormap.{cls.__name__}' "
                       "directly instead.", DeprecationWarning)
+        return cls()
 
     if isinstance(name, BaseColormap):
         return name

--- a/vispy/visuals/tests/test_colormap.py
+++ b/vispy/visuals/tests/test_colormap.py
@@ -11,7 +11,7 @@ from vispy.scene.visuals import Image
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
 from vispy.testing.image_tester import assert_image_approved
-from vispy.color import (get_colormap, Colormap)
+from vispy.color import Colormap
 
 size = (100, 100)
 
@@ -58,10 +58,12 @@ def test_colormap_discrete_nu():
 @requires_application()
 def test_colormap_single_hue():
     """Test colormap support using a single hue()"""
+    from vispy.color.colormap import SingleHue
     with TestingCanvas(size=size, bgcolor='w') as c:
         idata = np.linspace(255, 0, size[0]*size[1]).astype(np.ubyte)
         data = idata.reshape((size[0], size[1]))
-        image = Image(cmap=get_colormap('single_hue', 255),
+        cmap = SingleHue(255)
+        image = Image(cmap=cmap,
                       clim='auto', parent=c.scene)
         image.set_data(data)
         assert_image_approved(c.render(), "visuals/colormap_hue.png")
@@ -81,10 +83,12 @@ def test_colormap_coolwarm():
 @requires_application()
 def test_colormap_CubeHelix():
     """Test colormap support using cubehelix colormap in only blues"""
+    from vispy.color.colormap import CubeHelixColormap
     with TestingCanvas(size=size, bgcolor='w') as c:
         idata = np.linspace(255, 0, size[0]*size[1]).astype(np.ubyte)
         data = idata.reshape((size[0], size[1]))
-        image = Image(cmap=get_colormap('cubehelix', rot=0, start=0),
+        cmap = CubeHelixColormap(rot=0, start=0)
+        image = Image(cmap=cmap,
                       clim='auto', parent=c.scene)
         image.set_data(data)
         assert_image_approved(c.render(), "visuals/colormap_cubehelix.png")


### PR DESCRIPTION
Closes #1487 

Some of the colormaps available through `vispy.color.colormap.get_colormap` were classes that were created when `get_colormap` was called with optional args, kwargs provided. This has always smelled bad to me code-wise. In this PR I create instances of the colormaps as replacements and deprecate ones that are redundant.

One consideration: should I just remove all of these instances, list them as deprecated, and then rename the classes to not be prefixed with `_`? So `_SingleHue` becomes `SingleHue` and if a user wants to create this colormap they can import it, create it, and pass it directly.

Edit: I have not updated the tests which seem to test some of these specifically.