### PR TITLE
Fix `VolumeVisual.cmap` setter not working for most colormaps

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -289,17 +289,15 @@ def test_changing_cmap():
         v.camera.fov = 0
         v.camera.scale_factor = 40.0
 
-        # render with grays colormap, sample center
-        rendered = c.render()
-        center = np.array(rendered.shape)[:2] // 2
-        center_sample = rendered[center[0], center[1], :]
+        # render with grays colormap
+        grays = c.render()
 
-        # update cmap, compare rendered value at center
+        # update cmap, compare rendered array with the grays cmap render
         for cmap in test_cmaps:
             volume.cmap = cmap
-            current_cmap_center = c.render()[center[0], center[1], :]
+            current_cmap = c.render()
             with pytest.raises(AssertionError):
-                np.testing.assert_allclose(center_sample, current_cmap_center)
+                np.testing.assert_allclose(grays, current_cmap)
 
 
 run_tests_if_main()

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -622,7 +622,7 @@ class VolumeVisual(Visual):
             raise ValueError('Volume visual needs a 3D array.')
         if isinstance(self._texture, GPUScaledTextured3D):
             copy = False
-        
+
         if clim is not None and clim != self._texture.clim:
             self._texture.set_clim(clim)
 
@@ -687,6 +687,11 @@ class VolumeVisual(Visual):
     def cmap(self, cmap):
         self._cmap = get_colormap(cmap)
         self.shared_program.frag['cmap'] = Function(self._cmap.glsl_map)
+        self.shared_program['texture2D_LUT'] = (
+            self.cmap.texture_lut()
+            if (hasattr(self.cmap, 'texture_lut'))
+            else None
+        )
         self.update()
 
     @property


### PR DESCRIPTION
Right now, updating the `cmap` property of the volume visual either doesn't change anything or results in an ugly traceback. This PR is upstreaming a fix for that from napari, originally made by @sofroniewn.

Here is an example you can play with
```python
# -*- coding: utf-8 -*-
# -----------------------------------------------------------------------------
# Copyright (c) Vispy Development Team. All Rights Reserved.
# Distributed under the (new) BSD License. See LICENSE.txt for more info.
# -----------------------------------------------------------------------------
# vispy: gallery 2

"""
Example volume rendering

Controls:

* 1  - change colormap
"""

from itertools import cycle

import numpy as np

from vispy import app, scene, io
from vispy.color import get_colormaps, BaseColormap
from vispy.visuals.transforms import STTransform

# Read volume
vol1 = np.load(io.load_data_file('volume/stent.npz'))['arr_0']

# Prepare canvas
canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)

# Set up a viewbox to display the image with interactive pan/zoom
view = canvas.central_widget.add_view()

# Create the volume visual
volume = scene.visuals.Volume(vol1, parent=view.scene, threshold=0.225)


# Create three cameras (Fly, Turntable and Arcball)
fov = 60.
cam1 = scene.cameras.FlyCamera(parent=view.scene, fov=fov, name='Fly')
cam2 = scene.cameras.TurntableCamera(parent=view.scene, fov=fov,
                                     name='Turntable')
cam3 = scene.cameras.ArcballCamera(parent=view.scene, fov=fov, name='Arcball')
view.camera = cam2  # Select turntable at first

# Create an XYZAxis visual
axis = scene.visuals.XYZAxis(parent=view)
s = STTransform(translate=(50, 50), scale=(50, 50, 50, 1))
affine = s.as_matrix()
axis.transform = affine


@canvas.events.mouse_move.connect
def on_mouse_move(event):
    if event.button == 1 and event.is_dragging:
        axis.transform.reset()

        axis.transform.rotate(cam2.roll, (0, 0, 1))
        axis.transform.rotate(cam2.elevation, (1, 0, 0))
        axis.transform.rotate(cam2.azimuth, (0, 1, 0))

        axis.transform.scale((50, 50, 0.001))
        axis.transform.translate((50., 50.))
        axis.update()

current_cmap = 'grays'
cmaps = ['grays', 'reds', 'greens', 'blues']

# Implement key presses
@canvas.events.key_press.connect
def on_key_press(event):
    global current_cmap
    if event.text == '1':
        current_cmap = cmaps[(cmaps.index(current_cmap) + 1) % 4]
        volume.cmap = current_cmap

if __name__ == '__main__':
    print(__doc__)
    app.run()

```

Example of the ugly traceback without this PR
```python
WARNING: Error drawing visual <Volume at 0x172387dc0>
WARNING: Traceback (most recent call last):
  File "/Users/aburt/Programming/vispy/playground/volume_simple.py", line 80, in <module>
    app.run()
  File "/Users/aburt/Programming/vispy/vispy/app/_default_app.py", line 60, in run
    return default_app.run()
  File "/Users/aburt/Programming/vispy/vispy/app/application.py", line 155, in run
    return self._backend._vispy_run()
  File "/Users/aburt/Programming/vispy/vispy/app/backends/_qt.py", line 292, in _vispy_run
    return app.exec_()
  File "/Users/aburt/Programming/vispy/vispy/app/backends/_qt.py", line 526, in event
    out = super(QtBaseCanvasBackend, self).event(ev)
  File "/Users/aburt/Programming/vispy/vispy/app/backends/_qt.py", line 526, in event
    out = super(QtBaseCanvasBackend, self).event(ev)
  File "/Users/aburt/Programming/vispy/vispy/app/backends/_qt.py", line 846, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/Users/aburt/Programming/vispy/vispy/util/event.py", line 453, in __call__
    self._invoke_callback(cb, event)
  File "/Users/aburt/Programming/vispy/vispy/util/event.py", line 471, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  << caught exception here: >>
  File "/Users/aburt/Programming/vispy/vispy/util/event.py", line 469, in _invoke_callback
    cb(event)
  File "/Users/aburt/Programming/vispy/vispy/scene/canvas.py", line 218, in on_draw
    self._draw_scene()
  File "/Users/aburt/Programming/vispy/vispy/scene/canvas.py", line 277, in _draw_scene
    self.draw_visual(self.scene)
  File "/Users/aburt/Programming/vispy/vispy/scene/canvas.py", line 315, in draw_visual
    node.draw()
  File "/Users/aburt/Programming/vispy/vispy/scene/visuals.py", line 99, in draw
    self._visual_superclass.draw(self)
  File "/Users/aburt/Programming/vispy/vispy/visuals/visual.py", line 451, in draw
    self._program.draw(self._vshare.draw_mode,
  File "/Users/aburt/Programming/vispy/vispy/visuals/shaders/program.py", line 102, in draw
    Program.draw(self, *args, **kwargs)
  File "/Users/aburt/Programming/vispy/vispy/gloo/program.py", line 526, in draw
    canvas.context.flush_commands()
  File "/Users/aburt/Programming/vispy/vispy/gloo/context.py", line 172, in flush_commands
    self.glir.flush(self.shared.parser)
  File "/Users/aburt/Programming/vispy/vispy/gloo/glir.py", line 579, in flush
    self._shared.flush(parser)
  File "/Users/aburt/Programming/vispy/vispy/gloo/glir.py", line 501, in flush
    parser.parse(self._filter(self.clear(), parser))
  File "/Users/aburt/Programming/vispy/vispy/gloo/glir.py", line 819, in parse
    self._parse(command)
  File "/Users/aburt/Programming/vispy/vispy/gloo/glir.py", line 781, in _parse
    ob.draw(*args)
  File "/Users/aburt/Programming/vispy/vispy/gloo/glir.py", line 1344, in draw
    gl.check_error('Check after draw')
  File "/Users/aburt/Programming/vispy/vispy/gloo/gl/__init__.py", line 204, in check_error
    raise err
RuntimeError: OpenGL got errors (Check after draw): GL_INVALID_OPERATION
ERROR: Invoking <bound method SceneCanvas.on_draw of <SceneCanvas (PyQt5) at 0x15be77c10>> for DrawEvent
WARNING: Error drawing visual <Volume at 0x172387dc0>
ERROR: Invoking <bound method SceneCanvas.on_draw of <SceneCanvas (PyQt5) at 0x15be77c10>> repeat 2
WARNING: Error drawing visual <Volume at 0x172387dc0>
```

