### PR TITLE
Switch to cibuildwheel github action and skip 3.10 wheel building

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,21 +20,14 @@ jobs:
       with:
         fetch-depth: 0
         submodules: 'recursive'
-    - name: Use MSBuild (Windows)
-      uses: microsoft/setup-msbuild@v1.0.2
-      if: matrix.os == 'windows-2019'
-    - uses: actions/setup-python@v2
-      name: Install Python
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install --upgrade pip
-        pip install cibuildwheel
     - name: Build wheels
-      run: python -m cibuildwheel --output-dir wheelhouse
+      uses: pypa/cibuildwheel@v2.1.1
       env:
         CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* pp* *-win32"
         CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow sphinx_gallery imageio"
         CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
+        # Pillow is missing a python 3.10 wheel and can't build from source here
+        CIBW_TEST_SKIP: "cp310-*"
         CIBW_BUILD_VERBOSITY: "2"
         CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
         CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,11 +23,9 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.1.1
       env:
-        CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* pp* *-win32"
+        CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp310-* pp* *-win32"
         CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow sphinx_gallery imageio"
         CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
-        # Pillow is missing a python 3.10 wheel and can't build from source here
-        CIBW_TEST_SKIP: "cp310-*"
         CIBW_BUILD_VERBOSITY: "2"
         CIBW_BEFORE_BUILD: "pip install -U numpy Cython jupyter ipywidgets"
         CIBW_BEFORE_BUILD_MACOS: "npm install npm@latest -g; pip install -U pip setuptools"


### PR DESCRIPTION
Addresses the build issues identified and discussed in #2116 

Currently cibuildwheel is trying to build with Python 3.10. However, many libraries don't have wheels for 3.10 yet (including vispy) and this causes issues for CI. We depend on Pillow for testing our wheels and since Pillow doesn't currently have a 3.10 wheel it tries to build from source during cibuildwheel's test phase. This fails with some missing C dependencies.

This PR switches to using the new PyPA-based cibuildwheel github action and skips testing the wheel for Python 3.10.