### PR TITLE
Restore ambient light behavior as in v0.6.0

### DIFF
--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -215,7 +215,7 @@ void shade() {
                     * specular_light.rgb * specular_light.a;
 
     // Blend the base color and combine the illuminations.
-    vec3 color = ambient + base_color * diffuse + specular;
+    vec3 color = base_color * (ambient + diffuse) + specular;
 
     gl_FragColor.rgb = color;
 }
@@ -395,7 +395,7 @@ class ShadingFilter(Filter):
                  specular_coefficient=(1, 1, 1, 1),
                  shininess=100,
                  light_dir=(10, 5, -5),
-                 ambient_light=(1, 1, 1, 0),
+                 ambient_light=(1, 1, 1, .3),
                  diffuse_light=(1, 1, 1, 1),
                  specular_light=(1, 1, 1, .25),
                  enabled=True):


### PR DESCRIPTION
With these changes, the ambient light is:
- on by default with intensity 0.3,
- applied on the base color of the mesh.

The restores the behaviour of the MeshVisual as before the ShadingFilter was introduced.