### PR TITLE
Add clipping planes to `VolumeVisual`

### DIFF
--- a/examples/basics/scene/volume_clipping.py
+++ b/examples/basics/scene/volume_clipping.py
@@ -86,12 +86,13 @@ def on_mouse_move(event):
         axis.transform.translate((50., 50.))
         axis.update()
 
+volume_center = (np.array(vol.shape) / 2)
 
 clip_modes = {
-    'x': np.array([[[0.5, 0.5, 0.5], [1, 0, 0]]]),
-    'y': np.array([[[0.5, 0.5, 0.5], [0, 1, 0]]]),
-    'z': np.array([[[0.5, 0.5, 0.5], [0, 0, 1]]]),
-    'o': np.array([[[0.5, 0.5, 0.5], [1, 1, 1]]]),
+    'x': np.array([[volume_center, [0, 0, 1]]]),
+    'y': np.array([[volume_center, [0, 1, 0]]]),
+    'z': np.array([[volume_center, [1, 0, 0]]]),
+    'o': np.array([[volume_center, [1, 1, 1]]]),
 }
 
 

--- a/examples/basics/scene/volume_clipping.py
+++ b/examples/basics/scene/volume_clipping.py
@@ -37,7 +37,7 @@ volume.transform = scene.STTransform(translate=(64, 64, 0))
 # Create three cameras (Fly, Turntable and Arcball)
 fov = 60.
 cam = scene.cameras.TurntableCamera(parent=view.scene, fov=fov,
-                                     name='Turntable')
+                                    name='Turntable')
 
 view.camera = cam  # Select turntable at first
 
@@ -64,6 +64,7 @@ class TransGrays(BaseColormap):
     }
     """
 
+
 # Setup colormap iterators
 opaque_cmaps = cycle(get_colormaps())
 translucent_cmaps = cycle([TransFire(), TransGrays()])
@@ -85,12 +86,14 @@ def on_mouse_move(event):
         axis.transform.translate((50., 50.))
         axis.update()
 
+
 clip_modes = {
     'x': np.array([[[0.5, 0.5, 0.5], [1, 0, 0]]]),
     'y': np.array([[[0.5, 0.5, 0.5], [0, 1, 0]]]),
     'z': np.array([[[0.5, 0.5, 0.5], [0, 0, 1]]]),
     'o': np.array([[[0.5, 0.5, 0.5], [1, 1, 1]]]),
 }
+
 
 def add_clip(vol, mode):
     new_plane = clip_modes[mode]
@@ -99,9 +102,11 @@ def add_clip(vol, mode):
     else:
         vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
 
+
 def remove_clip(vol):
     if vol.clipping_planes is not None:
         vol.clipping_planes = vol.clipping_planes[:-1]
+
 
 # Implement key presses
 @canvas.events.key_press.connect

--- a/examples/basics/scene/volume_clipping.py
+++ b/examples/basics/scene/volume_clipping.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+"""
+Example of volume rendering with clipping planes
+Controls:
+- x/y/z/o - add new clipping plane with normal along x/y/z or [1,1,1] oblique axis
+- r - remove a clipping plane
+"""
+
+from itertools import cycle
+
+import numpy as np
+
+from vispy import app, scene, io
+from vispy.color import get_colormaps, BaseColormap
+from vispy.visuals.transforms import STTransform
+
+# Read volume
+vol = np.load(io.load_data_file('volume/stent.npz'))['arr_0']
+
+# Prepare canvas
+canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
+
+# Set up a viewbox to display the image with interactive pan/zoom
+view = canvas.central_widget.add_view()
+
+# Set whether we are emulating a 3D texture
+emulate_texture = False
+
+# Create the volume visuals, only one is visible
+volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
+volume.transform = scene.STTransform(translate=(64, 64, 0))
+
+# Create three cameras (Fly, Turntable and Arcball)
+fov = 60.
+cam = scene.cameras.TurntableCamera(parent=view.scene, fov=fov,
+                                     name='Turntable')
+
+view.camera = cam  # Select turntable at first
+
+# Create an XYZAxis visual
+axis = scene.visuals.XYZAxis(parent=view)
+s = STTransform(translate=(50, 50), scale=(50, 50, 50, 1))
+affine = s.as_matrix()
+axis.transform = affine
+
+
+# create colormaps that work well for translucent and additive volume rendering
+class TransFire(BaseColormap):
+    glsl_map = """
+    vec4 translucent_fire(float t) {
+        return vec4(pow(t, 0.5), t, t*t, max(0, t*1.05 - 0.05));
+    }
+    """
+
+
+class TransGrays(BaseColormap):
+    glsl_map = """
+    vec4 translucent_grays(float t) {
+        return vec4(t, t, t, t*0.05);
+    }
+    """
+
+# Setup colormap iterators
+opaque_cmaps = cycle(get_colormaps())
+translucent_cmaps = cycle([TransFire(), TransGrays()])
+opaque_cmap = next(opaque_cmaps)
+translucent_cmap = next(translucent_cmaps)
+
+
+# Implement axis connection with cam2
+@canvas.events.mouse_move.connect
+def on_mouse_move(event):
+    if event.button == 1 and event.is_dragging:
+        axis.transform.reset()
+
+        axis.transform.rotate(cam.roll, (0, 0, 1))
+        axis.transform.rotate(cam.elevation, (1, 0, 0))
+        axis.transform.rotate(cam.azimuth, (0, 1, 0))
+
+        axis.transform.scale((50, 50, 0.001))
+        axis.transform.translate((50., 50.))
+        axis.update()
+
+clip_modes = {
+    'x': np.array([[[0.5, 0.5, 0.5], [1, 0, 0]]]),
+    'y': np.array([[[0.5, 0.5, 0.5], [0, 1, 0]]]),
+    'z': np.array([[[0.5, 0.5, 0.5], [0, 0, 1]]]),
+    'o': np.array([[[0.5, 0.5, 0.5], [1, 1, 1]]]),
+}
+
+def add_clip(vol, mode):
+    new_plane = clip_modes[mode]
+    if vol.clipping_planes is None:
+        vol.clipping_planes = new_plane
+    else:
+        vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
+
+def remove_clip(vol):
+    if vol.clipping_planes is not None:
+        vol.clipping_planes = vol.clipping_planes[:-1]
+
+# Implement key presses
+@canvas.events.key_press.connect
+def on_key_press(event):
+    if event.text in 'xyzo':
+        add_clip(volume, event.text)
+    elif event.text == 'r':
+        remove_clip(volume)
+
+
+# for testing performance
+# @canvas.connect
+# def on_draw(ev):
+# canvas.update()
+
+if __name__ == '__main__':
+    print(__doc__)
+    app.run()

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -5,7 +5,7 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 """
-Example of volume rendering with clipping planes
+Volume rendering with clipping planes
 ================================================
 Controls:
 - x/y/z/o - add new clipping plane with normal along x/y/z or [1,1,1] oblique axis

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+# vispy: gallery 5
 # -----------------------------------------------------------------------------
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 """
 Example of volume rendering with clipping planes
+================================================
 Controls:
 - x/y/z/o - add new clipping plane with normal along x/y/z or [1,1,1] oblique axis
 - r - remove a clipping plane

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 """
 Volume rendering with clipping planes
-================================================
+=====================================
 Controls:
 - x/y/z/o - add new clipping plane with normal along x/y/z or [1,1,1] oblique axis
 - r - remove a clipping plane

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -708,7 +708,7 @@ class VolumeVisual(Visual):
             self.update()
 
     @staticmethod
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _build_clipping_planes_func(n_planes):
         """
         build the code snippet used to clip the volume based on self.clipping_planes

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -254,7 +254,7 @@ void main() {
                 vec4 color = $sample(u_volumetex, loc);
                 float val = color.r;
 
-                {in_loop}
+                $in_loop
             }
             // Advance location deeper into the volume
             loc += step;

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -724,7 +724,8 @@ class VolumeVisual(Visual):
             uniform vec3 u_clipping_plane_norm{idx};
             '''
         clip_template = '''
-            vec3 relative_vec{idx} = loc - u_clipping_plane_pos{idx};
+            vec3 clipping_plane{idx}_tex = u_clipping_plane_pos{idx} / u_shape;
+            vec3 relative_vec{idx} = loc - clipping_plane{idx}_tex;
             float is_shown{idx} = dot(relative_vec{idx}, u_clipping_plane_norm{idx});
             is_shown = min(is_shown{idx}, is_shown);
             '''

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -710,9 +710,7 @@ class VolumeVisual(Visual):
     @staticmethod
     @lru_cache(maxsize=10)
     def _build_clipping_planes_func(n_planes):
-        """
-        build the code snippet used to clip the volume based on self.clipping_planes
-        """
+        """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func = Function(
             '$vars\nfloat clip_planes(vec3 loc, vec3 vol_shape) { float is_shown = 1.0; $clips; return is_shown; }')
         # each plane is defined by a position and a normal vector
@@ -737,9 +735,9 @@ class VolumeVisual(Visual):
 
     @property
     def clipping_planes(self):
-        """
-        a set of planes used to clip the volume. Each plane is defined by a position and
-        a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
+        """Get the set of planes used to clip the volume.
+
+        Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
         """
         return self._clipping_planes[:, :, ::-1]
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -749,12 +749,14 @@ class VolumeVisual(Visual):
     def clipping_planes(self, value):
         if value is not None:
             value = value[:, :, ::-1]
-        self._clipping_planes = value
-        self.shared_program.frag['clip_by_planes'] = self._build_clipping_planes_func()
+        # only remake the code if number of planes changed
+        if len(value) != len(self._clipping_planes):
+            self.shared_program.frag['clip_by_planes'] = self._build_clipping_planes_func()
         if value is not None:
             for idx, plane in enumerate(value):
                 self.shared_program[f'u_clipping_plane_pos{idx}'] = tuple(plane[0])
                 self.shared_program[f'u_clipping_plane_norm{idx}'] = tuple(plane[1])
+        self._clipping_planes = value
         self.update()
 
     @property

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -727,7 +727,7 @@ class VolumeVisual(Visual):
         if self.clipping_planes is None:
             cl_planes = []
         else:
-            cl_planes = self.clipping_planes
+            cl_planes = self._clipping_planes
         for idx in range(len(cl_planes)):
             all_vars.append(vars_template.format(idx=idx))
             all_clips.append(clip_template.format(idx=idx))
@@ -741,10 +741,14 @@ class VolumeVisual(Visual):
         a set of planes used to clip the volume. Each plane is defined by a position and
         a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
         """
-        return self._clipping_planes
+        if self._clipping_planes is None:
+            return self._clipping_planes
+        return self._clipping_planes[:, :, ::-1]
 
     @clipping_planes.setter
     def clipping_planes(self, value):
+        if value is not None:
+            value = value[:, :, ::-1]
         self._clipping_planes = value
         self.shared_program.frag['clip_by_planes'] = self._build_clipping_planes_func()
         if value is not None:

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -708,7 +708,7 @@ class VolumeVisual(Visual):
             self.update()
 
     @staticmethod
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=10)
     def _build_clipping_planes_func(n_planes):
         """
         build the code snippet used to clip the volume based on self.clipping_planes

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -245,16 +245,21 @@ void main() {
     // datasets. Ugly, but it works ...
     vec3 loc = start_loc;
     int iter = 0;
+    
+    // Keep track of whether texture has been sampled
+    int texture_sampled = 0;
+    
     while (iter < nsteps) {
         for (iter=iter; iter<nsteps; iter++)
         {
-            // Ignore this step if clipped out by the clipping planes
+            // Only sample volume if loc is not clipped by clipping planes
             float is_shown = $clip_by_planes(loc, u_shape);
             if (is_shown >= 0)
             {
                 // Get sample color
                 vec4 color = $sample(u_volumetex, loc);
                 float val = color.r;
+                texture_sampled = 1;
 
                 $in_loop
             }
@@ -262,7 +267,12 @@ void main() {
             loc += step;
         }
     }
-
+    
+    // discard fragment if texture not sampled
+    if ( texture_sampled != 1 ) {
+        discard;
+    }
+    
     $after_loop
 
     /* Set depth value - from visvis TODO


### PR DESCRIPTION
After trying to implement this [in napari](https://github.com/napari/napari/pull/2934) and getting some very useful input in #2113, here's a pure vispy implementation of clipping planes for the Volume visual.

I added an example (`examples/basics/scene/volume_clipping.py`) with some simple keybindings to showcase the code (thanks @alisterburt for your code at #2074 :)).

https://user-images.githubusercontent.com/23482191/123859348-d1646600-d924-11eb-8c12-d28f9fe087a9.mp4

Planes are defined as two vec3 (position and normal vector), and are used to clip the volume (anything on the negative side of the normal vector is not shown). The shape of `volume.clipping_planes` should therefore be `(n_planes, 2, 3)`.

Currently, the vector coordinates are normalized in (0, 1), but they should probably be in world coordinates; I'm not sure how to handle that...