### PR TITLE
Fix grid solver allowing for 0 sized widgets and causing errors

### DIFF
--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -387,8 +387,8 @@ class Grid(Widget):
         self._solver.suggestValue(self._var_w, rect.width)
         self._solver.suggestValue(self._var_h, rect.height)
 
-        self._solver.addConstraint(self._var_w >= 0)
-        self._solver.addConstraint(self._var_h >= 0)
+        self._solver.addConstraint(self._var_w > 0)
+        self._solver.addConstraint(self._var_h > 0)
 
         # self._height_stay = None
         # self._width_stay = None

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -346,7 +346,7 @@ class Grid(Widget):
 
         for ws in width_grid:
             for w in ws:
-                solver.addConstraint(w >= 0,)
+                solver.addConstraint(w >= 0)
 
         for hs in height_grid:
             for h in hs:
@@ -463,18 +463,10 @@ class Grid(Widget):
         # we only need to remove and add the height and width constraints of
         # the solver if they are not the same as the current value
         if abs(rect.height - self._var_h.value()) > 1e-4:
-            # if self._height_stay:
-            #     self._solver.remove_constraint(self._height_stay)
-
             self._solver.suggestValue(self._var_h, rect.height)
-            # self._height_stay = self._solver.add_stay(self._var_h | 'strong')
 
         if abs(rect.width - self._var_w.value()) > 1e-4:
-            # if self._width_stay:
-            #     self._solver.remove_constraint(self._width_stay)
-
             self._solver.suggestValue(self._var_w, rect.width)
-            # self._width_stay = self._solver.add_stay(self._var_w | 'strong')
 
         value_vectorized = np.vectorize(lambda x: x.value())
 

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -346,11 +346,11 @@ class Grid(Widget):
 
         for ws in width_grid:
             for w in ws:
-                solver.addConstraint(w >= 0)
+                solver.addConstraint(w >= 1)
 
         for hs in height_grid:
             for h in hs:
-                solver.addConstraint(h >= 0)
+                solver.addConstraint(h >= 1)
 
         for (_, val) in grid_widgets.items():
             (y, x, ys, xs, widget) = val

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -387,8 +387,8 @@ class Grid(Widget):
         self._solver.suggestValue(self._var_w, rect.width)
         self._solver.suggestValue(self._var_h, rect.height)
 
-        self._solver.addConstraint(self._var_w > 0)
-        self._solver.addConstraint(self._var_h > 0)
+        self._solver.addConstraint(self._var_w >= 1)
+        self._solver.addConstraint(self._var_h >= 1)
 
         # self._height_stay = None
         # self._width_stay = None


### PR DESCRIPTION
As discussed in #2093 it seems there are random cases (hard to reproduce) that produce widgets in a Grid widget with 0 size. This results in the PanZoomCamera sometimes getting a scale of `0` which then fails later inside the STTransform/MatrixTransform work.