### PR TITLE
Extract out and test the computation of normals

### DIFF
--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -63,11 +63,13 @@ def _compute_vertex_normals(face_normals, vertex_faces):
         An array defining a normal for each vertex.
     """
     n_vertices = len(vertex_faces)
-    vertex_normals = np.zeros((n_vertices, 3), dtype=np.float32)
+    dtype_float = face_normals.dtype
+    vertex_normals = np.zeros((n_vertices, 3), dtype=dtype_float)
     for vertex_index in range(n_vertices):
         faces = vertex_faces[vertex_index]
         if len(faces) == 0:
             continue
+        faces = list(faces)  # Require a list for indexing.
         adjacent_normals = face_normals[faces]
         vertex_normal = adjacent_normals.sum(axis=0)
         norm = (vertex_normal ** 2).sum() ** 0.5

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -40,6 +40,8 @@ def _compute_face_normals(vertices, faces=None):
     if faces is not None:
         assert vertices.shape[1:] == (3,)
         vertices = vertices[faces]
+    else:
+        assert vertices.shape[1:] == (3, 3)
     edges1 = vertices[:, 1] - vertices[:, 0]
     edges2 = vertices[:, 2] - vertices[:, 0]
     return np.cross(edges1, edges2)

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -20,6 +20,23 @@ def _fix_colors(colors):
 
 
 def _compute_face_normals(vertices, faces=None):
+    """Compute the face normals of a triangle mesh.
+
+    Parameters
+    ----------
+    vertices : array_like of shape (n, 3) or (f, 3, 3)
+        A float array of vertex positions. With shape `(n, 3)`, `n` is the
+        number of vertices. With shape `(f, 3, 3)`, `f` is the number of faces,
+        with 3 vertex positions per face, and `faces` is not used.
+    faces : array_like of shape (f, 3), optional
+        An integer array defining each face by 3 indices into the `vertices`
+        array. If set, `vertices` must have dimensions (n, 3).
+
+    Returns
+    -------
+    face_normals : array_like of shape (f, 3)
+        An array defining a normal for each face.
+    """
     if faces is not None:
         assert vertices.shape[1:] == (3,)
         vertices = vertices[faces]
@@ -29,6 +46,22 @@ def _compute_face_normals(vertices, faces=None):
 
 
 def _compute_vertex_normals(face_normals, vertex_faces):
+    """Compute the vertex normals of a triangle mesh.
+
+    Parameters
+    ----------
+    face_normals : array_like of shape (f, 3)
+        A float array defining a normal for each face.
+    vertex_faces : iterable of iterable
+        A iterable sequence of length `n`, with `n` the number of vertices,
+        where each element contains the indices to the adjacent faces of the
+        vertex.
+
+    Returns
+    -------
+    vertex_normals : array_like of shape (n, 3)
+        An array defining a normal for each vertex.
+    """
     n_vertices = len(vertex_faces)
     vertex_normals = np.zeros((n_vertices, 3), dtype=np.float32)
     for vertex_index in range(n_vertices):

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -19,6 +19,15 @@ def _fix_colors(colors):
     return colors
 
 
+def _compute_face_normals(vertices, faces=None):
+    if faces is not None:
+        assert vertices.shape[1:] == (3,)
+        vertices = vertices[faces]
+    edges1 = vertices[:, 1] - vertices[:, 0]
+    edges2 = vertices[:, 2] - vertices[:, 0]
+    return np.cross(edges1, edges2)
+
+
 class MeshData(object):
     """
     Class for storing and operating on 3D mesh data.
@@ -294,9 +303,8 @@ class MeshData(object):
             The normals.
         """
         if self._face_normals is None:
-            v = self.get_vertices(indexed='faces')
-            self._face_normals = np.cross(v[:, 1] - v[:, 0],
-                                          v[:, 2] - v[:, 0])
+            vertices = self.get_vertices(indexed='faces')
+            self._face_normals = _compute_face_normals(vertices)
 
         if indexed is None:
             return self._face_normals

--- a/vispy/geometry/tests/test_meshdata.py
+++ b/vispy/geometry/tests/test_meshdata.py
@@ -10,25 +10,31 @@ from vispy.geometry.meshdata import MeshData
 
 
 def test_meshdata():
-    """Test meshdata Class
-    It's a unit square cut in two triangular element
-    """
-    square_vertices = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]],
-                               dtype=np.float64)
-    square_faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint8)
-    square_normals = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]],
-                              dtype=np.float64)
-    square_edges = np.array([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]],
-                            dtype=np.uint8)
+    dtype_float = np.float64
+    dtype_int = np.uint8
+    # Three ajacent triangles forming the tip of a tetrahedron at the origin.
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                        dtype=dtype_float)
+    faces = np.array([[0, 1, 2], [0, 2, 3], [0, 3, 1]], dtype=dtype_int)
+    face_normals = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]],
+                            dtype=dtype_float)
+    isqrt3 = 1 / np.sqrt(3)
+    isqrt2 = 1 / np.sqrt(2)
+    vertex_normals = np.array([
+        [isqrt3, isqrt3, isqrt3],
+        [0, isqrt2, isqrt2],
+        [isqrt2, 0, isqrt2],
+        [isqrt2, isqrt2, 0]
+    ], dtype=dtype_float)
+    edges = np.array([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
+                     dtype=dtype_int)
 
-    mesh = MeshData(vertices=square_vertices, faces=square_faces)
-    # test vertices and faces assignement
-    assert_array_equal(square_vertices, mesh.get_vertices())
-    assert_array_equal(square_faces, mesh.get_faces())
-    # test normals calculus
-    assert_array_equal(square_normals, mesh.get_vertex_normals())
-    # test edge calculus
-    assert_array_equal(square_edges, mesh.get_edges())
+    mesh = MeshData(vertices=vertices, faces=faces)
+    assert_array_equal(vertices, mesh.get_vertices())
+    assert_array_equal(faces, mesh.get_faces())
+    assert_array_equal(vertex_normals, mesh.get_vertex_normals())
+    assert_array_equal(face_normals, mesh.get_face_normals())
+    assert_array_equal(edges, mesh.get_edges())
 
 
 run_tests_if_main()


### PR DESCRIPTION
This does not add any new functionality, but tries to isolate the routines for unit testing for correctness.

This is in preparation for including the accelerated computation of vertex normals from #2069.