### PR TITLE
Fix alpha handling in 'translucent' Visuals and add 'alpha' keyword argument to Canvas.render

### DIFF
--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -529,8 +529,10 @@ class Canvas(object):
         logger.debug('Context manager exit complete for %s' % (self,))
 
     def render(self):
-        """Render the canvas to an offscreen buffer and return the image
-        array.
+        """Render the canvas to an offscreen buffer and return the image array.
+
+        This method may not return the expected result in some cases when it
+        comes to transparency or more complex visualizations.
 
         Returns
         -------
@@ -550,6 +552,31 @@ class Canvas(object):
             return fbo.read()
         finally:
             fbo.deactivate()
+
+    def screenshot(self, viewport=None, alpha=True):
+        """Read the current rendered buffer from the GPU and return as an array.
+
+        This function will capture whatever was last drawn.
+        Note this uses the low-level ``glReadPixels`` and does not run using
+        the gloo GLIR queue.
+
+        Parameters
+        ----------
+        viewport : array-like | None
+            4-element list of x, y, w, h parameters. If None (default),
+            the current GL viewport will be queried and used.
+        alpha : bool
+            If True (default), the returned array has 4 elements (RGBA).
+            Otherwise, it has 3 (RGB)
+
+        Returns
+        -------
+        pixels : array
+            3D array of pixels in np.uint8 format
+
+        """
+        from vispy.gloo.wrappers import read_pixels
+        return read_pixels(viewport=viewport, alpha=alpha)
 
 
 # Event subclasses specific to the Canvas

--- a/vispy/app/tests/test_canvas.py
+++ b/vispy/app/tests/test_canvas.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+from vispy.app import Canvas
+from vispy.visuals import ImageVisual
+from vispy.testing import requires_application
+
+
+@requires_application()
+def test_run():
+    """Test app running"""
+    with Canvas(size=(100, 100), show=True, title='run') as c:
+
+        image = Image(cmap='grays', clim=[0, 1], parent=c.scene)
+        shape = (size[1]-10, size[0]-10) + ((3,) if is_3d else ())
+        np.random.seed(379823)
+        data = np.random.rand(*shape)
+        image.set_data(data)
+        assert_image_approved(c.render(), "visuals/image%s.png" %
+                              ("_rgb" if is_3d else "_mono"))

--- a/vispy/app/tests/test_canvas.py
+++ b/vispy/app/tests/test_canvas.py
@@ -36,4 +36,4 @@ def test_canvas_render():
         # the results should be the same except for alpha
         np.testing.assert_allclose(rgba_result[..., :3], rgb_result)
         # the alpha should have some transparency
-        assert (rgba_result[..., 3] != 1).any()
+        assert (rgba_result[..., 3] != 255).any()

--- a/vispy/app/tests/test_canvas.py
+++ b/vispy/app/tests/test_canvas.py
@@ -6,14 +6,28 @@ from vispy.app import Canvas
 from vispy.visuals import ImageVisual
 from vispy.testing import requires_application
 from vispy.visuals.transforms import STTransform
+from vispy import gloo
 
 import numpy as np
+import pytest
 
 
 @requires_application()
-def test_canvas_render():
-    """Test rendering a canvas to an array."""
-    with Canvas(size=(800, 600), show=True, title='run') as c:
+@pytest.mark.parametrize(
+    'blend_func',
+    [
+        ('src_alpha', 'one_minus_src_alpha', 'one', 'one_minus_src_alpha'),
+        ('src_alpha', 'one_minus_src_alpha'),
+        None,
+    ])
+def test_canvas_render(blend_func):
+    """Test rendering a canvas to an array.
+
+    Different blending functions are used to test what various Visuals may
+    produce without actually using different types of Visuals.
+
+    """
+    with Canvas(size=(125, 125), show=True, title='run') as c:
         im1 = np.zeros((100, 100, 4)).astype(np.float32)
         im1[:, :, 0] = 1
         im1[:, :, 3] = 1
@@ -24,16 +38,34 @@ def test_canvas_render():
 
         # Create the image
         image1 = ImageVisual(im1)
+        image1.transform = STTransform(translate=(20, 20, 0))
+        image1.transforms.configure(canvas=c, viewport=(0, 0, 125, 125))
         image2 = ImageVisual(im2)
-        image2.transform = STTransform(translate=(-20, -20, -1))
+        image2.transform = STTransform(translate=(0, 0, -1))
+        image2.transforms.configure(canvas=c, viewport=(0, 0, 125, 125))
+        if blend_func:
+            image1.set_gl_state(preset='translucent', blend_func=blend_func)
+            image2.set_gl_state(preset='translucent', blend_func=blend_func)
 
-        image1.draw()
-        image2.draw()
+        @c.events.draw.connect
+        def on_draw(ev):
+            gloo.clear('black')
+            gloo.set_viewport(0, 0, *c.physical_size)
+            image1.draw()
+            image2.draw()
 
         rgba_result = c.render()
         rgb_result = c.render(alpha=False)
 
         # the results should be the same except for alpha
         np.testing.assert_allclose(rgba_result[..., :3], rgb_result)
-        # the alpha should have some transparency
-        assert (rgba_result[..., 3] != 255).any()
+        # the image should have something drawn in it
+        assert not np.allclose(rgba_result[..., :3], 0)
+        # the alpha should not be completely transparent
+        assert not np.allclose(rgba_result[..., 3], 0)
+        if blend_func is None or 'one' in blend_func:
+            # no transparency
+            np.testing.assert_allclose(rgba_result[..., 3], 255)
+        else:
+            # the alpha should have some transparency
+            assert (rgba_result[..., 3] != 255).any()

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -38,7 +38,7 @@ _gl_presets = {
         depth_test=True,
         cull_face=False,
         blend=True,
-        blend_func=('src_alpha', 'one_minus_src_alpha')),
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'one', 'one_minus_src_alpha')),
     'additive': dict(
         depth_test=False,
         cull_face=False,
@@ -444,7 +444,7 @@ class BaseGlooFunctions(object):
         ----------
         preset : str | None
             Can be one of ('opaque', 'translucent', 'additive') to use
-            use reasonable defaults for these typical use cases.
+            reasonable defaults for these typical use cases.
         **kwargs : keyword arguments
             Other supplied keyword arguments will override any preset defaults.
             Options to be enabled or disabled should be supplied as booleans

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -43,7 +43,7 @@ GL_PRESETS = {
         depth_test=True,
         cull_face=False,
         blend=True,
-        blend_func=('src_alpha', 'one_minus_src_alpha', 'one', 'one_minus_src_alpha')),
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one')),
     'additive': dict(
         depth_test=False,
         cull_face=False,

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -7,12 +7,24 @@ from vispy.testing import requires_application, TestingCanvas
 from vispy.visuals.transforms import STTransform
 
 import numpy as np
-
+import pytest
 
 @requires_application()
-def test_canvas_render():
-    """Test rendering a canvas to an array."""
-    with TestingCanvas(size=(800, 600), show=True, title='run') as c:
+@pytest.mark.parametrize(
+    'blend_func',
+    [
+        ('src_alpha', 'one_minus_src_alpha', 'one', 'one_minus_src_alpha'),
+        ('src_alpha', 'one_minus_src_alpha'),
+        None,
+    ])
+def test_canvas_render(blend_func):
+    """Test rendering a canvas to an array.
+
+    Different blending functions are used to test what various Visuals may
+    produce without actually using different types of Visuals.
+
+    """
+    with TestingCanvas(size=(125, 125), show=True, title='run') as c:
         view = c.central_widget.add_view()
 
         im1 = np.zeros((100, 100, 4)).astype(np.float32)
@@ -25,13 +37,25 @@ def test_canvas_render():
 
         # Create the image
         image1 = scene.visuals.Image(im1, parent=view.scene)
+        image1.transform = STTransform(translate=(20, 20, 0))
         image2 = scene.visuals.Image(im2, parent=view.scene)
-        image2.transform = STTransform(translate=(-20, -20, -1))
+        image2.transform = STTransform(translate=(0, 0, -1))
+        if blend_func:
+            image1.set_gl_state(preset='translucent', blend_func=blend_func)
+            image2.set_gl_state(preset='translucent', blend_func=blend_func)
 
         rgba_result = c.render()
         rgb_result = c.render(alpha=False)
 
         # the results should be the same except for alpha
         np.testing.assert_allclose(rgba_result[..., :3], rgb_result)
-        # the alpha should have some transparency
-        assert (rgba_result[..., 3] != 255).any()
+        # the image should have something drawn in it
+        assert not np.allclose(rgba_result[..., :3], 0)
+        # the alpha should not be completely transparent
+        assert not np.allclose(rgba_result[..., 3], 0)
+        if blend_func is None or 'one' in blend_func:
+            # no transparency
+            np.testing.assert_allclose(rgba_result[..., 3], 255)
+        else:
+            # the alpha should have some transparency
+            assert (rgba_result[..., 3] != 255).any()

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -9,6 +9,7 @@ from vispy.visuals.transforms import STTransform
 import numpy as np
 import pytest
 
+
 @requires_application()
 @pytest.mark.parametrize(
     'blend_func',

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -34,4 +34,4 @@ def test_canvas_render():
         # the results should be the same except for alpha
         np.testing.assert_allclose(rgba_result[..., :3], rgb_result)
         # the alpha should have some transparency
-        assert (rgba_result[..., 3] != 1).any()
+        assert (rgba_result[..., 3] != 255).any()

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -2,9 +2,8 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-from vispy.app import Canvas
-from vispy.visuals import ImageVisual
-from vispy.testing import requires_application
+from vispy import scene
+from vispy.testing import requires_application, TestingCanvas
 from vispy.visuals.transforms import STTransform
 
 import numpy as np
@@ -13,7 +12,9 @@ import numpy as np
 @requires_application()
 def test_canvas_render():
     """Test rendering a canvas to an array."""
-    with Canvas(size=(800, 600), show=True, title='run') as c:
+    with TestingCanvas(size=(800, 600), show=True, title='run') as c:
+        view = c.central_widget.add_view()
+
         im1 = np.zeros((100, 100, 4)).astype(np.float32)
         im1[:, :, 0] = 1
         im1[:, :, 3] = 1
@@ -23,12 +24,9 @@ def test_canvas_render():
         im2[:, :, 3] = 0.4
 
         # Create the image
-        image1 = ImageVisual(im1)
-        image2 = ImageVisual(im2)
+        image1 = scene.visuals.Image(im1, parent=view.scene)
+        image2 = scene.visuals.Image(im2, parent=view.scene)
         image2.transform = STTransform(translate=(-20, -20, -1))
-
-        image1.draw()
-        image2.draw()
 
         rgba_result = c.render()
         rgb_result = c.render(alpha=False)


### PR DESCRIPTION
This is an attempt at providing a more clear and stable way for users to get a numpy array of the current visualization. Users often see the `Canvas.render` method, but are then surprised by some of the results. For example:

https://github.com/napari/napari/issues/1566#issuecomment-690748249

I think it may be more important for us to figure out a way around this. I've made this PR to discuss it and to provide a possible workaround with a `Canvas.screenshot` method as the `_screenshot` utility function is my usual go to response for users who run into `.render` issues. @almarklein and I discussed this a little here: https://github.com/vispy/vispy/pull/2082#issuecomment-864962729

I think in the best case `.render` would produce the expected results, but I'm not sure what the proper solution is. This is a partial solution to #1979.