### PR TITLE
Refactor ImageVisual for easier subclassing

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -229,6 +229,7 @@ class ImageVisual(Visual):
         self._need_vertex_update = True
         self._need_colortransform_update = True
         self._need_interpolation_update = True
+        self._texture = self._init_texture(data, texture_format)
         self._subdiv_position = VertexBuffer()
         self._subdiv_texcoord = VertexBuffer()
 

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -199,7 +199,6 @@ class ImageVisual(Visual):
                  interpolation='nearest', texture_format=None, **kwargs):
         """Initialize image properties, texture storage, and interpolation methods."""
         self._data = None
-        self._gamma = gamma
 
         # load 'float packed rgba8' interpolation kernel
         # to load float interpolation kernel use
@@ -251,6 +250,7 @@ class ImageVisual(Visual):
 
         self.clim = clim or "auto"  # None -> "auto"
         self.cmap = cmap
+        self.gamma = gamma
         if data is not None:
             self.set_data(data)
         self.freeze()

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -223,25 +223,12 @@ class ImageVisual(Visual):
             raise ValueError("interpolation must be one of %s" %
                              ', '.join(self._interpolation_names))
 
-        # check texture interpolation
-        if self._interpolation == 'bilinear':
-            texture_interpolation = 'linear'
-        else:
-            texture_interpolation = 'nearest'
-
         self._method = method
         self._grid = grid
         self._need_texture_upload = True
         self._need_vertex_update = True
         self._need_colortransform_update = True
         self._need_interpolation_update = True
-        if texture_format is None:
-            self._texture = CPUScaledTexture2D(
-                data, interpolation=texture_interpolation)
-        else:
-            self._texture = GPUScaledTexture2D(
-                data, internalformat=texture_format,
-                interpolation=texture_interpolation)
         self._subdiv_position = VertexBuffer()
         self._subdiv_texcoord = VertexBuffer()
 
@@ -283,6 +270,21 @@ class ImageVisual(Visual):
         interpolation_fun['nearest'] = Function(_texture_lookup)
         interpolation_fun['bilinear'] = Function(_texture_lookup)
         return interpolation_names, interpolation_fun
+
+    def _init_texture(self, data, texture_format):
+        if self._interpolation == 'bilinear':
+            texture_interpolation = 'linear'
+        else:
+            texture_interpolation = 'nearest'
+
+        if texture_format is None:
+            tex = CPUScaledTexture2D(
+                data, interpolation=texture_interpolation)
+        else:
+            tex = GPUScaledTexture2D(
+                data, internalformat=texture_format,
+                interpolation=texture_interpolation)
+        return tex
 
     def set_data(self, image):
         """Set the image data.

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -27,6 +27,13 @@ def test_image(is_3d):
                               ("_rgb" if is_3d else "_mono"))
 
 
+@pytest.mark.parametrize('gamma', [None, -0.5, "0.5"])
+def test_bad_init_gamma(gamma):
+    """Test creating an Image with a bad gamma value."""
+    with TestingCanvas(size=(100, 50)) as c:
+        pytest.raises((TypeError, ValueError), Image, gamma=gamma, parent=c.scene)
+
+
 def _make_test_data(shape, input_dtype):
     data = np.random.random_sample(shape)
     if data.ndim == 3 and data.shape[-1] == 4:

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -27,6 +27,7 @@ def test_image(is_3d):
                               ("_rgb" if is_3d else "_mono"))
 
 
+@requires_application()
 @pytest.mark.parametrize('gamma', [None, -0.5, "0.5"])
 def test_bad_init_gamma(gamma):
     """Test creating an Image with a bad gamma value."""


### PR DESCRIPTION
This PR refactors the ImageVisual's creations of its Texture object. This is to help me in my own applications where I want to subclass the ImageVisual. This simple change gives me much more control over how the textures are created while not requiring me to replicate the whole `__init__`. There is probably larger refactor that could serve subclasses (like the one @tlambert03 is working on in #1999), but I'm not sure we're ready for that yet. I hope to find some time today to use this refactor in my application and make sure it works. Eventually the subclass I'm working on will probably be added to VisPy-core.