### PR TITLE
Fix for Apple Silicon M1 (arm64)

### DIFF
--- a/vispy/ext/cocoapy.py
+++ b/vispy/ext/cocoapy.py
@@ -176,8 +176,9 @@ objc.class_getIvarLayout.argtypes = [c_void_p]
 objc.class_getMethodImplementation.restype = c_void_p
 objc.class_getMethodImplementation.argtypes = [c_void_p, c_void_p]
 
-objc.class_getMethodImplementation_stret.restype = c_void_p
-objc.class_getMethodImplementation_stret.argtypes = [c_void_p, c_void_p]
+if platform.machine() != "arm64":
+    objc.class_getMethodImplementation_stret.restype = c_void_p
+    objc.class_getMethodImplementation_stret.argtypes = [c_void_p, c_void_p]
 
 objc.class_getName.restype = c_char_p
 objc.class_getName.argtypes = [c_void_p]
@@ -275,9 +276,9 @@ objc.objc_getMetaClass.argtypes = [c_char_p]
 objc.objc_getProtocol.restype = c_void_p
 objc.objc_getProtocol.argtypes = [c_char_p]
 
-objc.objc_msgSendSuper_stret.restype = None
-
-objc.objc_msgSend_stret.restype = None
+if platform.machine() != "arm64":
+    objc.objc_msgSendSuper_stret.restype = None
+    objc.objc_msgSend_stret.restype = None
 
 objc.objc_registerClassPair.restype = None
 objc.objc_registerClassPair.argtypes = [c_void_p]


### PR DESCRIPTION
As requested by @djhoese here:
https://github.com/vispy/vispy/pull/1975#issuecomment-873084868

In order to have vispy run on Apple Silicon M1 (arm64) some functions marked as OBJC_ARM64_UNAVAILABLE need to be screen via arch
See also: 
https://github.com/pyglet/pyglet/pull/335/commits/5aa1870188b9675cdee090bbecb342661ccc06a6
This fix was originally proposed by @isuruf here:
https://github.com/vispy/vispy/issues/2013#issuecomment-819690863
And then expanded by @watjurk here:
https://github.com/vispy/vispy/issues/2013#issuecomment-819724112
However, the first two lines they also modified:
```
objc.class_getClassMethod.restype = c_void_p 
 objc.class_getClassMethod.argtypes = [c_void_p, c_void_p] 
```
seem to not need skipping on M1.

Using this fix, napari (python image viewer, etc.) runs just fine. 
Without, each of those functions results in "symbol not found" errors.

Disclaimer: I don't really understand this fully, but I've been using this fix for a week and everything seems fine in napari—I have no other vispy using software/code.