### PR TITLE
Prevent panzoom viewbox become zero

### DIFF
--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -253,6 +253,8 @@ class PanZoomCamera(BaseCamera):
         rect = self.rect
         self._real_rect = Rect(rect)
         vbr = self._viewbox.rect.flipped(x=self.flip[0], y=(not self.flip[1]))
+        # size should not be zero (but can be negative)
+        vbr.size = vbr.width or 1, vbr.height or 1
         d = self.depth_value
 
         # apply scale ratio constraint


### PR DESCRIPTION
See #2093. This fix prevents the `scatter_histogram.py` example from producing an error when one of its widgets gets zero height, which happens intermittendly. This does not solve the underlying problem of a zero-height widget being created in the first place, but it does prevent errors in case a scene is created with a zero-sized viewbox in other situations.

See  #2097 for (an attempt at) a proper solution.