### PR TITLE
Add handling of NaNs in ImageVisual

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -134,6 +134,10 @@ class ImageVisual(Visual):
     ----------
     data : ndarray
         ImageVisual data. Can be shape (M, N), (M, N, 3), or (M, N, 4).
+        If floating point data is provided and contains NaNs, they will
+        be made transparent (discarded) for the single band data case.
+        For RGB data, NaNs will be mapped to the lowest ``clim`` value.
+        If the Alpha band is NaN it will be mapped to 0 (transparent).
     method : str
         Selects method of rendering image in case of non-linear transforms.
         Each method produces similar results, but may trade efficiency

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,12 +89,26 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
+        if (!(color.r <= 0.0 || 0.0 <= color.r)) {
+            discard;
+        }
         data = clamp(data, min($clim.x, $clim.y), max($clim.x, $clim.y));
         data = (data - $clim.x) / ($clim.y - $clim.x);
         return data;
     }"""
 _apply_clim = """
     vec4 apply_clim(vec4 color) {
+        // If all the pixels are NaN make it completely transparent
+        // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
+        if (
+            !(color.r <= 0.0 || 0.0 <= color.r) &&
+            !(color.g <= 0.0 || 0.0 <= color.g) &&
+            !(color.b <= 0.0 || 0.0 <= color.b)) {
+            color.a = 0;
+        }
+        color.r = !(color.r <= 0.0 || 0.0 <= color.r) ? min($clim.x, $clim.y) : color.r;
+        color.g = !(color.g <= 0.0 || 0.0 <= color.g) ? min($clim.x, $clim.y) : color.g;
+        color.b = !(color.b <= 0.0 || 0.0 <= color.b) ? min($clim.x, $clim.y) : color.b;
         color.rgb = clamp(color.rgb, min($clim.x, $clim.y), max($clim.x, $clim.y));
         color.rgb = (color.rgb - $clim.x) / ($clim.y - $clim.x);
         return max(color, 0.0);

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,7 +89,7 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
-        if (!(color.r <= 0.0 || 0.0 <= color.r)) {
+        if (!(data <= 0.0 || 0.0 <= data)) {
             discard;
         }
         data = clamp(data, min($clim.x, $clim.y), max($clim.x, $clim.y));

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -135,7 +135,10 @@ class ImageVisual(Visual):
     data : ndarray
         ImageVisual data. Can be shape (M, N), (M, N, 3), or (M, N, 4).
         If floating point data is provided and contains NaNs, they will
-        be made transparent (discarded) for the single band data case.
+        be made transparent (discarded) for the single band data case when
+        scaling is done on the GPU (see ``texture_format``). On the CPU,
+        single band NaNs are mapped to 0 as they are sent to the GPU which
+        result in them using the lowest ``clim`` value in the GPU.
         For RGB data, NaNs will be mapped to the lowest ``clim`` value.
         If the Alpha band is NaN it will be mapped to 0 (transparent).
     method : str

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -141,6 +141,8 @@ class ImageVisual(Visual):
         result in them using the lowest ``clim`` value in the GPU.
         For RGB data, NaNs will be mapped to the lowest ``clim`` value.
         If the Alpha band is NaN it will be mapped to 0 (transparent).
+        Note that NaN handling is not required by some OpenGL implementations
+        and NaNs may be treated differently on some systems (ex. as 0s).
     method : str
         Selects method of rendering image in case of non-linear transforms.
         Each method produces similar results, but may trade efficiency

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,6 +89,8 @@ _texture_lookup = """
 
 _apply_clim_float = """
     float apply_clim(float data) {
+        // If data is NaN, don't draw it at all
+        // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
         if (!(data <= 0.0 || 0.0 <= data)) {
             discard;
         }
@@ -98,17 +100,12 @@ _apply_clim_float = """
     }"""
 _apply_clim = """
     vec4 apply_clim(vec4 color) {
-        // If all the pixels are NaN make it completely transparent
+        // Handle NaN values
         // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
-        if (
-            !(color.r <= 0.0 || 0.0 <= color.r) &&
-            !(color.g <= 0.0 || 0.0 <= color.g) &&
-            !(color.b <= 0.0 || 0.0 <= color.b)) {
-            color.a = 0;
-        }
         color.r = !(color.r <= 0.0 || 0.0 <= color.r) ? min($clim.x, $clim.y) : color.r;
         color.g = !(color.g <= 0.0 || 0.0 <= color.g) ? min($clim.x, $clim.y) : color.g;
         color.b = !(color.b <= 0.0 || 0.0 <= color.b) ? min($clim.x, $clim.y) : color.b;
+        color.a = !(color.b <= 0.0 || 0.0 <= color.b) ? 0 : color.b;
         color.rgb = clamp(color.rgb, min($clim.x, $clim.y), max($clim.x, $clim.y));
         color.rgb = (color.rgb - $clim.x) / ($clim.y - $clim.x);
         return max(color, 0.0);

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -105,7 +105,7 @@ _apply_clim = """
         color.r = !(color.r <= 0.0 || 0.0 <= color.r) ? min($clim.x, $clim.y) : color.r;
         color.g = !(color.g <= 0.0 || 0.0 <= color.g) ? min($clim.x, $clim.y) : color.g;
         color.b = !(color.b <= 0.0 || 0.0 <= color.b) ? min($clim.x, $clim.y) : color.b;
-        color.a = !(color.b <= 0.0 || 0.0 <= color.b) ? 0 : color.b;
+        color.a = !(color.a <= 0.0 || 0.0 <= color.a) ? 0 : color.a;
         color.rgb = clamp(color.rgb, min($clim.x, $clim.y), max($clim.x, $clim.y));
         color.rgb = (color.rgb - $clim.x) / ($clim.y - $clim.x);
         return max(color, 0.0);

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from vispy.scene.visuals import Image
 from vispy.testing import (requires_application, TestingCanvas,
-                           run_tests_if_main)
+                           run_tests_if_main, IS_CI)
 from vispy.testing.image_tester import assert_image_approved, downsample
 
 import numpy as np
@@ -120,6 +120,7 @@ def test_image_clims_and_gamma(input_dtype, texture_format, num_channels,
         compare_render(scaled_data ** 2, rendered3, rendered2, atol=gamma_atol)
 
 
+@pytest.mark.xfail(IS_CI, reason="CI environments sometimes treat NaN as 0")
 @requires_application()
 @pytest.mark.parametrize('texture_format', [None, 'auto'])
 def test_image_nan_single_band(texture_format):

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -113,6 +113,74 @@ def test_image_clims_and_gamma(input_dtype, texture_format, num_channels,
 
 
 @requires_application()
+@pytest.mark.parametrize('texture_format', [None, 'auto'])
+def test_image_nan_single_band(texture_format):
+    size = (40, 40)
+    data = np.ones((40, 40))
+    data[:5, :5] = np.nan
+    data[:5, -5:] = 0
+
+    expected = (np.ones((40, 40, 4)) * 255).astype(np.uint8)
+    # black square
+    expected[:5, -5:, :3] = 0
+    if texture_format is None:
+        # CPU scaling's NaNs get converted to 0s
+        expected[:5, :5, :3] = 0
+    else:
+        # GPU receives NaNs
+        # nan - transparent square
+        expected[:5, :5, 0] = 0
+        expected[:5, :5, 1] = 255  # match the 'green' background
+        expected[:5, :5, 2] = 0
+
+    with TestingCanvas(size=size[::-1], bgcolor=(0, 1, 0)) as c:
+        Image(data, cmap='grays',
+              texture_format=texture_format, parent=c.scene)
+        rendered = c.render()
+        np.testing.assert_allclose(rendered, expected)
+
+
+@requires_application()
+@pytest.mark.parametrize('num_bands', [3, 4])
+@pytest.mark.parametrize('texture_format', [None, 'auto'])
+def test_image_nan_rgb(texture_format, num_bands):
+    size = (40, 40)
+    data = np.ones((40, 40, num_bands))
+    data[:5, :5, :3] = np.nan  # upper left - RGB all NaN
+    data[:5, 20:25, 0] = np.nan  # upper middle - R NaN
+    data[:5, -5:, :3] = 0  # upper right - opaque RGB black square
+    data[-5:, -5:, :] = np.nan  # lower right RGBA all NaN
+    if num_bands == 4:
+        data[-5:, :5, 3] = np.nan  # lower left - Alpha NaN
+
+    expected = (np.ones((40, 40, 4)) * 255).astype(np.uint8)
+    # upper left - NaN goes to opaque black
+    expected[:5, :5, :3] = 0
+    # upper middle -> NaN R goes to 0
+    expected[:5, 20:25, 0] = 0
+    # upper right - opaque RGB black square
+    expected[:5, -5:, :3] = 0
+    # lower right - NaN RGB/A goes to 0
+    # RGBA case - we see the green background behind the image
+    expected[-5:, -5:, 0] = 0
+    expected[-5:, -5:, 2] = 0
+    if num_bands == 3:
+        # RGB case - opaque black because Alpha defaults 1
+        expected[-5:, -5:, 1] = 0
+    # lower left - NaN Alpha goes to 0
+    if num_bands == 4:
+        # see the green background behind the image
+        expected[-5:, :5, 0] = 0
+        expected[-5:, :5, 2] = 0
+
+    with TestingCanvas(size=size[::-1], bgcolor=(0, 1, 0)) as c:
+        Image(data, cmap='grays',
+              texture_format=texture_format, parent=c.scene)
+        rendered = c.render()
+        np.testing.assert_allclose(rendered, expected)
+
+
+@requires_application()
 @pytest.mark.parametrize('num_channels', [0, 1, 3, 4])
 @pytest.mark.parametrize('texture_format', [None, 'auto'])
 def test_image_equal_clims(texture_format, num_channels):


### PR DESCRIPTION
This was discussed a little in #2085 and I know this current implementation isn't optimized (multiple nan checks and branches), but I wanted to start the discussion since this shows (I think) what we want the end result to be. For single channel images, the NaN pixels should be fully transparent (or discarded). For RGB images, if all pixels are NaNs then make them transparent, otherwise make them the lower clim limit.

Thoughts? Changes?