### PR TITLE
Fix minor bug in volume_clipping.py example

### DIFF
--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -12,12 +12,9 @@ Controls:
 - r - remove a clipping plane
 """
 
-from itertools import cycle
-
 import numpy as np
 
 from vispy import app, scene, io
-from vispy.color import get_colormaps, BaseColormap
 from vispy.visuals.transforms import STTransform
 
 # Read volume
@@ -29,49 +26,24 @@ canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 # Set up a viewbox to display the image with interactive pan/zoom
 view = canvas.central_widget.add_view()
 
-# Set whether we are emulating a 3D texture
-emulate_texture = False
-
-# Create the volume visuals, only one is visible
+# Create the volume visual
 volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
 volume.transform = scene.STTransform(translate=(64, 64, 0))
 
-# Create three cameras (Fly, Turntable and Arcball)
+# Create and set the camera
 fov = 60.
-cam = scene.cameras.TurntableCamera(parent=view.scene, fov=fov,
-                                    name='Turntable')
-
-view.camera = cam  # Select turntable at first
+cam = scene.cameras.TurntableCamera(
+    parent=view.scene,
+    fov=fov,
+    name='Turntable'
+)
+view.camera = cam
 
 # Create an XYZAxis visual
 axis = scene.visuals.XYZAxis(parent=view)
 s = STTransform(translate=(50, 50), scale=(50, 50, 50, 1))
 affine = s.as_matrix()
 axis.transform = affine
-
-
-# create colormaps that work well for translucent and additive volume rendering
-class TransFire(BaseColormap):
-    glsl_map = """
-    vec4 translucent_fire(float t) {
-        return vec4(pow(t, 0.5), t, t*t, max(0, t*1.05 - 0.05));
-    }
-    """
-
-
-class TransGrays(BaseColormap):
-    glsl_map = """
-    vec4 translucent_grays(float t) {
-        return vec4(t, t, t, t*0.05);
-    }
-    """
-
-
-# Setup colormap iterators
-opaque_cmaps = cycle(get_colormaps())
-translucent_cmaps = cycle([TransFire(), TransGrays()])
-opaque_cmap = next(opaque_cmaps)
-translucent_cmap = next(translucent_cmaps)
 
 
 # Implement axis connection with cam2

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -71,12 +71,13 @@ clip_modes = {
 
 
 def add_clip(vol, mode):
-    if mode in clip_modes:
-        new_plane = clip_modes[mode]
-        if vol.clipping_planes is None:
-            vol.clipping_planes = new_plane
-        else:
-            vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
+    if mode not in clip_modes:
+        return
+    new_plane = clip_modes[mode]
+    if vol.clipping_planes is None:
+        vol.clipping_planes = new_plane
+    else:
+        vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
 
 
 def remove_clip(vol):

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -99,11 +99,12 @@ clip_modes = {
 
 
 def add_clip(vol, mode):
-    new_plane = clip_modes[mode]
-    if vol.clipping_planes is None:
-        vol.clipping_planes = new_plane
-    else:
-        vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
+    if mode in clip_modes:
+        new_plane = clip_modes[mode]
+        if vol.clipping_planes is None:
+            vol.clipping_planes = new_plane
+        else:
+            vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
 
 
 def remove_clip(vol):


### PR DESCRIPTION
First of all, thanks for an amazing project!

Pressing a modifier (e.g., shift) in the `examples/scene/volume_clipping.py` example caused an error (traceback below) since `''in 'xyzo'` evaluates to `True` [here](https://github.com/vispy/vispy/blob/3ef02c5f1ae6bf34616060e350d7e1818c8d3c21/examples/scene/volume_clipping.py#L117). I have added a small check in `add_clip()` to make sure `mode` is valid before attempting to add a clipping plane.

edit: I also removed some lines of code that seemed unused.

```python
WARNING: Traceback (most recent call last):
  File "/Users/kyamauch/Documents/vispy/examples/scene/volume_clipping.py", line 130, in <module>
    app.run()
  File "/Users/kyamauch/Documents/vispy/vispy/app/_default_app.py", line 60, in run
    return default_app.run()
  File "/Users/kyamauch/Documents/vispy/vispy/app/application.py", line 163, in run
    return self._backend._vispy_run()
  File "/Users/kyamauch/Documents/vispy/vispy/app/backends/_qt.py", line 292, in _vispy_run
    return app.exec_()
  File "/Users/kyamauch/Documents/vispy/vispy/app/backends/_qt.py", line 525, in event
    out = super(QtBaseCanvasBackend, self).event(ev)
  File "/Users/kyamauch/Documents/vispy/vispy/app/backends/_qt.py", line 519, in keyPressEvent
    self._keyEvent(self._vispy_canvas.events.key_press, ev)
  File "/Users/kyamauch/Documents/vispy/vispy/app/backends/_qt.py", line 571, in _keyEvent
    func(native=ev, key=key, text=str(ev.text()), modifiers=mod)
  File "/Users/kyamauch/Documents/vispy/vispy/util/event.py", line 453, in __call__
    self._invoke_callback(cb, event)
  File "/Users/kyamauch/Documents/vispy/vispy/util/event.py", line 471, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  << caught exception here: >>
  File "/Users/kyamauch/Documents/vispy/vispy/util/event.py", line 469, in _invoke_callback
    cb(event)
  File "/Users/kyamauch/Documents/vispy/examples/scene/volume_clipping.py", line 118, in on_key_press
    add_clip(volume, event.text)
  File "/Users/kyamauch/Documents/vispy/examples/scene/volume_clipping.py", line 102, in add_clip
    new_plane = clip_modes[mode]
KeyError: ''
ERROR: Invoking <function on_key_press at 0x7fd0e6fbb1f0> for KeyEvent
```