### PR TITLE
Fix SceneCanvas Node leaking reference to itself

### DIFF
--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -284,12 +284,12 @@ class Node(object):
             p = self.parent
             while True:
                 if isinstance(p, SubScene) or p is None:
-                    self._scene_node = p
+                    self._scene_node = p and weakref.ref(p)
                     break
                 p = p.parent
             if self._scene_node is None:
-                self._scene_node = self
-        return self._scene_node
+                self._scene_node = weakref.ref(self)
+        return self._scene_node()
 
     @property
     def root_node(self):


### PR DESCRIPTION
This is a possible cleanup as discussed in #2083. This assumes a lot of stuff about VisPy and Python garbage collection that may not actually matter. I kind of ran wild with this idea that VisPy is adding a reference to a Visual that never gets collected. I tracked it down to the `self.scene_node` property of the Node class (used by SceneCanvas graph nodes). The behavior that I was trying to "fix" was that when you set a parent for a Node and then remove that parent you should end up with the same number of references for that Visual. This may not matter or be wrong because:

1. I don't think Python garbage collection cares about an object referencing itself.
2. I'm not sure if this will break certain cases of using VisPy where the `.scene_node` should be a "hard" reference...but I'm not sure why that would be useful.

CC @yxdragon