### PR TITLE
Set stacklevel for colormap deprecation.

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1132,9 +1132,13 @@ def get_colormap(name, *args, **kwargs):
     if name in _colormaps:  # vispy cmap
         cmap = _colormaps[name]
         if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
-            warnings.warn(f"Colormap '{name}' has been deprecated. "
-                          f"Please import and create 'vispy.color.colormap.{cmap.__class__.__name__}' "
-                          "directly instead.", DeprecationWarning)
+            warnings.warn(
+                f"Colormap '{name}' has been deprecated since vispy 0.7 . "
+                f"Please import and create 'vispy.color.colormap.{cmap.__class__.__name__}' "
+                "directly instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     elif has_matplotlib():  # matplotlib cmap
         try:

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1133,7 +1133,7 @@ def get_colormap(name, *args, **kwargs):
         cmap = _colormaps[name]
         if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
             warnings.warn(
-                f"Colormap '{name}' has been deprecated since vispy 0.7 . "
+                f"Colormap '{name}' has been deprecated since vispy 0.7. "
                 f"Please import and create 'vispy.color.colormap.{cmap.__class__.__name__}' "
                 "directly instead.",
                 DeprecationWarning,

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -15,6 +15,7 @@ from .shaders import Function, FunctionChain
 from ..gloo import VertexBuffer
 from ..geometry import MeshData
 from ..color import Color, get_colormap
+from ..color.colormap import CubeHelixColormap
 from ..util.event import Event
 
 
@@ -135,7 +136,7 @@ class MeshVisual(Visual):
 
         # Define buffers
         self._vertices = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
-        self._cmap = get_colormap('cubehelix')
+        self._cmap = CubeHelixColormap()
         self._clim = 'auto'
 
         # Uniform color


### PR DESCRIPTION
This allows to get proper file/line for deprecation in test suite, which
make it a bit easier to track where the errors come from.

Also update a literal usage of get_colormap('cubehelix') with the
corresponding new import.