### PR TITLE
Close some GL leaks

### DIFF
--- a/examples/collections/path_collection.py
+++ b/examples/collections/path_collection.py
@@ -28,7 +28,7 @@ P[:, :, :2] += np.random.uniform(0, 800, (n, 2))[:, np.newaxis, :]
 P = P.reshape(n * len(S), 3)
 P = 2 * (P / (800, 800, 1)) - 1
 
-paths = PathCollection(mode="agg")
+paths = PathCollection(mode="agg+")
 paths.append(P, closed=True, itemsize=len(S))
 paths["linewidth"] = 1.0
 paths['viewport'] = 0, 0, 800, 800

--- a/examples/collections/path_collection.py
+++ b/examples/collections/path_collection.py
@@ -28,7 +28,7 @@ P[:, :, :2] += np.random.uniform(0, 800, (n, 2))[:, np.newaxis, :]
 P = P.reshape(n * len(S), 3)
 P = 2 * (P / (800, 800, 1)) - 1
 
-paths = PathCollection(mode="agg+")
+paths = PathCollection(mode="agg")
 paths.append(P, closed=True, itemsize=len(S))
 paths["linewidth"] = 1.0
 paths['viewport'] = 0, 0, 800, 800

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-ignore = E226,W291,W293,W503,F999,E305,F405,W504
+ignore = E226,W291,W293,W503,F999,E305,F405,W504,N
 exclude =
     glfw.py,_proxy.py,_es2.py,_gl2.py,_pyopengl2.py,
     _constants.py,png.py,ipy_inputhook.py,

--- a/vispy/app/backends/_tk.py
+++ b/vispy/app/backends/_tk.py
@@ -12,7 +12,7 @@ from ..base import (BaseApplicationBackend, BaseCanvasBackend,
                     BaseTimerBackend)
 from ...util import keys
 from ...util.ptime import time
-
+from ...gloo import gl
 
 # -------------------------------------------------------------------- init ---
 
@@ -25,9 +25,6 @@ try:
     _tk_pyopengltk_imported = False
 
     import tkinter as tk
-
-    # Explicitely use OpenGL here instead of gloo since pyopengltk will import it anyway.
-    from OpenGL import GL
     import pyopengltk
 except (ModuleNotFoundError, ImportError):
     available, testable, why_not, which = \
@@ -406,8 +403,8 @@ class CanvasBackend(OpenGLFrame, BaseCanvasBackend):
             self._native_context = vars(self).get("_CanvasBackend__context", None)
 
         self.update_idletasks()
-        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
-        GL.glClearColor(0.0, 0.0, 0.0, 0.0)
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+        gl.glClearColor(0.0, 0.0, 0.0, 0.0)
 
     def redraw(self, *args):
         """Overridden from OpenGLFrame

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -509,6 +509,16 @@ class BaseGlooFunctions(object):
                 self.glir.command('FUNC', 'glEnable', 'cull_face')
                 self.set_cull_face(*_to_args(cull_face))
 
+        # Line width needs some special care ...
+        if 'line_width' in kwargs:
+            line_width = kwargs.pop('line_width')
+            self.glir.command('FUNC', 'glLineWidth', line_width)
+        if 'line_smooth' in kwargs:
+            line_smooth = kwargs.pop('line_smooth')
+            funcname = 'glEnable' if line_smooth else 'glDisable'
+            line_smooth_enum_value = 2848  # int(GL.GL_LINE_SMOOTH)
+            self.glir.command('FUNC', funcname, line_smooth_enum_value)
+
         # Iterate over kwargs
         for key, val in kwargs.items():
             if key in _setters:

--- a/vispy/visuals/collections/agg_fast_path_collection.py
+++ b/vispy/visuals/collections/agg_fast_path_collection.py
@@ -13,6 +13,7 @@ on miter joins which may result in some glitches on screen.
 """
 import numpy as np
 from ... import glsl
+from ... import gloo
 from ...gloo import gl
 from . collection import Collection
 from ..transforms import NullTransform
@@ -213,7 +214,6 @@ class AggFastPathCollection(Collection):
 
     def draw(self, mode="triangle_strip"):
         """Draw collection"""
-        # Would call context.set_depth_mask() here, but we have no access
-        gl.glDepthMask(0)
+        gloo.set_depth_mask(0)
         Collection.draw(self, mode)
-        gl.glDepthMask(1)
+        gloo.set_depth_mask(1)

--- a/vispy/visuals/collections/agg_fast_path_collection.py
+++ b/vispy/visuals/collections/agg_fast_path_collection.py
@@ -76,7 +76,7 @@ class AggFastPathCollection(Collection):
             vertex = glsl.get('collections/agg-fast-path.vert')
         if transform is None:
             transform = NullTransform()
-        self.transform = transform        
+        self.transform = transform
         if fragment is None:
             fragment = glsl.get('collections/agg-fast-path.frag')
 
@@ -213,6 +213,7 @@ class AggFastPathCollection(Collection):
 
     def draw(self, mode="triangle_strip"):
         """Draw collection"""
-        gl.glDepthMask(gl.GL_FALSE)
+        # Would call context.set_depth_mask() here, but we have no access
+        gl.glDepthMask(0)
         Collection.draw(self, mode)
-        gl.glDepthMask(gl.GL_TRUE)
+        gl.glDepthMask(1)

--- a/vispy/visuals/collections/agg_fast_path_collection.py
+++ b/vispy/visuals/collections/agg_fast_path_collection.py
@@ -14,7 +14,6 @@ on miter joins which may result in some glitches on screen.
 import numpy as np
 from ... import glsl
 from ... import gloo
-from ...gloo import gl
 from . collection import Collection
 from ..transforms import NullTransform
 

--- a/vispy/visuals/collections/agg_path_collection.py
+++ b/vispy/visuals/collections/agg_path_collection.py
@@ -13,7 +13,6 @@ thick paths where quality is critical.
 import numpy as np
 from ... import glsl
 from ... import gloo
-from ...gloo import gl
 from . collection import Collection
 from ..transforms import NullTransform
 

--- a/vispy/visuals/collections/agg_path_collection.py
+++ b/vispy/visuals/collections/agg_path_collection.py
@@ -12,6 +12,7 @@ thick paths where quality is critical.
 """
 import numpy as np
 from ... import glsl
+from ... import gloo
 from ...gloo import gl
 from . collection import Collection
 from ..transforms import NullTransform
@@ -192,7 +193,6 @@ class AggPathCollection(Collection):
 
     def draw(self, mode="triangles"):
         """Draw collection"""
-        # Would call context.set_depth_mask() here, but we have no access
-        gl.glDepthMask(0)
+        gloo.set_depth_mask(0)
         Collection.draw(self, mode)
-        gl.glDepthMask(1)
+        gloo.set_depth_mask(1)

--- a/vispy/visuals/collections/agg_path_collection.py
+++ b/vispy/visuals/collections/agg_path_collection.py
@@ -86,7 +86,7 @@ class AggPathCollection(Collection):
             vertex = glsl.get('collections/agg-path.vert')
         if transform is None:
             transform = NullTransform()
-        self.transform = transform        
+        self.transform = transform
         if fragment is None:
             fragment = glsl.get('collections/agg-path.frag')
 
@@ -192,6 +192,7 @@ class AggPathCollection(Collection):
 
     def draw(self, mode="triangles"):
         """Draw collection"""
+        # Would call context.set_depth_mask() here, but we have no access
         gl.glDepthMask(0)
         Collection.draw(self, mode)
         gl.glDepthMask(1)


### PR DESCRIPTION
* Make flake8 ignore `N` in case the pendantic "pep8-naming" is installed.
* Check for imports of `OpenGL`:
  * Removes use of `OpenGL` in `visuals/line/line.py`.
  * Remove use of `OpenGL` in  `backends/_tk.py`.
  * No other usages.
* Check for usage of `gl` in visuals and above:
  * It is used in path collections to disable the depth buffer. Seems hard to fix, so added a comment for now.
  * No other usages.

