### PR TITLE
fix: the FOV in BaseCamera is conflicting with Base3DRotationCamera...

### DIFF
--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -218,7 +218,7 @@ class BaseCamera(Node):
     @fov.setter
     def fov(self, fov):
         fov = float(fov)
-        if fov < 0 or fov >= 180:
+        if fov < 0 or fov > 180:
             raise ValueError("fov must be between 0 and 180.")
         self._fov = fov
         self.view_changed()


### PR DESCRIPTION
…and possibly other camera classes as well

In Base3DRotationCamera, changing the FOV through mouse event will be handle by viewbox_mouse_event(). With this line: self.fov = min(180.0, max(0.0, fov)), it is possible to have self.fov = 180 when fov = 180. And this will create an exception since BaseCamera class does not allow fov >= 180.