### PR TITLE
Prevent memory surge in two examples

### DIFF
--- a/examples/demo/gloo/realtime_signals.py
+++ b/examples/demo/gloo/realtime_signals.py
@@ -155,6 +155,7 @@ class Canvas(app.Canvas):
 
         self.program['a_position'].set_data(y.ravel().astype(np.float32))
         self.update()
+        self.context.flush()  # prevent memory leak when minimized
 
     def on_draw(self, event):
         gloo.clear()

--- a/examples/demo/scene/scrolling_plots.py
+++ b/examples/demo/scene/scrolling_plots.py
@@ -41,6 +41,7 @@ def update(ev):
     data = np.random.normal(size=(N, m), scale=0.3)
     data[data > 1] += 4
     lines.roll_data(data)
+    canvas.context.flush()  # prevent memory leak when minimized
 
 timer = app.Timer(connect=update, interval=0)
 timer.start()


### PR DESCRIPTION
Closes #1871

The problem is that if updates are done, these are encoded as GLIR commands, which end up in a queue. You can imagine that this queue becomes a problem if it is not emptied. If a Qt window is minimized, it won't invoke a draw event, so the queue is not flushed, and it builds up.

The solution/workaround is to call `canvas.context.flush()` explicitly. There are multiple examples affected by this. Basically any example that does *any* update to a GPU buffer, texture or program. However, most these updates are so small that it does not show a noticable memory increase (no increase seen in the process manager). These two examples change so much data at such a high speed that it does matter.

@rossant here's a nasty downside of the GLIR queue :)  On the long run it could be worth examining if we can get rid of the queue completely, since all our GLIR backends are local and can be flushes immediately ...