### PR TITLE
Improve specular light in phong shading

### DIFF
--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -203,11 +203,11 @@ void shade() {
     bool is_illuminated = diffuse_factor > 0.0;
     if (is_illuminated && shininess > 0.0) {
         // Phong reflection
-        vec3 reflection = reflect(-light_vec, normal);
-        float reflection_factor = max(dot(reflection, eye_vec), 0.0);
+        //vec3 reflection = reflect(-light_vec, normal);
+        //float reflection_factor = max(dot(reflection, eye_vec), 0.0);
         // Blinn-Phong reflection
-        //vec3 halfway = -normalize(light_vec + eye_vec);
-        //float reflection_factor clamp(dot(halfway, normal), 0.0, 1.0);
+        vec3 halfway = -normalize(light_vec + eye_vec);
+        float reflection_factor = clamp(dot(halfway, normal), 0.0, 1.0);
         specular_factor = pow(reflection_factor, shininess);
     }
     vec3 specular = specular_factor

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -68,11 +68,11 @@ def test_mesh_shading_filter(shading):
         if shading in ("flat", "smooth"):
             # there should be a gradient, not solid colors
             assert np.unique(rendered).size >= 28
-            # sphere/circle starts "dark" on the left and gets brighter
-            # then hits a bright spot and decreases after
-            invest_row = rendered[23].astype(np.float64)
+            # sphere/circle is "dark" on the right and gets brighter as you
+            # move to the left, then hits a bright spot and decreases after
+            invest_row = rendered[34].astype(np.float64)
             # overall, we should be increasing brightness up to a "bright spot"
-            assert (np.diff(invest_row[:29]) >= -1).all()
+            assert (np.diff(invest_row[34:60]) <= 0).all()
         else:
             assert np.unique(rendered).size == 2
 


### PR DESCRIPTION
Addresses the main point in  #2087

* Make the depth step for calculating the view direction a bit smaller to avoid glitches.
* Fixes that the view direction was reversed. I don't think this caused any problems, but it did cause confusion while making changes. (I verified the direction by adding `light_vec = eye_vec`.)
* Changes the reflection model to the better Blinn-Phong: see https://learnopengl.com/Advanced-Lighting/Advanced-Lighting.
* Tweaked default light paramseters.

Dropping this here:
```
    // Note (AK): Below is a way to flip the surface normal so that it's always in
    // the view direction. However, this only works well when the light and view
    // vector are (about) the same. Otherwise, normals on faces that that are
    // near-parallel to the eye vector can flip, affecting how they're lit,
    // causing bright and dark artifacts at the edges of objects.
    normal = faceforward(-normal, normal, eye_vec);
```