### PR TITLE
Change Visual GL state so it is only set if drawing

### DIFF
--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -439,13 +439,14 @@ class Visual(BaseVisual):
     def draw(self):
         if not self.visible:
             return
-        self._configure_gl_state()
         if self._prepare_draw(view=self) is False:
             return
 
         if self._vshare.draw_mode is None:
             raise ValueError("_draw_mode has not been set for visual %r" %
                              self)
+
+        self._configure_gl_state()
         try:
             self._program.draw(self._vshare.draw_mode,
                                self._vshare.index_buffer)


### PR DESCRIPTION
Closes #2109 

As discussed in #2109, this moves when the GL state is applied/sent to the GPU. This is things like depth test, blend functions, etc. Previously this was done *before* `_prepare_draw` of the individual Visual was called. If `_prepare_draw` returns `False` then a `Visual` isn't drawn and this is wasted. This PR is currently just a test to see what happens if we do this change. In the best case this passes all tests and is a slight performance improvement. In the next best case it only effects the `TextVisual` which has some complicated rendering before "real" drawing. Worst case is there are settings that reset GPU state (like clear color?) and doing these after texture, buffer, and other data commands will cause issues. In this last case, this can't be merged.