### PR TITLE
Jupyter widget based on jupyter_rfb

### DIFF
--- a/ci/requirements/linux_full_deps_pip.txt
+++ b/ci/requirements/linux_full_deps_pip.txt
@@ -2,3 +2,4 @@ husl
 pypng
 cassowary
 pyopengltk
+jupyter_rfb

--- a/examples/ipynb/Rotating Cube.ipynb
+++ b/examples/ipynb/Rotating Cube.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import vispy\n",
-    "vispy.use(\"ipynb_rfb\")"
+    "vispy.use(\"jupyter_rfb\")"
    ]
   },
   {

--- a/examples/ipynb/Rotating Cube.ipynb
+++ b/examples/ipynb/Rotating Cube.ipynb
@@ -11,41 +11,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/davidh/anaconda/envs/vispy_py37_pyqt5/lib/python3.7/site-packages/dask/config.py:168: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
-      "  data = yaml.load(f.read()) or {}\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7e8f7947b9b343a6a17acc9119696903",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VispyWidget(height=400, width=400)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
-    "# Copyright (c) Vispy Development Team. All Rights Reserved.\n",
-    "# Distributed under the (new) BSD License. See LICENSE.txt for more info.\n",
-    "\n",
-    "\"\"\"\n",
-    "Demonstration of Cube\n",
-    "\"\"\"\n",
-    "\n",
+    "import vispy\n",
+    "vispy.use(\"ipynb_rfb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import sys\n",
     "\n",
     "from vispy import app, gloo\n",
@@ -66,8 +45,6 @@
     "        self.cube.transform = self.cube_transform\n",
     "\n",
     "        self._timer = app.Timer('auto', connect=self.on_timer, start=True)\n",
-    "\n",
-    "#         self.show()\n",
     "\n",
     "    def on_resize(self, event):\n",
     "        # Set canvas viewport and reconfigure visual transforms to match.\n",
@@ -91,50 +68,11 @@
     "        self.cube_transform.translate((200, 200))\n",
     "        self.update()\n",
     "\n",
+    "\n",
     "win = Canvas()\n",
-    "win.show()"
+    "win.show()\n",
+    "win"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_send:  {'method': 'custom', 'content': {'msg_type': 'glir_commands', 'commands': [['CURRENT', 0, 0]], 'array_serialization': 'binary'}}\n",
-      "_send:  {'method': 'custom', 'content': {'msg_type': 'glir_commands', 'commands': [['FUNC', 'viewport', 0, 0, 400, 400], ['FUNC', 'clearColor', 1.0, 1.0, 1.0, 1.0], ['FUNC', 'clear', 17664], ['FUNC', 'enable', 'polygon_offset_fill'], ['FUNC', 'polygonOffset', 1.0, 1.0], ['FUNC', 'enable', 'depth_test'], ['UNIFORM', 1, 'u_matrix', 'mat4', [99.08135986328125, 9.584575653076172, -9.540449536871165e-05, 0.0, -9.540450096130371, 99.53961944580078, 9.186408533423673e-06, 0.0, 9.584575653076172, 0.0, 0.0009953961707651615, 0.0, 200.0, 200.0, 0.0, 1.0]], ['DRAW', 1, 'triangles', [0, 36]]], 'array_serialization': 'binary'}}\n",
-      "_send:  {'method': 'custom', 'content': {'msg_type': 'glir_commands', 'commands': [['FUNC', 'disable', 'cull_face'], ['FUNC', 'enable', 'depth_test'], ['FUNC', 'enable', 'blend'], ['FUNC', 'blendFuncSeparate', 'src_alpha', 'one_minus_src_alpha', 'src_alpha', 'one_minus_src_alpha'], ['UNIFORM', 5, 'u_matrix', 'mat4', [99.08135986328125, 9.584575653076172, -9.540449536871165e-05, 0.0, -9.540450096130371, 99.53961944580078, 9.186408533423673e-06, 0.0, 9.584575653076172, 0.0, 0.0009953961707651615, 0.0, 200.0, 200.0, 0.0, 1.0]], ['DRAW', 5, 'lines', [0, 48]]], 'array_serialization': 'binary'}}\n",
-      "_send:  {'method': 'custom', 'content': {'msg_type': 'glir_commands', 'commands': [['SWAP']], 'array_serialization': 'binary'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "win.on_timer(None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -153,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/vispy/app/application.py
+++ b/vispy/app/application.py
@@ -190,7 +190,7 @@ class Application(object):
             backend_name = test_name.lower()
             assert backend_name in BACKENDMAP
         elif self.is_notebook():
-            backend_name = 'ipynb_webgl'
+            backend_name = 'jupyter_rfb'
 
         # Should we try and load any backend, or just this specific one?
         try_others = backend_name is None

--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -31,7 +31,8 @@ CORE_BACKENDS = [
 # canvas, the pseudo backends act more like a proxy.
 PSEUDO_BACKENDS = [
     # ('ipynb_vnc', '_ipynb_vnc', None),
-    # ('ipynb_static', '_ipynb_static', None),
+    ('ipynb_static', '_ipynb_static', None),
+    ('ipynb_rfb', '_ipynb_rfb', None),
     ('ipynb_webgl', '_ipynb_webgl', None),
     ('_test', '_test', 'vispy.app.backends._test'),  # add one that will fail
 ]

--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -31,7 +31,7 @@ CORE_BACKENDS = [
 # canvas, the pseudo backends act more like a proxy.
 PSEUDO_BACKENDS = [
     # ('ipynb_vnc', '_ipynb_vnc', None),
-    ('ipynb_static', '_ipynb_static', None),
+    # ('ipynb_static', '_ipynb_static', None),
     ('ipynb_rfb', '_ipynb_rfb', None),
     ('ipynb_webgl', '_ipynb_webgl', None),
     ('_test', '_test', 'vispy.app.backends._test'),  # add one that will fail

--- a/vispy/app/backends/__init__.py
+++ b/vispy/app/backends/__init__.py
@@ -32,7 +32,7 @@ CORE_BACKENDS = [
 PSEUDO_BACKENDS = [
     # ('ipynb_vnc', '_ipynb_vnc', None),
     # ('ipynb_static', '_ipynb_static', None),
-    ('ipynb_rfb', '_ipynb_rfb', None),
+    ('jupyter_rfb', '_jupyter_rfb', None),
     ('ipynb_webgl', '_ipynb_webgl', None),
     ('_test', '_test', 'vispy.app.backends._test'),  # add one that will fail
 ]

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from ..base import BaseApplicationBackend, BaseCanvasBackend, BaseTimerBackend
-# from ...gloo.context import set_current_canvas
 from ...app import Timer
 from ...util import keys
 from ._offscreen_util import OffscreenContext, FrameBufferHelper

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -18,24 +18,6 @@ else:
     which = "jupyter_rfb"
 
 
-# try:
-#     # Explicitly use default (avoid using test-app)
-#     _app = Application('default')
-# except Exception:
-#     _msg = 'ipynb_rf backend relies on a proxy backend'
-#     available, testable, why_not, which = False, False, _msg, None
-# else:
-#     # Try importing jupyter_rfb
-#     # todo: give good error message if jupyter_rfb is not available
-#     try:
-#         from jupyter_rfb import RemoteFrameBuffer
-#     except Exception as exp:
-#         available, testable, why_not, which = False, False, str(exp), None
-#     else:
-#         available, testable, why_not = True, False, None
-#         which = _app.backend_module.which
-
-
 # -------------------------------------------------------------- capability ---
 
 capability = dict(

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -1,0 +1,226 @@
+import asyncio
+
+from ..base import (BaseApplicationBackend, BaseCanvasBackend,
+                    BaseTimerBackend)
+from ...app import Timer
+from ._offscreen_util import OffscreenCanvasHelper
+
+
+# todo: can create a global GL context helper here too
+
+try:
+    from jupyter_rfb import RemoteFrameBuffer
+except Exception:
+    RemoteFrameBuffer = object
+    _msg = 'ipynb_rfb backend relies on a the jupyter_rfb library: ``pip install jupyter_rfb``'
+    available, testable, why_not, which = False, False, _msg, None
+else:
+    available, testable, why_not = True, False, None
+    which = "jupyter_rfb"
+
+
+# try:
+#     # Explicitly use default (avoid using test-app)
+#     _app = Application('default')
+# except Exception:
+#     _msg = 'ipynb_rf backend relies on a proxy backend'
+#     available, testable, why_not, which = False, False, _msg, None
+# else:
+#     # Try importing jupyter_rfb
+#     # todo: give good error message if jupyter_rfb is not available
+#     try:
+#         from jupyter_rfb import RemoteFrameBuffer
+#     except Exception as exp:
+#         available, testable, why_not, which = False, False, str(exp), None
+#     else:
+#         available, testable, why_not = True, False, None
+#         which = _app.backend_module.which
+
+
+# -------------------------------------------------------------- capability ---
+
+capability = dict(
+    title=True,  # But it only applies to the dummy window :P
+    size=True,
+    position=False,
+    show=True, # todo: can show/hide window?? -> should probably be false
+    vsync=False,
+    resizable=True,
+    decorate=False,
+    fullscreen=False,
+    context=True,  # via the proxy backend
+    multi_window=True,  # todo: right?
+    scroll=True,
+    parent=False,
+    always_on_top=False,
+)
+
+
+# ------------------------------------------------------- set_configuration ---
+
+# todo: call this?
+def _set_config(c):
+    _app.backend_module._set_config(c)
+
+
+# ------------------------------------------------------------- application ---
+
+
+class ApplicationBackend(BaseApplicationBackend):
+
+    def __init__(self):
+        super().__init__()
+        # self._proxy_app_backend = _app._backend
+
+    def _vispy_get_backend_name(self):
+        # proxyname = self._proxy_app_backend._vispy_get_backend_name()
+        # return f'ipynb_rfb (via {proxyname})'
+        return f'ipynb_rfb'
+
+    def _vispy_process_events(self):
+        # return self._proxy_app_backend._vispy_process_events()
+        raise RuntimeError("Cannot process events while asyncio event-loop is running.")
+
+    def _vispy_run(self):
+        pass  # We're in IPython; don't enter a mainloop or we'll block!
+
+    def _vispy_quit(self):
+        # return self._proxy_app_backend._vispy_quit()
+        pass
+
+    def _vispy_get_native_app(self):
+        # return self._proxy_app_backend._vispy_get_native_app()
+        return asyncio
+
+
+# ------------------------------------------------------------------ canvas ---
+
+class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        # todo: take stuff from kwargs, such as size
+        # Get helper object to get a GL context and a FBO to render to
+        self._helper = OffscreenCanvasHelper()
+        self._helper.set_physical_size(640, 480)
+
+        self._loop = asyncio.get_event_loop()
+        self._draw_pending = False
+        self._logical_size = 640, 480
+        self._vispy_set_size(640, 480)
+        self._initialized = False
+        self._vispy_update()
+
+    def receive_events(self, widget, content, buffers):
+        return
+
+        if content['msg_type'] == 'init':
+            self.canvas_backend._reinit_widget()
+        elif content['msg_type'] == 'events':
+            events = content['contents']
+            for ev in events:
+                self.gen_event(ev)
+        elif content['msg_type'] == 'status':
+            if content['contents'] == 'removed':
+                # Stop all timers associated to the widget.
+                _stop_timers(self.canvas_backend._vispy_canvas)
+
+    def on_draw(self):
+        self._draw_pending = False
+        # Handle initialization
+        if not self._initialized:
+            self._initialized = True
+            self._vispy_canvas.events.initialize()
+            physical_size = self._logical_size  # todo: physical != logical
+            self._vispy_canvas.events.resize(
+                size=self._logical_size,
+                physical_size=physical_size,
+             )
+
+        # Normal behavior
+        self._vispy_canvas.set_current()
+        with self._helper:
+            self._vispy_canvas.events.draw(region=None)
+
+        # Present
+        array = self._helper.get_frame()
+        self._ndraws = getattr(self, "_ndraws", 0) + 1
+        self.send_frame(array)
+
+    def _vispy_warmup(self):
+        self._vispy_canvas.set_current()
+
+    def _vispy_set_current(self):
+        self._helper.set_current()
+
+    def _vispy_swap_buffers(self):
+        pass
+
+    def _vispy_set_title(self, title):
+        pass
+
+    def _vispy_set_size(self, w, h):
+        self.css_width = f"{w}px"
+        self.css_width = f"{h}px"
+
+    def _vispy_set_position(self, x, y):
+        pass
+
+    def _vispy_set_visible(self, visible):
+        pass  # todo: could implement this by minimizing it, I guess?
+        raise NotImplementedError()
+
+    def _vispy_set_fullscreen(self, fullscreen):
+        raise NotImplementedError()
+
+    def _vispy_update(self):
+        if not self._draw_pending:
+            self._draw_pending = True
+            self._loop.call_later(0.01, self.on_draw)
+
+    def _vispy_close(self):
+        raise NotImplementedError()
+
+    def _vispy_get_size(self):
+        return self._logical_size
+
+    def _vispy_get_position(self):
+        return 0, 0
+
+    def _vispy_get_fullscreen(self):
+        return False
+
+
+# ------------------------------------------------------------------- timer ---
+
+# todo: test this
+class TimerBackend(BaseTimerBackend):
+
+    def __init__(self, vispy_timer):
+        super().__init__(vispy_timer)
+        self._proxy_timer_backend = _app.backend_module.TimerBackend(vispy_timer)
+
+    def _vispy_start(self, interval):
+        return self._proxy_timer_backend._vispy_start(interval)
+
+    def _vispy_stop(self):
+        return self._proxy_timer_backend._vispy_stop()
+
+    def _vispy_timeout(self):
+        return self._proxy_timer_backend._vispy_timeout()
+
+    def _vispy_get_native_timer(self):
+        return self._proxy_timer_backend._vispy_get_native_timer()
+
+
+# todo: Taken from ipython/_widget.py, but it seems a bit weird to me
+def _stop_timers(canvas):
+    """Stop all timers in a canvas."""
+    for attr in dir(canvas):
+        try:
+            attr_obj = getattr(canvas, attr)
+        except NotImplementedError:
+            continue  # not everything is implemented in this backend
+        if isinstance(attr_obj, Timer):
+            attr_obj.stop()
+

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -81,8 +81,8 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         self._helper = FrameBufferHelper()
         self._loop = asyncio.get_event_loop()
         self._draw_pending = False
-        self._logical_size = 1, 1
-        self._physical_size = 1, 1
+        self._logical_size = 0, 0
+        self._physical_size = 0, 0
         self._lifecycle = 0  # 0: not initialized, 1: initialized, 2: closed
         # Init more based on kwargs (could maybe handle, title, show, context)
         self._vispy_set_size(*kwargs["size"])
@@ -169,6 +169,10 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
     def on_draw(self):
         self._draw_pending = False
 
+        # Only draw if the draw region is not null
+        if 0 in self._physical_size:
+            return
+
         # Handle initialization
         if not self._lifecycle:
             self._lifecycle = 1
@@ -213,7 +217,8 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         pass
 
     def _vispy_set_visible(self, visible):
-        raise NotImplementedError()
+        if not visible:
+            raise NotImplementedError("Cannot hide the RFB widget")
 
     def _vispy_set_fullscreen(self, fullscreen):
         raise NotImplementedError()

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -81,8 +81,8 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         self._helper = FrameBufferHelper()
         self._loop = asyncio.get_event_loop()
         self._draw_pending = False
-        self._logical_size = 0, 0
-        self._physical_size = 0, 0
+        self._logical_size = 1, 1
+        self._physical_size = 1, 1
         self._lifecycle = 0  # 0: not initialized, 1: initialized, 2: closed
         # Init more based on kwargs (could maybe handle, title, show, context)
         self._vispy_set_size(*kwargs["size"])
@@ -98,6 +98,7 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
             self._logical_size = w, h
             self._physical_size = int(w * r), int(h * r)
             self._loop.call_soon(self._emit_resize_event)
+            self._vispy_update()  # make sure to schedule a new draw
         elif type == "pointer_down":
             self._vispy_mouse_press(
                 native=ev,
@@ -170,7 +171,7 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         self._draw_pending = False
 
         # Only draw if the draw region is not null
-        if 0 in self._physical_size:
+        if self._physical_size[0] <= 1 or self._physical_size[1] <= 1:
             return
 
         # Handle initialization

--- a/vispy/app/backends/_ipynb_rfb.py
+++ b/vispy/app/backends/_ipynb_rfb.py
@@ -73,7 +73,8 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
     _double_click_supported = True
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args)
+        RemoteFrameBuffer.__init__(self)
+        BaseCanvasBackend.__init__(self, *args)
         # Init
         # Use a context per canvas, because we seem to make assumptions
         # about OpenGL state being local to the canvas.

--- a/vispy/app/backends/_jupyter_rfb.py
+++ b/vispy/app/backends/_jupyter_rfb.py
@@ -10,7 +10,7 @@ try:
     from jupyter_rfb import RemoteFrameBuffer
 except Exception:
     RemoteFrameBuffer = object
-    _msg = 'ipynb_rfb backend relies on a the jupyter_rfb library: ``pip install jupyter_rfb``'
+    _msg = 'The jupyter_rfb backend relies on a the jupyter_rfb library: ``pip install jupyter_rfb``'
     available, testable, why_not, which = False, False, _msg, None
 else:
     available, testable, why_not = True, False, None
@@ -51,7 +51,7 @@ class ApplicationBackend(BaseApplicationBackend):
         super().__init__()
 
     def _vispy_get_backend_name(self):
-        return 'ipynb_rfb'
+        return 'jupyter_rfb'
 
     def _vispy_process_events(self):
         raise RuntimeError("Cannot process events while asyncio event-loop is running.")

--- a/vispy/app/backends/_jupyter_rfb.py
+++ b/vispy/app/backends/_jupyter_rfb.py
@@ -97,6 +97,7 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
             w, h, r = ev["width"], ev["height"], ev["pixel_ratio"]
             self._logical_size = w, h
             self._physical_size = int(w * r), int(h * r)
+            self._helper.set_physical_size(*self._physical_size)
             self._loop.call_soon(self._emit_resize_event)
             self._vispy_update()  # make sure to schedule a new draw
         elif type == "pointer_down":
@@ -161,7 +162,6 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         return tuple(getattr(keys, m.upper()) for m in ev["modifiers"])
 
     def _emit_resize_event(self):
-        self._helper.set_physical_size(*self._physical_size)
         self._vispy_canvas.events.resize(
             size=self._logical_size,
             physical_size=self._physical_size,

--- a/vispy/app/backends/_offscreen_util.py
+++ b/vispy/app/backends/_offscreen_util.py
@@ -1,0 +1,69 @@
+"""
+Utils for offscreen rendering.
+"""
+
+from .. import Application, Canvas
+from ... import gloo
+
+
+# todo: we can share the context accross multiple canvases / fbo's
+# todo: how well does resizing an FBO work ... can we use just an fbo (no heper wrapper)
+
+
+class OffscreenCanvasHelper:
+    """ Provides a canvas to render to, using an FBO.
+    """
+
+    def __init__(self):
+        self._fbo = None
+        self._size = 1, 1
+        self._get_context()
+
+    def _get_context(self):
+
+        try:
+            import glfw
+        except ImportError:
+            self.glfw = None
+        else:
+            self.glfw = glfw
+
+        if self.glfw:
+            self.glfw.init()
+            self.glfw.window_hint(self.glfw.VISIBLE, 0)
+            self._canvas = self.glfw.create_window(1, 1, "dummy window", None, None)
+        else:
+            _app = Application('default')
+            self._canvas = Canvas(app=_app)
+            self._canvas.show(False)
+
+    def set_current(self):
+        if self.glfw:
+            self.glfw.make_context_current(self._canvas)
+        else:
+            self._canvas._vispy_set_current()
+
+        if self._fbo is None:
+            self._create_fbo()
+
+    def _create_fbo(self):
+        w, h = self._size
+        color_buffer = gloo.Texture2D((w, h, 4))
+        depth_buffer = gloo.RenderBuffer((w, h))
+        self._fbo = gloo.FrameBuffer(color_buffer, depth_buffer)
+
+    def set_physical_size(self, w, h):
+        new_size = w, h
+        if new_size != self._size:
+            self._size = new_size
+            self._create_fbo()
+
+    def __enter__(self):
+        return self._fbo.__enter__()
+
+    def __exit__(self, *args):
+        return self._fbo.__exit__(*args)
+
+    def get_frame(self):
+        with self._fbo:
+            return self._fbo.read()

--- a/vispy/app/backends/_offscreen_util.py
+++ b/vispy/app/backends/_offscreen_util.py
@@ -6,27 +6,35 @@ from .. import Application, Canvas
 from ... import gloo
 
 
-# todo: we can share the context accross multiple canvases / fbo's
-# todo: how well does resizing an FBO work ... can we use just an fbo (no heper wrapper)
-
-
-class OffscreenCanvasHelper:
-    """ Provides a canvas to render to, using an FBO.
+class GlobalOffscreenContext:
+    """ A helper class to provide an OpenGL context. This context is global
+    to the application.
     """
 
+    _instance = None
+    _canvas = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+            print("new!")
+        return cls._instance
+
     def __init__(self):
-        self._fbo = None
-        self._size = 1, 1
-        self._get_context()
+        if self._canvas is not None:
+            return  # already initialized
 
-    def _get_context(self):
-
+        # Glfw is probably the most lightweight approach, so let's try that.
+        # But there are two incompatible packages providing glfw :/
+        self.glfw = None
         try:
             import glfw
         except ImportError:
-            self.glfw = None
+            pass
         else:
-            self.glfw = glfw
+            need_from_glfw = ["create_window", "make_context_current"]
+            if all(hasattr(glfw, attr) for attr in need_from_glfw):
+                self.glfw = glfw
 
         if self.glfw:
             self.glfw.init()
@@ -37,33 +45,51 @@ class OffscreenCanvasHelper:
             self._canvas = Canvas(app=_app)
             self._canvas.show(False)
 
-    def set_current(self):
+    def make_current(self):
+        """ Make this the currently active context.
+        """
+        # If an application only used off-screen canvases this would technically
+        # have to be called just once. But note that an application/session
+        # could run both real canvases and off-screen ones.
         if self.glfw:
             self.glfw.make_context_current(self._canvas)
         else:
             self._canvas._vispy_set_current()
 
-        if self._fbo is None:
-            self._create_fbo()
 
-    def _create_fbo(self):
-        w, h = self._size
-        color_buffer = gloo.Texture2D((h, w, 4))
-        depth_buffer = gloo.RenderBuffer((h, w))
-        self._fbo = gloo.FrameBuffer(color_buffer, depth_buffer)
+class FrameBufferHelper:
+    """ Provides a canvas to render to, using an FBO.
+    """
+
+    def __init__(self):
+        self._fbo = None
+        self._physical_size = 1, 1
+        self._fbo_size = -1, -1
+
+    def _ensure_fbo(self):
+        if self._fbo_size != self._physical_size:
+            self._fbo_size = self._physical_size
+            w, h = self._fbo_size
+            if self._fbo is None:
+                color_buffer = gloo.Texture2D((h, w, 4))
+                depth_buffer = gloo.RenderBuffer((h, w))
+                self._fbo = gloo.FrameBuffer(color_buffer, depth_buffer)
+            else:
+                self._fbo.resize((h, w))
 
     def set_physical_size(self, w, h):
-        new_size = w, h
-        if new_size != self._size:
-            self._size = new_size
-            self._create_fbo()
+        """ Set the physical size of the canvas.
+        """
+        self._physical_size = w, h
+
+    def get_frame(self):
+        """ Call this within the with-context to obtain the frame buffer contents.
+        """
+        return self._fbo.read()
 
     def __enter__(self):
+        self._ensure_fbo()
         return self._fbo.__enter__()
 
     def __exit__(self, *args):
         return self._fbo.__exit__(*args)
-
-    def get_frame(self):
-        with self._fbo:
-            return self._fbo.read()

--- a/vispy/app/backends/_offscreen_util.py
+++ b/vispy/app/backends/_offscreen_util.py
@@ -14,7 +14,11 @@ class OffscreenContext:
     _global_instance = None
     _canvas = None
 
+    @classmethod
     def get_global_instance(cls):
+        """ Get a global context. Note that any assumptions about OpenGL state
+        being local will not hold.
+        """
         if cls._global_instance is None:
             cls._global_instance = cls()
         return cls._global_instance
@@ -72,9 +76,7 @@ class OffscreenContext:
             self._is_closed = True
             if self.glfw:
                 self.glfw.destroy_window(self._canvas)
-                print("glfw destroy!")
             else:
-                print("native destroy!")
                 self._canvas.close()
 
     def __del__(self):

--- a/vispy/app/backends/_offscreen_util.py
+++ b/vispy/app/backends/_offscreen_util.py
@@ -48,8 +48,8 @@ class OffscreenCanvasHelper:
 
     def _create_fbo(self):
         w, h = self._size
-        color_buffer = gloo.Texture2D((w, h, 4))
-        depth_buffer = gloo.RenderBuffer((w, h))
+        color_buffer = gloo.Texture2D((h, w, 4))
+        depth_buffer = gloo.RenderBuffer((h, w))
         self._fbo = gloo.FrameBuffer(color_buffer, depth_buffer)
 
     def set_physical_size(self, w, h):

--- a/vispy/app/backends/_offscreen_util.py
+++ b/vispy/app/backends/_offscreen_util.py
@@ -41,7 +41,13 @@ class GlobalOffscreenContext:
             self.glfw.window_hint(self.glfw.VISIBLE, 0)
             self._canvas = self.glfw.create_window(1, 1, "dummy window", None, None)
         else:
-            _app = Application('default')
+            try:
+                _app = Application('default')
+            except Exception:
+                raise RuntimeError(
+                    "Cannot find a backend to create an OpenGL context. "
+                    "Install e.g. PyQt5, PySide2, or `pip install glfw`."
+                )
             self._canvas = Canvas(app=_app)
             self._canvas.show(False)
 

--- a/vispy/app/backends/tests/test_offscreen_util.py
+++ b/vispy/app/backends/tests/test_offscreen_util.py
@@ -1,8 +1,10 @@
 from vispy.app.backends._offscreen_util import OffscreenContext, FrameBufferHelper
+from vispy.testing import requires_application
 from vispy import gloo
 import numpy as np
 
 
+@requires_application()
 def test_offscreen_context():
     c1 = OffscreenContext()
     c2 = OffscreenContext.get_global_instance()
@@ -27,6 +29,7 @@ class FakeCanvas(object):
         self.context.flush_commands()
 
 
+@requires_application()
 def test_frame_buffer_helper():
     canvas = FakeCanvas()
     gl_context = OffscreenContext()

--- a/vispy/app/backends/tests/test_offscreen_util.py
+++ b/vispy/app/backends/tests/test_offscreen_util.py
@@ -1,0 +1,51 @@
+from vispy.app.backends._offscreen_util import OffscreenContext, FrameBufferHelper
+from vispy import gloo
+import numpy as np
+
+
+def test_offscreen_context():
+    c1 = OffscreenContext()
+    c2 = OffscreenContext.get_global_instance()
+    c3 = OffscreenContext.get_global_instance()
+    c4 = OffscreenContext()
+
+    assert c1 is not c2
+    assert c1 is not c4
+    assert c2 is c3
+
+    c1.make_current()
+    c1.close()
+
+
+class FakeCanvas(object):
+
+    def __init__(self):
+        self.context = gloo.GLContext()
+        gloo.context.set_current_canvas(self)
+
+    def flush(self):
+        self.context.flush_commands()
+
+
+def test_frame_buffer_helper():
+    canvas = FakeCanvas()
+    gl_context = OffscreenContext()
+    fbh = FrameBufferHelper()
+
+    gl_context.make_current()
+    fbh.set_physical_size(43, 67)
+    with fbh:
+        gloo.set_clear_color((0, 0.5, 1))
+        gloo.clear()
+        canvas.flush()
+        array = fbh.get_frame()
+
+    assert array.shape == (67, 43, 4)
+    assert np.all(array[:, :, 0] == 0)
+    assert np.all(array[:, :, 1] == 128)
+    assert np.all(array[:, :, 2] == 255)
+
+
+if __name__ == "__main__":
+    test_offscreen_context()
+    test_frame_buffer_helper()

--- a/vispy/app/backends/tests/test_offscreen_util.py
+++ b/vispy/app/backends/tests/test_offscreen_util.py
@@ -1,5 +1,5 @@
 from vispy.app.backends._offscreen_util import OffscreenContext, FrameBufferHelper
-from vispy.testing import requires_application
+from vispy.testing import run_tests_if_main, requires_application
 from vispy import gloo
 import numpy as np
 
@@ -49,6 +49,4 @@ def test_frame_buffer_helper():
     assert np.all(array[:, :, 2] == 255)
 
 
-if __name__ == "__main__":
-    test_offscreen_context()
-    test_frame_buffer_helper()
+run_tests_if_main()

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -4,7 +4,13 @@ import numpy as np
 from vispy import gloo
 from vispy.app import Application, Canvas
 from vispy.app.backends import _jupyter_rfb
-from vispy.testing import requires_application
+from vispy.testing import run_tests_if_main, requires_application
+import pytest
+
+try:
+    import jupyter_rfb
+except ImportError:
+    jupyter_rfb = None
 
 
 def test_rfb_app():
@@ -24,13 +30,9 @@ class MyCanvas(Canvas):
         gloo.clear()
 
 
+@pytest.mark.skipif(jupyter_rfb is None, reason='jupyter_rfb is not installed')
 @requires_application()
 def test_rfb_canvas():
-
-    try:
-        import jupyter_rfb
-    except ImportError:
-        return  # only the "all deps" build have jupyter_rfb
 
     app = Application("jupyter_rfb")
     canvas = MyCanvas(app=app)
@@ -72,6 +74,4 @@ def test_rfb_canvas():
     assert tuple(events[0].pos) == (11, 12)
 
 
-if __name__ == "__main__":
-    test_rfb_app()
-    test_rfb_canvas()
+run_tests_if_main()

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -45,8 +45,8 @@ def test_rfb_canvas():
     # Mimic a draw
     frame = canvas_backend.get_frame()
     assert frame.shape[:2] == (100, 100)
-    assert np.all(frame[:,:,0] == 0)
-    assert np.all(frame[:,:,1] == 255)
+    assert np.all(frame[:, :, 0] == 0)
+    assert np.all(frame[:, :, 1] == 255)
 
     # Pretend that the user resized in the browser
     canvas_backend.handle_event({"event_type": "resize", "width": 60, "height": 60, "pixel_ratio": 1.0})
@@ -56,8 +56,8 @@ def test_rfb_canvas():
     # Mimic another draw
     frame = canvas_backend.get_frame()
     assert frame.shape[:2] == (60, 60)
-    assert np.all(frame[:,:,0] == 0)
-    assert np.all(frame[:,:,1] == 255)
+    assert np.all(frame[:, :, 0] == 0)
+    assert np.all(frame[:, :, 1] == 255)
 
     # Test mouse event
     events = []

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -1,0 +1,5 @@
+# This currenly only tests that the backend exists and can be imported ...
+
+def test_rfb():
+    from vispy.app.backends import _ipynb_rfb
+    _ipynb_rfb  # flake

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -1,5 +1,72 @@
 # This currenly only tests that the backend exists and can be imported ...
 
-def test_rfb():
-    from vispy.app.backends import _jupyter_rfb
-    _jupyter_rfb  # flake
+import numpy as np
+from vispy import gloo
+from vispy.app import Application, Canvas
+from vispy.app.backends import _jupyter_rfb
+from vispy.testing import requires_application
+
+
+def test_rfb_app():
+
+    # Raw
+    app_backend = _jupyter_rfb.ApplicationBackend()
+
+    # Test that run and quit don't do anything - Jupyter is an interactive session!
+    app_backend._vispy_run()
+    app_backend._vispy_quit()
+
+
+class MyCanvas(Canvas):
+
+    def on_draw(self, event):
+        gloo.set_clear_color((0, 1, 0))
+        gloo.clear()
+
+
+@requires_application()
+def test_rfb_canvas():
+
+    app = Application("jupyter_rfb")
+    canvas = MyCanvas(app=app)
+    canvas_backend = canvas.native
+
+    assert isinstance(canvas_backend, _jupyter_rfb.CanvasBackend)
+
+    # Check that resize works
+    assert "42" not in canvas_backend.css_width
+    canvas.size = 42, 42
+    assert canvas_backend.css_width == "42px"
+    # Manually mimic what a browser would do, but round to 50
+    canvas_backend.handle_event({"event_type": "resize", "width": 50, "height": 50, "pixel_ratio": 2.0})
+    assert canvas.size == (50, 50)
+    assert canvas.physical_size == (100, 100)
+
+    # Mimic a draw
+    frame = canvas_backend.get_frame()
+    assert frame.shape[:2] == (100, 100)
+    assert np.all(frame[:,:,0] == 0)
+    assert np.all(frame[:,:,1] == 255)
+
+    # Pretend that the user resized in the browser
+    canvas_backend.handle_event({"event_type": "resize", "width": 60, "height": 60, "pixel_ratio": 1.0})
+    assert canvas.size == (60, 60)
+    assert canvas.physical_size == (60, 60)
+
+    # Mimic another draw
+    frame = canvas_backend.get_frame()
+    assert frame.shape[:2] == (60, 60)
+    assert np.all(frame[:,:,0] == 0)
+    assert np.all(frame[:,:,1] == 255)
+
+    # Test mouse event
+    events = []
+    canvas.events.mouse_press.connect(lambda e: events.append(e))
+    canvas_backend.handle_event({"event_type": "pointer_down", "x": 11, "y": 12, "button": 1, "modifiers": []})
+    assert len(events) == 1
+    assert tuple(events[0].pos) == (11, 12)
+
+
+if __name__ == "__main__":
+    test_rfb_app()
+    test_rfb_canvas()

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -1,5 +1,5 @@
 # This currenly only tests that the backend exists and can be imported ...
 
 def test_rfb():
-    from vispy.app.backends import _ipynb_rfb
-    _ipynb_rfb  # flake
+    from vispy.app.backends import _jupyter_rfb
+    _jupyter_rfb  # flake

--- a/vispy/app/backends/tests/test_rfb.py
+++ b/vispy/app/backends/tests/test_rfb.py
@@ -27,6 +27,11 @@ class MyCanvas(Canvas):
 @requires_application()
 def test_rfb_canvas():
 
+    try:
+        import jupyter_rfb
+    except ImportError:
+        return  # only the "all deps" build have jupyter_rfb
+
     app = Application("jupyter_rfb")
     canvas = MyCanvas(app=app)
     canvas_backend = canvas.native

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -58,7 +58,9 @@ class BaseCanvasBackend(object):
     """
 
     def __init__(self, vispy_canvas):
-        super().__init__()
+        # Note: it is the responsibility of the subclass to call
+        # the __init__ of the mro - we don't call super().__init__() here.
+
         from .canvas import Canvas  # Avoid circular import
         assert isinstance(vispy_canvas, Canvas)
         self._vispy_canvas = vispy_canvas

--- a/vispy/app/base.py
+++ b/vispy/app/base.py
@@ -48,7 +48,7 @@ class BaseCanvasBackend(object):
 
     Abstract class that provides an interface between backends and Canvas.
     Each backend must implement a subclass of CanvasBackend, and
-    implement all its _vispy_xxx methods. Also, also a backend must
+    implement all its _vispy_xxx methods. Also, a backend must
     make sure to generate the following events: 'initialize', 'resize',
     'draw', 'mouse_press', 'mouse_release', 'mouse_move',
     'mouse_wheel', 'key_press', 'key_release'. When a backend detects
@@ -58,6 +58,7 @@ class BaseCanvasBackend(object):
     """
 
     def __init__(self, vispy_canvas):
+        super().__init__()
         from .canvas import Canvas  # Avoid circular import
         assert isinstance(vispy_canvas, Canvas)
         self._vispy_canvas = vispy_canvas

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -514,9 +514,21 @@ class Canvas(object):
                 % (self.__class__.__name__,
                    self.app.backend_name, hex(id(self))))
 
+    def _repr_mimebundle_(self, *args, **kwargs):
+        """If the backend implements _repr_mimebundle_, we proxy it here.
+        """
+        # See https://ipython.readthedocs.io/en/stable/config/integrating.html
+        f = getattr(self._backend, "_repr_mimebundle_", None)
+        if f is not None:
+            return f(*args, **kwargs)
+        else:
+            # Let Jupyter know this failed - otherwise the standard repr is not shown
+            raise NotImplementedError()
+
     def _ipython_display_(self):
         """If the backend implements _ipython_display_, we proxy it here.
         """
+        # See https://ipython.readthedocs.io/en/stable/config/integrating.html
         f = getattr(self._backend, "_ipython_display_", None)
         if f is not None:
             return f()

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -512,6 +512,16 @@ class Canvas(object):
                 % (self.__class__.__name__,
                    self.app.backend_name, hex(id(self))))
 
+    def _ipython_display_(self):
+        """If the backend implements _ipython_display_, we proxy it here.
+        """
+        f = getattr(self._backend, "_ipython_display_", None)
+        if f is not None:
+            return f()
+        else:
+            # Let Jupyter know this failed - otherwise the standard repr is not shown
+            raise NotImplementedError()
+
     def __enter__(self):
         logger.debug('Context manager enter starting for %s' % (self,))
         self.show()

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -339,6 +339,8 @@ class Canvas(object):
     @property
     def size(self):
         """The size of canvas/window."""
+        # Note that _px_scale is an additional factor applied in addition to
+        # the scale factor imposed by the backend.
         size = self._backend._vispy_get_size()
         return (size[0] // self._px_scale, size[1] // self._px_scale)
 
@@ -364,7 +366,7 @@ class Canvas(object):
         by it). When writing Visuals or SceneGraph visualisations, this value
         is exposed as `TransformSystem.px_scale`.
         """
-        return self.physical_size[0] // self.size[0]
+        return self.physical_size[0] / self.size[0]
 
     @property
     def fullscreen(self):

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -844,7 +844,10 @@ class GlirParser(BaseGlirParser):
             else:
                 this_version = this_version[0]
 
-            if this_version and LooseVersion(this_version) < '2.1':
+            if not this_version:
+                logger.warning("OpenGL version could not be determined, which "
+                               "might be a sign that OpenGL is not loaded correctly.")
+            elif LooseVersion(this_version) < '2.1':
                 if os.getenv('VISPY_IGNORE_OLD_VERSION', '').lower() != 'true':
                     logger.warning('OpenGL version 2.1 or higher recommended, '
                                    'got %s. Some functionality may fail.'

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -844,8 +844,7 @@ class GlirParser(BaseGlirParser):
             else:
                 this_version = this_version[0]
 
-            this_version = LooseVersion(this_version)
-            if this_version < '2.1':
+            if this_version and LooseVersion(this_version) < '2.1':
                 if os.getenv('VISPY_IGNORE_OLD_VERSION', '').lower() != 'true':
                     logger.warning('OpenGL version 2.1 or higher recommended, '
                                    'got %s. Some functionality may fail.'

--- a/vispy/plot/tests/test_plot.py
+++ b/vispy/plot/tests/test_plot.py
@@ -35,7 +35,7 @@ def test_plot_widget_axes():
         # note: fig.show() must be called for this test to work... otherwise
         # Grid._update_child_widget_dim is not triggered and the axes aren't updated
         fig.show(run=False)
-        # currently, the AxisWidget adds a buffer of 5% of the 
+        # currently, the AxisWidget adds a buffer of 5% of the
         # full range to either end of the axis domain
         buffer = (point[1] - point[0]) * 0.05
         expectation = [point[0] - buffer, point[1] + buffer]

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -165,7 +165,7 @@ class SceneCanvas(app.Canvas, Frozen):
     @property
     def central_widget(self):
         """Returns the default widget that occupies the entire area of the
-        canvas. 
+        canvas.
         """
         if self._central_widget is None:
             self._central_widget = Widget(size=self.size, parent=self.scene)
@@ -223,11 +223,11 @@ class SceneCanvas(app.Canvas, Frozen):
         Parameters
         ----------
         region : tuple | None
-            Specifies the region of the canvas to render. Format is 
+            Specifies the region of the canvas to render. Format is
             (x, y, w, h). By default, the entire canvas is rendered.
         size : tuple | None
-            Specifies the size of the image array to return. If no size is 
-            given, then the size of the *region* is used, multiplied by the 
+            Specifies the size of the image array to return. If no size is
+            given, then the size of the *region* is used, multiplied by the
             pixel scaling factor of the canvas (see `pixel_scale`). This
             argument allows the scene to be rendered at resolutions different
             from the native canvas resolution.
@@ -245,7 +245,7 @@ class SceneCanvas(app.Canvas, Frozen):
         Returns
         -------
         image : array
-            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the 
+            Numpy array of type ubyte and shape (h, w, 4). Index [0, 0] is the
             upper-left corner of the rendered region. If ``alpha`` is ``False``,
             then only 3 channels will be returned (RGB).
 
@@ -255,7 +255,7 @@ class SceneCanvas(app.Canvas, Frozen):
         offset = (0, 0) if region is None else region[:2]
         csize = self.size if region is None else region[2:]
         s = self.pixel_scale
-        size = tuple([x * s for x in csize]) if size is None else size
+        size = tuple([int(x * s) for x in csize]) if size is None else size
         fbo = gloo.FrameBuffer(color=gloo.RenderBuffer(size[::-1]),
                                depth=gloo.RenderBuffer(size[::-1]))
 
@@ -476,7 +476,7 @@ class SceneCanvas(app.Canvas, Frozen):
         return [v for v in visuals if v is not None]
 
     def _render_picking(self, crop):
-        """Render the scene in picking mode, returning a 2D array of visual 
+        """Render the scene in picking mode, returning a 2D array of visual
         IDs in the area specified by crop.
 
         Parameters
@@ -570,7 +570,7 @@ class SceneCanvas(app.Canvas, Frozen):
 
         This activates the framebuffer and causes subsequent rendering to be
         written to the framebuffer rather than the canvas's back buffer. This
-        will also set the canvas viewport to cover the boundaries of the 
+        will also set the canvas viewport to cover the boundaries of the
         framebuffer.
 
         Parameters
@@ -581,7 +581,7 @@ class SceneCanvas(app.Canvas, Frozen):
             The location of the fbo origin relative to the canvas's framebuffer
             origin.
         csize : tuple
-            The size of the region in the canvas's framebuffer that should be 
+            The size of the region in the canvas's framebuffer that should be
             covered by this framebuffer object.
         """
         self._fb_stack.append((fbo, offset, csize))
@@ -617,7 +617,7 @@ class SceneCanvas(app.Canvas, Frozen):
             return self._fb_stack[-1]
 
     def _update_transforms(self):
-        """Update the canvas's TransformSystem to correct for the current 
+        """Update the canvas's TransformSystem to correct for the current
         canvas size, framebuffer, and viewport.
         """
         if len(self._fb_stack) == 0:


### PR DESCRIPTION
This implements a new backend based on `jupyter_rfb`. I'll be updating jupyter_rfb at the same time, so it aint easy to give this is a spin yet. This is basically the same as what was intended with the `ipynb_vnc` backend, but all the "hard parts" are delegated to an external library.

Includes a new simple way to create a (global) hidden window just for having a GL context, plus an approach to render offscreen using an FBO. The event system integrates with asyncio, because that's what Jupyter uses (via Tornado).

Closes #2127, closes #134, relates to all issues tagged with the jupyter-widget tag.

Todo:

* [x] Basic implementation
* [x] Can simply use canvas as cell output  
* [x] Events (mouse, key, scroll, ...)
* [x] Timers
* [x] Test multiple canvases
* [x] Test using a widget as subwidget
* [x] Tests
* [x] Examples
* [x] ~Use a global context~ -> no, we need to use one context per canvas to avoid interference.
* [x] Check for remaining todos that I left behind
* [x] Update and release jupyter_rfb.
* [x] More tests?
* [x] Look into `_ipython_display_`.