### PR TITLE
Replace CI environment variable checks with constants

### DIFF
--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -13,7 +13,7 @@ from vispy.app import use_app, Canvas, Timer, MouseEvent, KeyEvent
 from vispy.app.base import BaseApplicationBackend
 from vispy.testing import (requires_application, SkipTest, assert_is,
                            assert_in, run_tests_if_main,
-                           assert_equal, assert_true, assert_raises)
+                           assert_equal, assert_true, assert_raises, IS_TRAVIS_CI)
 from vispy.util import keys, use_log_level
 
 from vispy.gloo.program import (Program, VertexBuffer, IndexBuffer)
@@ -381,7 +381,7 @@ def test_close_keys():
     c.app.process_events()
 
 
-@pytest.mark.skipif(os.getenv('TRAVIS', 'false') == 'true' and 'darwin' in sys.platform,
+@pytest.mark.skipif(IS_TRAVIS_CI and 'darwin' in sys.platform,
                     reason='Travis OSX causes segmentation fault on this test for an unknown reason.')
 @requires_application()
 def test_event_order():

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from collections import namedtuple
 from io import StringIO

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest
@@ -33,7 +32,7 @@ def test_context_properties():
     for config in configs:
         n_items = len(config)
         with Canvas(config=config):
-            if 'true' in IS_CI:
+            if IS_CI:
                 # Travis and Appveyor cannot handle obtaining these values
                 props = config
             else:

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from vispy.testing import (requires_application, SkipTest, run_tests_if_main,
-                           assert_raises)
+                           assert_raises, IS_CI)
 from vispy.app import Canvas, use_app
 from vispy.gloo import get_gl_configuration, Program
 from vispy.gloo.gl import check_error
@@ -28,15 +28,12 @@ def test_context_properties():
     else:
         assert_raises(RuntimeError, Canvas, app=a,
                       config=dict(double_buffer=False))
-    if a.backend_name.lower() == 'sdl2' and 'true' in (os.getenv('TRAVIS', ''),
-                                                       os.getenv('GITHUB_ACTIONS', '')):
+    if a.backend_name.lower() == 'sdl2' and IS_CI:
         raise SkipTest('Travis SDL cannot set context')
     for config in configs:
         n_items = len(config)
         with Canvas(config=config):
-            if 'true' in (os.getenv('TRAVIS', ''),
-                          os.getenv('APPVEYOR', '').lower(),
-                          os.getenv('GITHUB_ACTIONS', '')):
+            if 'true' in IS_CI:
                 # Travis and Appveyor cannot handle obtaining these values
                 props = config
             else:

--- a/vispy/app/tests/test_simultaneous.py
+++ b/vispy/app/tests/test_simultaneous.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 import sys
 from time import sleep
 

--- a/vispy/app/tests/test_simultaneous.py
+++ b/vispy/app/tests/test_simultaneous.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from vispy.app import use_app, Canvas, Timer
-from vispy.testing import requires_application, SkipTest, run_tests_if_main
+from vispy.testing import requires_application, SkipTest, run_tests_if_main, IS_TRAVIS_CI
 from vispy.util.ptime import time
 from vispy.gloo import gl
 from vispy.gloo.util import _screenshot
@@ -43,7 +43,7 @@ def _update_process_check(canvas, val, draw=True):
         raise
 
 
-@pytest.mark.xfail(os.getenv('TRAVIS', 'false') == 'true' and 'darwin' in sys.platform,
+@pytest.mark.xfail(IS_TRAVIS_CI and 'darwin' in sys.platform,
                    reason='Travis OSX causes segmentation fault on this test for an unknown reason.')
 @requires_application()
 def test_multiple_canvases():

--- a/vispy/gloo/tests/test_use_gloo.py
+++ b/vispy/gloo/tests/test_use_gloo.py
@@ -16,7 +16,7 @@ from vispy.gloo import (Texture2D, Texture3D, Program, FrameBuffer,
 from vispy.gloo.util import draw_texture, _screenshot
 from vispy.testing import (requires_application, has_pyopengl,
                            run_tests_if_main,
-                           assert_raises, assert_equal)
+                           assert_raises, assert_equal, IS_TRAVIS_CI)
 
 
 @requires_application()
@@ -125,7 +125,7 @@ def test_use_texture3D():
             assert_allclose(out, expected, atol=1./255.)
 
 
-@pytest.mark.xfail(os.getenv('TRAVIS', 'false') == 'true' and 'darwin' in sys.platform,
+@pytest.mark.xfail(IS_TRAVIS_CI and 'darwin' in sys.platform,
                    reason='Travis OSX causes segmentation fault on this test for an unknown reason.')
 @requires_application()
 def test_use_uniforms():

--- a/vispy/gloo/tests/test_use_gloo.py
+++ b/vispy/gloo/tests/test_use_gloo.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2014, Nicolas P. Rougier. All rights reserved.
 # Distributed under the terms of the new BSD License.
 # -----------------------------------------------------------------------------
-import os
 import sys
 
 import numpy as np

--- a/vispy/testing/__init__.py
+++ b/vispy/testing/__init__.py
@@ -47,5 +47,5 @@ from ._testing import (SkipTest, requires_application, requires_ipython,  # noqa
                        run_tests_if_main, requires_ssl,  # noqa
                        assert_is, assert_in, assert_not_in, assert_equal,
                        assert_not_equal, assert_raises, assert_true,  # noqa
-                       raises, requires_numpydoc)  # noqa
+                       raises, requires_numpydoc, IS_TRAVIS_CI, IS_CI)  # noqa
 from ._runners import test  # noqa

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ..util import use_log_level, run_subprocess
 from ..util.ptime import time
-from ._testing import has_application, nottest
+from ._testing import has_application, nottest, IS_CI, IS_TRAVIS_CI
 
 
 _line_sep = '-' * 70
@@ -240,7 +240,7 @@ with canvas as c:
 """
 
 bad_examples = []
-if os.getenv('TRAVIS', 'false') == 'true' and sys.platform == 'darwin':
+if IS_TRAVIS_CI and sys.platform == 'darwin':
     # example scripts that contain non-ascii text
     # seem to fail on Travis OSX
     bad_examples = [
@@ -249,14 +249,13 @@ if os.getenv('TRAVIS', 'false') == 'true' and sys.platform == 'darwin':
         'examples/demo/gloo/high_frequency.py',
         'examples/basics/scene/shared_context.py',
     ]
-elif 'true' in (os.getenv('TRAVIS', ''),
-                os.getenv('GITHUB_ACTIONS', '')) and 'linux' in sys.platform:
+elif IS_CI and 'linux' in sys.platform:
     # example scripts that contain non-ascii text
     # seem to fail on Travis OSX
     bad_examples = [
         'examples/basics/scene/shared_context.py',
     ]
-if 'true' in (os.getenv('TRAVIS', ''), os.getenv('GITHUB_ACTIONS', '')):
+if IS_CI:
     # OpenGL >2.0 that fail on Travis
     bad_examples += [
         'examples/basics/gloo/geometry_shader.py'

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -20,6 +20,10 @@ from ..util.check_environment import has_backend
 
 skipif = pytest.mark.skipif
 
+IS_TRAVIS_CI = "true" in os.getenv("TRAVIS", "")
+IS_GITHUB_ACTIONS = "true" in os.getenv("GITHUB_ACTIONS", "")
+IS_CI = IS_TRAVIS_CI or IS_GITHUB_ACTIONS
+
 
 def SkipTest(*args, **kwargs):
     """Backport for raising SkipTest that gives a better traceback."""

--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -60,6 +60,7 @@ from .. import scene, config
 from ..io import read_png, write_png
 from ..gloo.util import _screenshot
 from ..util import run_subprocess
+from . import IS_CI
 
 
 tester = None
@@ -152,8 +153,7 @@ def assert_image_approved(image, standard_file, message=None, **kwargs):
             if std_image is None:
                 raise Exception("Test standard %s does not exist." % std_file)
             else:
-                if os.getenv('TRAVIS') is not None or \
-                        os.getenv('APPVEYOR') is not None:
+                if IS_CI:
                     _save_failed_test(image, std_image, standard_file)
                 raise
 
@@ -420,7 +420,7 @@ def get_test_data_repo():
         if not os.path.isdir(parent_path):
             os.makedirs(parent_path)
 
-        if os.getenv('TRAVIS') is not None:
+        if IS_CI:
             # Create a shallow clone of the test-data repository (to avoid
             # downloading more data than is necessary)
             os.makedirs(data_path)

--- a/vispy/visuals/tests/test_arrows.py
+++ b/vispy/visuals/tests/test_arrows.py
@@ -9,7 +9,7 @@ import numpy as np
 from vispy.visuals.line.arrow import ARROW_TYPES
 from vispy.scene import visuals, transforms
 from vispy.testing import (requires_application, TestingCanvas,
-                           run_tests_if_main, assert_raises, SkipTest)
+                           run_tests_if_main, assert_raises, SkipTest, IS_TRAVIS_CI)
 from vispy.testing.image_tester import assert_image_approved
 
 
@@ -36,8 +36,7 @@ arrows = np.array([
 def test_arrow_draw():
     """Test drawing arrows without transforms"""
     with TestingCanvas() as c:
-        if os.getenv('TRAVIS', 'false') == 'true' and \
-                c.app.backend_name.lower() == 'pyqt4':
+        if IS_TRAVIS_CI and c.app.backend_name.lower() == 'pyqt4':
             # TODO: Fix this (issue #1042
             raise SkipTest('Travis fails due to FB stack problem')
         for arrow_type in ARROW_TYPES:
@@ -55,8 +54,7 @@ def test_arrow_draw():
 def test_arrow_transform_draw():
     """Tests the ArrowVisual when a transform is applied"""
     with TestingCanvas() as c:
-        if os.getenv('TRAVIS', 'false') == 'true' and \
-                c.app.backend_name.lower() == 'pyqt4':
+        if IS_TRAVIS_CI and c.app.backend_name.lower() == 'pyqt4':
             # TODO: Fix this (issue #1042
             raise SkipTest('Travis fails due to FB stack problem')
         for arrow_type in ARROW_TYPES:

--- a/vispy/visuals/tests/test_arrows.py
+++ b/vispy/visuals/tests/test_arrows.py
@@ -2,8 +2,6 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-import os
-
 import numpy as np
 
 from vispy.visuals.line.arrow import ARROW_TYPES


### PR DESCRIPTION
I wanted to do an xfail in #2106 and realized that we have `os.getenv` all over the tests. I felt replacing these with constants in the testing utilities would make this simpler and cleaner in the long run.