### PR TITLE
Fix VolumeVisual bounds representing the wrong axis

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -47,6 +47,18 @@ def test_volume():
 
 
 @requires_pyopengl()
+def test_volume_bounds():
+    vol = np.zeros((20, 30, 40), 'float32')
+    vol[8:16, 8:16, :] = 1.0
+
+    # Create
+    V = scene.visuals.Volume(vol)
+    assert V._compute_bounds(0, V) == (0, 40)  # x
+    assert V._compute_bounds(1, V) == (0, 30)  # y
+    assert V._compute_bounds(2, V) == (0, 20)  # z
+
+
+@requires_pyopengl()
 @requires_application()
 def test_volume_draw():
     with TestingCanvas(bgcolor='k', size=(100, 100)) as c:

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -888,7 +888,8 @@ class VolumeVisual(Visual):
     def _compute_bounds(self, axis, view):
         if self._is_zyx:
             # axis=(x, y, z) -> shape(..., z, y, x)
-            return 0, self._vol_shape[-(axis + 1)]
+            ndim = len(self._vol_shape)
+            return 0, self._vol_shape[ndim - 1 - axis]
         else:
             # axis=(x, y, z) -> shape(x, y, z)
             return 0, self._vol_shape[axis]

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -463,7 +463,8 @@ class VolumeVisual(Visual):
     Parameters
     ----------
     vol : ndarray
-        The volume to display. Must be ndim==3.
+        The volume to display. Must be ndim==3. Array is assumed to be stored
+        as ``(z, y, x)``.
     clim : tuple of two floats | None
         The contrast limits. The values in the volume are mapped to
         black and white corresponding to these values. Default maps

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -519,6 +519,7 @@ class VolumeVisual(Visual):
         self._clim_range_threshold = clim_range_threshold
         # Set the colormap
         self._cmap = get_colormap(cmap)
+        self._is_zyx = True
 
         # Create gloo objects
         self._vertices = VertexBuffer()
@@ -885,7 +886,12 @@ class VolumeVisual(Visual):
         self._index_buffer.set_data(indices)
 
     def _compute_bounds(self, axis, view):
-        return 0, self._vol_shape[axis]
+        if self._is_zyx:
+            # axis=(x, y, z) -> shape(..., z, y, x)
+            return 0, self._vol_shape[-(axis + 1)]
+        else:
+            # axis=(x, y, z) -> shape(x, y, z)
+            return 0, self._vol_shape[axis]
 
     def _prepare_transforms(self, view):
         trs = view.transforms


### PR DESCRIPTION
This is a partial fix for #2064 (CC @yxdragon).

The issue is that the VolumeVisual assumes data is in the shape of `(z, y, x)`, but VisPy seems to assume that axis (0, 1, 2) -> (x, y, z). We can see this in the `ImageVisual` which passes data as `(y, x)` and in its `_compute_bounds` method it uses `self.size` which is the reversed shape of the array. So the bounds are computed accurately. For the VolumeVisual, we need to take these values in reverse as well (but aren't currently). This PR does this by using in a way so if a VolumeVisual ever has more than 3 dimensions, the last 3 dimensions are used. I'm not sure that is a bad assumption or not bug :shrug: 

Also, I've added a `self._is_zyx` property to the `VolumeVisual` so that in the future the rest of #2064 can be resolved in which a user can pass data with `(x, y, z)` (matching `MeshVisual`/`Isosurface`) and still get the correct bounds.

Running this code:

```python
from vispy import scene
import numpy as np
import scipy.ndimage as ndimg

canvas = scene.SceneCanvas(keys='interactive', bgcolor='white', size=(800, 600), show=True)
view = canvas.central_widget.add_view()

imgs = np.zeros((100,200,300), dtype=np.float32)
imgs.ravel()[np.random.randint(0,100*200*300,1000)]=1
imgs = ndimg.gaussian_filter(imgs, 3)
scene.visuals.Volume(imgs, cmap='hot', parent=view.scene)

if __name__ == '__main__':
    canvas.app.run()
```

Without this PR produces (not centered on the Visual):

![image](https://user-images.githubusercontent.com/1828519/121828832-62311580-cc86-11eb-862b-8829420db643.png)

With this PR produces (centered on the Visual):

![image](https://user-images.githubusercontent.com/1828519/121828848-737a2200-cc86-11eb-885d-c4f84201dcc0.png)
