### PR TITLE
Fix PanZoomCamera 'center' property not updating view

### DIFF
--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -43,9 +43,11 @@ class PanZoomCamera(BaseCamera):
 
     """
 
+    DEFAULT_RECT_TUPLE = (0, 0, 1, 1)
+
     _state_props = BaseCamera._state_props + ('rect', )
 
-    def __init__(self, rect=(0, 0, 1, 1), aspect=None, **kwargs):
+    def __init__(self, rect=DEFAULT_RECT_TUPLE, aspect=None, **kwargs):
         super(PanZoomCamera, self).__init__(**kwargs)
 
         self.transform = STTransform()
@@ -152,22 +154,23 @@ class PanZoomCamera(BaseCamera):
     @property
     def center(self):
         rect = self._rect
-        return 0.5 * (rect.left + rect.right), 0.5 * (rect.top +
-                                                      rect.bottom), 0
+        return (*rect.center, 0)
 
     @center.setter
     def center(self, center):
         if not (isinstance(center, (tuple, list)) and len(center) in (2, 3)):
             raise ValueError('center must be a 2 or 3 element tuple')
-        rect = self.rect or Rect(0, 0, 1, 1)
+        rect = self.rect or Rect(*DEFAULT_RECT_TUPLE)
         # Get half-ranges
-        x2 = 0.5 * (rect.right - rect.left)
-        y2 = 0.5 * (rect.top - rect.bottom)
+        x2 = rect.center[0]
+        y2 = rect.center[1]
         # Apply new ranges
-        rect.left = center[0] - x2
-        rect.right = center[0] + x2
-        rect.bottom = center[1] - y2
-        rect.top = center[1] + y2
+        x1 = center[0]
+        y1 = center[1]
+        rect.left = x1 - x2
+        rect.right = x1 + x2
+        rect.bottom = y1 - y2
+        rect.top = y1 + y2
         #
         self.rect = rect
 

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -11,6 +11,9 @@ from ...geometry import Rect
 from ...visuals.transforms import STTransform, MatrixTransform
 
 
+DEFAULT_RECT_TUPLE = (0, 0, 1, 1)
+
+
 class PanZoomCamera(BaseCamera):
     """Camera implementing 2D pan/zoom mouse interaction.
 
@@ -42,8 +45,6 @@ class PanZoomCamera(BaseCamera):
         * RMB or scroll: zooms the view
 
     """
-
-    DEFAULT_RECT_TUPLE = (0, 0, 1, 1)
 
     _state_props = BaseCamera._state_props + ('rect', )
 

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -161,7 +161,7 @@ class PanZoomCamera(BaseCamera):
     def center(self, center):
         if not (isinstance(center, (tuple, list)) and len(center) in (2, 3)):
             raise ValueError('center must be a 2 or 3 element tuple')
-        rect = self.rect or Rect(*DEFAULT_RECT_TUPLE)
+        rect = Rect(self.rect) or Rect(*DEFAULT_RECT_TUPLE)
         # Get half-ranges
         x2 = rect.center[0]
         y2 = rect.center[1]

--- a/vispy/scene/cameras/tests/test_perspective.py
+++ b/vispy/scene/cameras/tests/test_perspective.py
@@ -5,6 +5,7 @@
 # -----------------------------------------------------------------------------
 import sys
 
+import numpy as np
 import pytest
 
 from vispy import scene, io
@@ -50,6 +51,35 @@ def test_perspective_render():
                               px_threshold=20,
                               px_count=60,
                               max_px_diff=200)
+
+
+@requires_application()
+def test_panzoom_center():
+    with TestingCanvas(size=(120, 200)) as canvas:
+        grid = canvas.central_widget.add_grid()
+        imdata = io.load_crate().astype('float32') / 255
+
+        v = grid.add_view(row=0, col=0)
+        v.camera = 'panzoom'
+
+        image = scene.visuals.Image(imdata)
+        image.transform = scene.STTransform(translate=(-12.8, -12.8),
+                                            scale=(0.1, 0.1))
+        v.add(image)
+
+        result1 = canvas.render()[..., :3]
+        assert v.camera.center == (0.5, 0.5, 0)
+
+        v.camera.center = (-12.8, -12.8, 0)
+        result2 = canvas.render()[..., :3]
+
+        assert not np.allclose(result1, result2)
+        # we moved to the lower-left corner of the image that means only the
+        # upper-right quadrant should have data, the rest is black background
+        np.testing.assert_allclose(result2[100:, :], 0)
+        np.testing.assert_allclose(result2[:, :60], 0)
+        assert not np.allclose(result2[:100, 60:], 0)
+        assert v.camera.center == (-12.8, -12.8, 0)
 
 
 run_tests_if_main()


### PR DESCRIPTION
Replaces #1751. I tried to rebase that PR on to `main` and git (or rather pycharm) warned me that it wasn't going to end well. I instead created a new branch off of `main` and cherry-picked it since it was a single commit. I've then modified how the `DEFAULT_RECT_TUPLE` was defined as flake8 was pointing out that it isn't actually available in the internal method scope.

Now to write a test... :fearful: 