### PR TITLE
Improve infinity/NaN handling in VolumeVisual and ImageVisual clim calculations

### DIFF
--- a/examples/basics/plotting/volume.py
+++ b/examples/basics/plotting/volume.py
@@ -20,12 +20,10 @@ clim = [32, 192]
 texture_format = "auto"  # None for CPUScaled, "auto" for GPUScaled
 
 vol_pw = fig[0, 0]
-v=vol_pw.volume(vol_data, clim=clim, texture_format=texture_format)
+v = vol_pw.volume(vol_data, clim=clim, texture_format=texture_format)
 vol_pw.view.camera.elevation = 30
 vol_pw.view.camera.azimuth = 30
 vol_pw.view.camera.scale_factor /= 1.5
-
-
 
 shape = vol_data.shape
 fig[1, 0].image(vol_data[:, :, shape[2] // 2], cmap='grays', clim=clim,

--- a/examples/basics/plotting/volume.py
+++ b/examples/basics/plotting/volume.py
@@ -14,21 +14,26 @@ fig = vp.Fig(bgcolor='k', size=(800, 800), show=False)
 
 vol_data = np.load(io.load_data_file('brain/mri.npz'))['data']
 vol_data = np.flipud(np.rollaxis(vol_data, 1))
+vol_data = vol_data.astype(np.float32)
 
 clim = [32, 192]
+texture_format = "auto"  # None for CPUScaled, "auto" for GPUScaled
+
 vol_pw = fig[0, 0]
-vol_pw.volume(vol_data, clim=clim)
+v=vol_pw.volume(vol_data, clim=clim, texture_format=texture_format)
 vol_pw.view.camera.elevation = 30
 vol_pw.view.camera.azimuth = 30
 vol_pw.view.camera.scale_factor /= 1.5
 
+
+
 shape = vol_data.shape
 fig[1, 0].image(vol_data[:, :, shape[2] // 2], cmap='grays', clim=clim,
-                fg_color=(0.5, 0.5, 0.5, 1))
+                fg_color=(0.5, 0.5, 0.5, 1), texture_format=texture_format)
 fig[0, 1].image(vol_data[:, shape[1] // 2, :], cmap='grays', clim=clim,
-                fg_color=(0.5, 0.5, 0.5, 1))
+                fg_color=(0.5, 0.5, 0.5, 1), texture_format=texture_format)
 fig[1, 1].image(vol_data[shape[0] // 2, :, :].T, cmap='grays', clim=clim,
-                fg_color=(0.5, 0.5, 0.5, 1))
+                fg_color=(0.5, 0.5, 0.5, 1), texture_format=texture_format)
 
 if __name__ == '__main__':
     fig.show(run=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-ignore = E226,W291,W293,W503,F999,E305,F405,W504
+ignore = E226,W291,W293,W503,F999,E305,F405,W504,N
 exclude =
     glfw.py,_proxy.py,_es2.py,_gl2.py,_pyopengl2.py,
     _constants.py,png.py,ipy_inputhook.py,

--- a/vispy/plot/plotwidget.py
+++ b/vispy/plot/plotwidget.py
@@ -202,7 +202,7 @@ class PlotWidget(scene.Widget):
         fg_color : Color or None
             Sets the plot foreground color if specified.
         kwargs : keyword arguments.
-            More args to pass to visual.Volume.
+            More args to pass to :class:`~vispy.visuals.image.Image`.
 
         Returns
         -------
@@ -412,7 +412,7 @@ class PlotWidget(scene.Widget):
         cmap : str
             The colormap to use.
         kwargs : keyword arguments.
-            More args to pass to visual.Volume.
+            More args to pass to :class:`~vispy.visuals.volume.Volume`.
 
         Returns
         -------

--- a/vispy/plot/plotwidget.py
+++ b/vispy/plot/plotwidget.py
@@ -187,7 +187,7 @@ class PlotWidget(scene.Widget):
         self.view.camera.set_range()
         return hist
 
-    def image(self, data, cmap='cubehelix', clim='auto', fg_color=None):
+    def image(self, data, cmap='cubehelix', clim='auto', fg_color=None, **kwargs):
         """Show an image
 
         Parameters
@@ -201,6 +201,8 @@ class PlotWidget(scene.Widget):
             min and max values.
         fg_color : Color or None
             Sets the plot foreground color if specified.
+        kwargs : keyword arguments.
+            More args to pass to visual.Volume.
 
         Returns
         -------
@@ -212,7 +214,7 @@ class PlotWidget(scene.Widget):
         The colormap is only used if the image pixels are scalars.
         """
         self._configure_2d(fg_color)
-        image = scene.Image(data, cmap=cmap, clim=clim)
+        image = scene.Image(data, cmap=cmap, clim=clim, **kwargs)
         self.view.add(image)
         self.view.camera.aspect = 1
         self.view.camera.set_range()
@@ -390,7 +392,7 @@ class PlotWidget(scene.Widget):
         return spec
 
     def volume(self, vol, clim=None, method='mip', threshold=None,
-               cmap='grays'):
+               cmap='grays', **kwargs):
         """Show a 3D volume
 
         Parameters
@@ -409,6 +411,8 @@ class PlotWidget(scene.Widget):
             the mean of the given volume is used.
         cmap : str
             The colormap to use.
+        kwargs : keyword arguments.
+            More args to pass to visual.Volume.
 
         Returns
         -------
@@ -420,7 +424,7 @@ class PlotWidget(scene.Widget):
         Volume
         """
         self._configure_3d()
-        volume = scene.Volume(vol, clim, method, threshold, cmap=cmap)
+        volume = scene.Volume(vol, clim, method, threshold, cmap=cmap, **kwargs)
         self.view.add(volume)
         self.view.camera.set_range()
         return volume

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -10,7 +10,7 @@ from vispy.gloo.texture import should_cast_to_f32
 
 
 def get_default_clim_from_dtype(dtype):
-    """Get min and max color limits based on the rsange of the dtype."""
+    """Get min and max color limits based on the range of the dtype."""
     # assume floating point data is pre-normalized to 0 and 1
     if np.issubdtype(dtype, np.floating):
         return 0, 1
@@ -22,11 +22,11 @@ def get_default_clim_from_dtype(dtype):
 
 
 def get_default_clim_from_data(data):
-    """ Compute a reasonable clim from the min and max, taking nans into account.
+    """Compute a reasonable clim from the min and max, taking nans into account.
+    
     If there are no non-finite values (nan, inf, -inf) this is as fast as it can be.
     Otherwise, this functions is about 3x slower.
     """
-
     # Fast
     min_value = data.min()
     max_value = data.max()

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -9,7 +9,7 @@ from vispy.gloo import Texture2D, Texture3D
 from vispy.gloo.texture import should_cast_to_f32
 
 
-def get_default_clim_from_dtype( dtype):
+def get_default_clim_from_dtype(dtype):
     """Get min and max color limits based on the rsange of the dtype."""
     # assume floating point data is pre-normalized to 0 and 1
     if np.issubdtype(dtype, np.floating):
@@ -41,8 +41,6 @@ def get_default_clim_from_data(data):
 
     return min_value, max_value
 
-
-##
 
 class _ScaledTextureMixin:
     """Mixin class to make a texture aware of color limits.
@@ -368,7 +366,6 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
         clim_min = self.normalize_value(self.clim[0], self._data_dtype)
         clim_max = self.normalize_value(self.clim[1], self._data_dtype)
         return clim_min, clim_max
-
 
     def _handle_auto_texture_format(self, texture_format, data):
         if isinstance(texture_format, str) and texture_format == 'auto':

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -9,6 +9,41 @@ from vispy.gloo import Texture2D, Texture3D
 from vispy.gloo.texture import should_cast_to_f32
 
 
+def get_default_clim_from_dtype( dtype):
+    """Get min and max color limits based on the rsange of the dtype."""
+    # assume floating point data is pre-normalized to 0 and 1
+    if np.issubdtype(dtype, np.floating):
+        return 0, 1
+    # assume integer RGBs fill the whole data space
+    dtype_info = np.iinfo(dtype)
+    dmin = dtype_info.min
+    dmax = dtype_info.max
+    return dmin, dmax
+
+
+def get_default_clim_from_data(data):
+    """ Compute a reasonable clim from the min and max, taking nans into account.
+    If there are no non-finite values (nan, inf, -inf) this is as fast as it can be.
+    Otherwise, this functions is about 3x slower.
+    """
+
+    # Fast
+    min_value = data.min()
+    max_value = data.max()
+
+    # Need more work? The nan-functions are slower
+    min_finite = np.isfinite(min_value)
+    max_finite = np.isfinite(max_value)
+    if not (min_finite and max_finite):
+        finite_data = data[np.isfinite(data)]
+        min_value = finite_data.min()
+        max_value = finite_data.max()
+
+    return min_value, max_value
+
+
+##
+
 class _ScaledTextureMixin:
     """Mixin class to make a texture aware of color limits.
 
@@ -78,13 +113,6 @@ class _ScaledTextureMixin:
     @property
     def clim_normalized(self):
         """Normalize current clims to match texture data inside the shader.
-
-        Scaling only happens on the GPU so we only normalize
-        the color limits when needed (for unsigned normalized integer
-        internal formats). Otherwise, for internal formats that are not
-        normalized such as floating point (ex. r32f) we can leave the ``clim``
-        as is.
-
         """
         # if the internalformat of the texture is normalized we need to
         # also normalize the clims so they match in-shader
@@ -163,23 +191,12 @@ class _ScaledTextureMixin:
         # this texture type has no limitations
         return
 
-    def _get_default_clims(self, data):
-        """Get min and max color limits."""
-        # assume floating point data is pre-normalized to 0 and 1
-        if np.issubdtype(data.dtype, np.floating):
-            return 0, 1
-        # assume integer RGBs fill the whole data space
-        dtype_info = np.iinfo(data.dtype)
-        dmin = dtype_info.min
-        dmax = dtype_info.max
-        return dmin, dmax
-
     def scale_and_set_data(self, data, offset=None, copy=False):
         """Upload new data to the GPU."""
         return self.set_data(data, offset=offset, copy=copy)
 
 
-class CPUScaledTextureMixIn(_ScaledTextureMixin):
+class CPUScaledTextureMixin(_ScaledTextureMixin):
     """Texture mixin class for smarter scaling decisions.
 
     This class wraps the logic to normalize data on the CPU before sending
@@ -245,7 +262,7 @@ class CPUScaledTextureMixIn(_ScaledTextureMixin):
         range_min, range_max = self._data_limits
         clim_min, clim_max = self.clim
         if clim_min == clim_max:
-            return 0.0, 0.0
+            return 0, np.inf
         clim_min = (clim_min - range_min) / (range_max - range_min)
         clim_max = (clim_max - range_min) / (range_max - range_min)
         return clim_min, clim_max
@@ -258,9 +275,11 @@ class CPUScaledTextureMixIn(_ScaledTextureMixin):
         elif not copy and not np.issubdtype(data.dtype, np.floating):
             raise ValueError("Data must be of floating type for no copying to occur.")
 
-        if clim[0] != clim[1]:
+        if clim[0] == clim[1]:
+            pass  # Does not matter - clim range will be inf
+        else:
             data -= clim[0]
-            data /= clim[1] - clim[0]
+            data *= 1.0 / (clim[1] - clim[0])
         if should_cast_to_f32(data.dtype):
             data = data.astype(np.float32)
         return data
@@ -273,12 +292,11 @@ class CPUScaledTextureMixIn(_ScaledTextureMixin):
         is_auto = isinstance(clim, str) and clim == 'auto'
         if data.ndim == self._ndim or data.shape[self._ndim] == 1:
             if is_auto:
-                clim = np.min(data), np.max(data)
-            clim = (np.float32(clim[0]), np.float32(clim[1]))
+                clim = get_default_clim_from_data(data)
             data = self._scale_data_on_cpu(data, clim, copy=copy)
             data_limits = clim
         else:
-            data_limits = self._get_default_clims(data)
+            data_limits = get_default_clim_from_dtype(data.dtype)
             if is_auto:
                 clim = data_limits
 
@@ -332,6 +350,26 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
     # instance variable that will be used later on
     _auto_texture_format = False
 
+    @property
+    def clim_normalized(self):
+        """Normalize current clims to match texture data inside the shader.
+
+        If data is scaled on the CPU then the texture data will be in the range
+        0-1 in the _build_texture() method. Inside the fragment shader the
+        final contrast adjustment will be applied based on this normalized
+        ``clim``.
+
+        """
+        if self.clim[0] == self.clim[1]:
+            return self.clim[0], np.inf
+
+        # if the internalformat of the texture is normalized we need to
+        # also normalize the clims so they match in-shader
+        clim_min = self.normalize_value(self.clim[0], self._data_dtype)
+        clim_max = self.normalize_value(self.clim[1], self._data_dtype)
+        return clim_min, clim_max
+
+
     def _handle_auto_texture_format(self, texture_format, data):
         if isinstance(texture_format, str) and texture_format == 'auto':
             if data is None:
@@ -359,18 +397,20 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
             num_channels = self._data_num_channels(data)
             texture_format = self._handle_auto_texture_format(internalformat, data)
             texture_format = self._get_gl_tex_format(texture_format, num_channels)
+        else:
+            raise NotImplementedError("wut?")
         return texture_format
 
     def _compute_clim(self, data):
         clim = self._clim
         is_auto = isinstance(clim, str) and clim == 'auto'
-        if data.ndim == 2 or data.shape[2] == 1:
+        if data.ndim == self._ndim or data.shape[2] == 1:
             if is_auto:
-                clim = np.min(data), np.max(data)
-            clim = (np.float32(clim[0]), np.float32(clim[1]))
+                clim = get_default_clim_from_data(data)
+            # clim = (np.float32(clim[0]), np.float32(clim[1]))
         elif is_auto:
             # assume that RGB data is already scaled (0, 1)
-            clim = self._get_default_clims(data)
+            clim = get_default_clim_from_dtype(data.dtype)
         return clim
 
     def _internalformat_will_change(self, data):
@@ -404,7 +444,7 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
         return super().scale_and_set_data(data, offset=offset, copy=copy)
 
 
-class CPUScaledTexture2D(CPUScaledTextureMixIn, Texture2D):
+class CPUScaledTexture2D(CPUScaledTextureMixin, Texture2D):
     """Texture class with clim scaling handling builtin.
 
     See :class:`vispy.visuals._scalable_textures.CPUScaledTextureMixin` for
@@ -422,7 +462,7 @@ class GPUScaledTexture2D(GPUScaledTextureMixin, Texture2D):
     """
 
 
-class CPUScaledTexture3D(CPUScaledTextureMixIn, Texture3D):
+class CPUScaledTexture3D(CPUScaledTextureMixin, Texture3D):
     """Texture class with clim scaling handling builtin.
 
     See :class:`vispy.visuals._scalable_textures.CPUScaledTextureMixin` for

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -388,7 +388,8 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
         return texture_format
 
     def _get_texture_format_for_data(self, data, internalformat):
-        assert internalformat is not None
+        if internalformat is None:
+            raise ValueError("'internalformat' must be provided for GPU scaled textures.")
         num_channels = self._data_num_channels(data)
         texture_format = self._handle_auto_texture_format(internalformat, data)
         texture_format = self._get_gl_tex_format(texture_format, num_channels)

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -23,7 +23,7 @@ def get_default_clim_from_dtype(dtype):
 
 def get_default_clim_from_data(data):
     """Compute a reasonable clim from the min and max, taking nans into account.
-    
+
     If there are no non-finite values (nan, inf, -inf) this is as fast as it can be.
     Otherwise, this functions is about 3x slower.
     """
@@ -273,9 +273,7 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
         elif not copy and not np.issubdtype(data.dtype, np.floating):
             raise ValueError("Data must be of floating type for no copying to occur.")
 
-        if clim[0] == clim[1]:
-            pass  # Does not matter - clim range will be inf
-        else:
+        if clim[0] != clim[1]:
             data -= clim[0]
             data *= 1.0 / (clim[1] - clim[0])
         if should_cast_to_f32(data.dtype):
@@ -390,12 +388,10 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
         return texture_format
 
     def _get_texture_format_for_data(self, data, internalformat):
-        if internalformat is not None:
-            num_channels = self._data_num_channels(data)
-            texture_format = self._handle_auto_texture_format(internalformat, data)
-            texture_format = self._get_gl_tex_format(texture_format, num_channels)
-        else:
-            raise NotImplementedError("wut?")
+        assert internalformat is not None
+        num_channels = self._data_num_channels(data)
+        texture_format = self._handle_auto_texture_format(internalformat, data)
+        texture_format = self._get_gl_tex_format(texture_format, num_channels)
         return texture_format
 
     def _compute_clim(self, data):

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -296,7 +296,7 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
             if is_auto:
                 clim = data_limits
 
-        self._clim = clim
+        self._clim = float(clim[0]), float(clim[1])
         self._data_limits = data_limits
         return super().scale_and_set_data(data, offset=offset, copy=copy)
 
@@ -400,11 +400,10 @@ class GPUScaledTextureMixin(_ScaledTextureMixin):
         if data.ndim == self._ndim or data.shape[2] == 1:
             if is_auto:
                 clim = get_default_clim_from_data(data)
-            # clim = (np.float32(clim[0]), np.float32(clim[1]))
         elif is_auto:
             # assume that RGB data is already scaled (0, 1)
             clim = get_default_clim_from_dtype(data.dtype)
-        return clim
+        return float(clim[0]), float(clim[1])
 
     def _internalformat_will_change(self, data):
         shape_repr = self._create_rep_array(data)

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,8 +89,9 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
+        data = clamp(data, min($clim.x, $clim.y), max($clim.x, $clim.y));
         data = (data - $clim.x) / ($clim.y - $clim.x);
-        return clamp(data, 0.0, 1.0);
+        return data;
     }"""
 _apply_clim = """
     vec4 apply_clim(vec4 color) {

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -153,8 +153,9 @@ class ImageVisual(Visual):
     cmap : str | ColorMap
         Colormap to use for luminance images.
     clim : str | tuple
-        Limits to use for the colormap. Can be 'auto' to auto-set bounds to
-        the min and max of the data.
+        Limits to use for the colormap. I.e. the values that map to black and white
+        in a gray colormap. Can be 'auto' to auto-set bounds to
+        the min and max of the data. If not given or None, 'auto' is used.
     gamma : float
         Gamma to use during colormap lookup.  Final color will be cmap(val**gamma).
         by default: 1.

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,10 +89,8 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
-
-        data = clamp(data, $clim.x, $clim.y);
         data = (data - $clim.x) / ($clim.y - $clim.x);
-        return data;
+        return clamp(data, 0.0, 1.0);
     }"""
 _apply_clim = """
     vec4 apply_clim(vec4 color) {

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,17 +89,10 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
-        if ($clim.x < $clim.y) {{
-            data = clamp(data, $clim.x, $clim.y);
-        }} else if ($clim.x > $clim.y) {{
-            data = clamp(data, $clim.y, $clim.x);
-        }} else {{
-            // clims are the same, show minimum colormap value
-            return 0.0;
-        }}
-        data = data - $clim.x;
-        data = data / ($clim.y - $clim.x);
-        return max(data, 0);
+
+        data = clamp(data, $clim.x, $clim.y);
+        data = (data - $clim.x) / ($clim.y - $clim.x);
+        return data;
     }"""
 _apply_clim = """
     vec4 apply_clim(vec4 color) {
@@ -276,7 +269,7 @@ class ImageVisual(Visual):
         # self._build_interpolation()
         self._data_lookup_fn = None
 
-        self.clim = clim
+        self.clim = clim or "auto"  # None -> "auto"
         self.cmap = cmap
         if data is not None:
             self.set_data(data)

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -33,7 +33,6 @@ class GPUScaledStub(GPUScaledTextureMixin, Stub):
 
 
 def test_default_clim():
-
     ref_data = np.array([10, 5, 15, 25, 15])
 
     # f32
@@ -115,7 +114,6 @@ def test_clim_handling_cpu():
 
 
 def test_clim_handling_gpu():
-    return
     ref_data = np.array([[10, 10, 5], [15, 25, 15]])
 
     # f32 - auto clim

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -143,7 +143,7 @@ def test_clim_handling_gpu():
     st.set_clim((10, 10))
     st.scale_and_set_data(ref_data.astype(np.float32))
     assert st.clim == (10, 10)
-    assert st.clim_normalized == (0, np.inf)
+    assert st.clim_normalized == (10, np.inf)
     # assert np.min(st._data) == 0 - does not matter
 
 

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -1,9 +1,8 @@
 import numpy as np
-import pytest
 
 from vispy.testing import run_tests_if_main
 
-from vispy.visuals._scalable_textures import(
+from vispy.visuals._scalable_textures import (
     get_default_clim_from_dtype,
     get_default_clim_from_data,
     CPUScaledTextureMixin,
@@ -17,7 +16,6 @@ class Stub:
     def __init__(self, data, **kwargs):
         pass
 
-
     def set_data(self, data, *args, **kwargs):
         self._data = data
 
@@ -27,7 +25,9 @@ class CPUScaledStub(CPUScaledTextureMixin, Stub):
 
 
 class GPUScaledStub(GPUScaledTextureMixin, Stub):
+
     internalformat = "r32f"
+
     def _get_texture_format_for_data(self, data, internalformat=None):
         return None
 
@@ -60,7 +60,7 @@ def test_default_clim():
 
 def test_default_clim_non_finite():
 
-    data =  np.array([10, np.nan, 5, 15, 25, 15]).astype(np.float32)
+    data = np.array([10, np.nan, 5, 15, 25, 15]).astype(np.float32)
     clim = get_default_clim_from_dtype(data.dtype)
     assert clim == (0, 1)
     clim = get_default_clim_from_data(data)
@@ -72,7 +72,7 @@ def test_default_clim_non_finite():
     clim = get_default_clim_from_data(data)
     assert clim == (5, 25)
 
-    data =  np.array([10, -np.inf, 5, 15, 25, 15]).astype(np.float32)
+    data = np.array([10, -np.inf, 5, 15, 25, 15]).astype(np.float32)
     clim = get_default_clim_from_dtype(data.dtype)
     assert clim == (0, 1)
     clim = get_default_clim_from_data(data)

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -1,0 +1,152 @@
+import numpy as np
+import pytest
+
+from vispy.testing import run_tests_if_main
+
+from vispy.visuals._scalable_textures import(
+    get_default_clim_from_dtype,
+    get_default_clim_from_data,
+    CPUScaledTextureMixin,
+    GPUScaledTextureMixin,
+)
+
+
+class Stub:
+    _ndim = 2
+
+    def __init__(self, data, **kwargs):
+        pass
+
+
+    def set_data(self, data, *args, **kwargs):
+        self._data = data
+
+
+class CPUScaledStub(CPUScaledTextureMixin, Stub):
+    pass
+
+
+class GPUScaledStub(GPUScaledTextureMixin, Stub):
+    internalformat = "r32f"
+    def _get_texture_format_for_data(self, data, internalformat=None):
+        return None
+
+
+def test_default_clim():
+
+    ref_data = np.array([10, 5, 15, 25, 15])
+
+    # f32
+    data = ref_data.astype(np.float32)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (0, 1)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+    # i32
+    data = ref_data.astype(np.int32)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (-2**31, 2**31 - 1)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+    # u8
+    data = ref_data.astype(np.uint8)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (0, 255)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+
+def test_default_clim_non_finite():
+
+    data =  np.array([10, np.nan, 5, 15, 25, 15]).astype(np.float32)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (0, 1)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+    data = np.array([10, np.inf, 5, 15, 25, 15]).astype(np.float32)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (0, 1)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+    data =  np.array([10, -np.inf, 5, 15, 25, 15]).astype(np.float32)
+    clim = get_default_clim_from_dtype(data.dtype)
+    assert clim == (0, 1)
+    clim = get_default_clim_from_data(data)
+    assert clim == (5, 25)
+
+
+def test_clim_handling_cpu():
+
+    ref_data = np.array([[10, 10, 5], [15, 25, 15]])
+
+    # f32 - auto clim
+    st = CPUScaledStub()
+    st.set_clim("auto")
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (5, 25)
+    assert st.clim_normalized == (0, 1)
+    assert np.all(st._data == (ref_data - 5) / 20)
+
+    # Updating clim keeps data the same if not changing too much
+    st.set_clim((0, 20))
+    assert st.clim == (0, 20)
+    assert st.clim_normalized == (-0.25, 0.75)
+    assert np.all(st._data == (ref_data - 5) / 20)
+
+    # f32 - custom clim
+    st = CPUScaledStub()
+    st.set_clim((0, 20))
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (0, 20)
+    assert st.clim_normalized == (0, 1)
+    assert np.all(st._data == ref_data / 20)
+
+    # f32 - flat clim
+    st = CPUScaledStub()
+    st.set_clim((10, 10))
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (10, 10)
+    assert st.clim_normalized == (0, np.inf)
+    # assert np.min(st._data) == 0 - does not matter
+
+
+def test_clim_handling_gpu():
+    return
+    ref_data = np.array([[10, 10, 5], [15, 25, 15]])
+
+    # f32 - auto clim
+    st = GPUScaledStub()
+    st.set_clim("auto")
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (5, 25)
+    assert st.clim_normalized == (5, 25)
+    assert np.all(st._data == ref_data)
+
+    # Updating clim keeps data the same if not changing too much
+    st.set_clim((0, 20))
+    assert st.clim == (0, 20)
+    assert st.clim_normalized == (0, 20)
+    assert np.all(st._data == ref_data)
+
+    # f32 - custom clim
+    st = GPUScaledStub()
+    st.set_clim((0, 20))
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (0, 20)
+    assert st.clim_normalized == (0, 20)
+    assert np.all(st._data == ref_data)
+
+    # f32 - flat clim
+    st = GPUScaledStub()
+    st.set_clim((10, 10))
+    st.scale_and_set_data(ref_data.astype(np.float32))
+    assert st.clim == (10, 10)
+    assert st.clim_normalized == (0, np.inf)
+    # assert np.min(st._data) == 0 - does not matter
+
+
+run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -29,7 +29,7 @@ def test_volume():
 
     # Clim
     V.set_data(vol, (0.5, 0.8))
-    assert V.clim == (np.float32(0.5), np.float32(0.8))
+    assert V.clim == (0.5, 0.8)
     with raises(ValueError):
         V.set_data((0.5, 0.8, 1.0))
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -120,8 +120,8 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 applyColormap(float data) {{
+    data = clamp(data, min(clim.x, clim.y), max(clim.x, clim.y));
     data = (data - clim.x) / (clim.y - clim.x);
-    data = clamp(data, 0.0, 1.0);
     vec4 color = $cmap(pow(data, gamma));
     return color;
 }}

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -120,8 +120,8 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 applyColormap(float data) {{
-    data = clamp(data, clim.x, clim.y);
     data = (data - clim.x) / (clim.y - clim.x);
+    data = clamp(data, 0.0, 1.0);
     vec4 color = $cmap(pow(data, gamma));
     return color;
 }}

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -120,16 +120,10 @@ float colorToVal(vec4 color1)
 }}
 
 vec4 applyColormap(float data) {{
-    if (clim.x < clim.y) {{
-        data = clamp(data, clim.x, clim.y);
-    }} else if (clim.x > clim.y) {{
-        data = clamp(data, clim.y, clim.x);
-    }} else {{
-        return $cmap(0.0);
-    }}
-
+    data = clamp(data, clim.x, clim.y);
     data = (data - clim.x) / (clim.y - clim.x);
-    return $cmap(pow(data, gamma));
+    vec4 color = $cmap(pow(data, gamma));
+    return color;
 }}
 
 
@@ -573,7 +567,7 @@ class VolumeVisual(Visual):
         self.set_gl_state('translucent', cull_face=False)
 
         # Apply clim and set data at the same time
-        self.set_data(vol, clim)
+        self.set_data(vol, clim or "auto")
 
         # Set params
         self.method = method
@@ -624,9 +618,7 @@ class VolumeVisual(Visual):
             raise ValueError('Volume visual needs a 3D array.')
         if isinstance(self._texture, GPUScaledTextured3D):
             copy = False
-
-        if clim is None and self._texture.clim is None:
-            clim = (vol.min(), vol.max())
+        
         if clim is not None and clim != self._texture.clim:
             self._texture.set_clim(clim)
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -463,10 +463,10 @@ class VolumeVisual(Visual):
     vol : ndarray
         The volume to display. Must be ndim==3. Array is assumed to be stored
         as ``(z, y, x)``.
-    clim : tuple of two floats | None
-        The contrast limits. The values in the volume are mapped to
-        black and white corresponding to these values. Default maps
-        between min and max.
+    clim : str | tuple
+        Limits to use for the colormap. I.e. the values that map to black and white
+        in a gray colormap. Can be 'auto' to auto-set bounds to
+        the min and max of the data. If not given or None, 'auto' is used.
     method : {'mip', 'attenuated_mip', 'minip', 'translucent', 'additive',
         'iso', 'average'}
         The render method to use. See corresponding docs for details.
@@ -521,7 +521,7 @@ class VolumeVisual(Visual):
 
     _interpolation_names = ['linear', 'nearest']
 
-    def __init__(self, vol, clim=None, method='mip', threshold=None,
+    def __init__(self, vol, clim="auto", method='mip', threshold=None,
                  attenuation=1.0, relative_step_size=0.8, cmap='grays',
                  gamma=1.0, interpolation='linear', texture_format=None):
         # Storage of information of volume


### PR DESCRIPTION
* The logic in the shader is simplified and has no branches (in the clim computation).
* Deal with nan and inf in data. Uses @larsoner's idea to stay performant by default at the cost of being a bit extra less performant when non-finite values are present :)
* Correct behavior when clim range is zero.

