### PR TITLE
Fix inconsistent picking behavior regarding depth testing

### DIFF
--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -75,7 +75,7 @@ def test_picking_basic():
         view.camera = 'panzoom'
 
         x = np.linspace(0, 400, 100)
-        y = np.linspace(-144.1, -9.44, 100)
+        y = np.linspace(0, 200, 100)
         line = scene.Line(np.array((x, y)).T.astype(np.float32))
         line.interactive = True
         view.add(line)
@@ -83,6 +83,7 @@ def test_picking_basic():
 
         c.render()  # initial basic draw
         for _ in range(2):  # run picking twice to make sure it is repeatable
+            # get Visuals on a Canvas point that Line is drawn on
             picked_visuals = c.visuals_at((100, 25))
             assert len(picked_visuals) == 2
             assert any(isinstance(vis, scene.ViewBox) for vis in picked_visuals)

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -60,3 +60,30 @@ def test_canvas_render(blend_func):
         else:
             # the alpha should have some transparency
             assert (rgba_result[..., 3] != 255).any()
+
+
+@requires_application()
+def test_picking_basic():
+    """Test basic picking behavior.
+
+    Based on https://github.com/vispy/vispy/issues/2107.
+
+    """
+    with TestingCanvas(size=(125, 125), show=True, title='run') as c:
+        view = c.central_widget.add_view()
+        view.margin = 5  # add empty space where there are no visuals
+        view.camera = 'panzoom'
+
+        x = np.linspace(0, 400, 100)
+        y = np.linspace(-144.1, -9.44, 100)
+        line = scene.Line(np.array((x, y)).T.astype(np.float32))
+        line.interactive = True
+        view.add(line)
+        view.camera.set_range()
+
+        c.render()  # initial basic draw
+        for _ in range(2):  # run picking twice to make sure it is repeatable
+            picked_visuals = c.visuals_at((100, 25))
+            assert len(picked_visuals) == 2
+            assert any(isinstance(vis, scene.ViewBox) for vis in picked_visuals)
+            assert any(isinstance(vis, scene.Line) for vis in picked_visuals)

--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -50,7 +50,7 @@ class Widget(Compound):
         self._mesh.set_gl_state('translucent', depth_test=False,
                                 cull_face=False)
         self._picking_mesh = MeshVisual(mode='triangle_fan')
-        self._picking_mesh.set_gl_state(cull_face=False)
+        self._picking_mesh.set_gl_state(cull_face=False, depth_test=False)
         self._picking_mesh.visible = False
 
         # reserved space inside border

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -358,9 +358,6 @@ class MeshVisual(Visual):
                 return False
             self._data_changed = False
 
-    def draw(self, *args, **kwds):
-        Visual.draw(self, *args, **kwds)
-
     @staticmethod
     def _prepare_transforms(view):
         tr = view.transforms.get_transform()


### PR DESCRIPTION
Closes #2107

See #2107 for the long debug process and discussion on this. Basically the MeshVisual used by the ViewBox (and all Widget objects) only has `cull_face` set, but depends heavily on the behavior/setting of depth testing. This PR forces depth testing to be off which seems to make this picking Mesh behave more consistently with ViewBox child Visuals.

TODO:

- [x] Add a test reflecting at least one of the cases in #2107.