### PR TITLE
Fix grid solver not updating variables when height/width changed

### DIFF
--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -462,19 +462,15 @@ class Grid(Widget):
 
         # we only need to remove and add the height and width constraints of
         # the solver if they are not the same as the current value
-        if abs(rect.height - self._var_h.value()) > 1e-4:
-            # if self._height_stay:
-            #     self._solver.remove_constraint(self._height_stay)
-
+        h_changed = abs(rect.height - self._var_h.value()) > 1e-4
+        w_changed = abs(rect.width - self._var_w.value()) > 1e-4
+        if h_changed:
             self._solver.suggestValue(self._var_h, rect.height)
-            # self._height_stay = self._solver.add_stay(self._var_h | 'strong')
 
-        if abs(rect.width - self._var_w.value()) > 1e-4:
-            # if self._width_stay:
-            #     self._solver.remove_constraint(self._width_stay)
-
+        if w_changed:
             self._solver.suggestValue(self._var_w, rect.width)
-            # self._width_stay = self._solver.add_stay(self._var_w | 'strong')
+        if h_changed or w_changed:
+            self._solver.updateVariables()
 
         value_vectorized = np.vectorize(lambda x: x.value())
 
@@ -496,6 +492,7 @@ class Grid(Widget):
                 y = np.sum(value_vectorized(self._height_grid[col][0:row]))
 
             if isinstance(widget, ViewBox):
+                print("####", val, x, y, width, height)
                 widget.rect = Rect(x, y, width, height)
             else:
                 widget.size = (width, height)

--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -492,7 +492,6 @@ class Grid(Widget):
                 y = np.sum(value_vectorized(self._height_grid[col][0:row]))
 
             if isinstance(widget, ViewBox):
-                print("####", val, x, y, width, height)
                 widget.rect = Rect(x, y, width, height)
             else:
                 widget.size = (width, height)


### PR DESCRIPTION
Closes #2093 
Closes #2099 
Closes #2097 

This closes the issue mentioned above and replaces the PRs mentioned. While debugging #2093 I noticed that the `height` of a widget would sometimes be set to `0` randomly. I thought I remembered kiwisolver's documentation talking about how to print out information about the solver so I was looking for [that](https://kiwisolver.readthedocs.io/en/latest/basis/solver_internals.html#inspecting-the-solver-state) when I found https://kiwisolver.readthedocs.io/en/latest/basis/basic_systems.html#solving-and-updating-variables. This mentions that if you suggest a new value for a variable you also have to later run `.updateVariables()` to have the solver actually calculate the new results.

I made the changes in this PR and ran the example code in #2093 for 438 times with no errors. This seems to actually fix the issue. I'm hoping @almarklein can do a little more testing. It would also be interesting (if we have the time) to know what the previous height was and what the new height was being set to. I guess I assume the height is being set to 0 originally, then the whole window is resized during `.show`, and the height never got changed from 0...well except why would width not be the problem :thinking: I don't know.