### PR TITLE
Add skinny cross marker (++) to MarkersVisual

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -450,6 +450,21 @@ float rect(vec2 pointcoord, float size)
 }
 """
 
+cross_lines = """
+float cross(vec2 pointcoord, float size)
+{
+    //vbar
+    float r1 = abs(pointcoord.x - 0.5)*size;
+    float r2 = abs(pointcoord.y - 0.5)*size - $v_size/2;
+    float vbar = max(r1,r2);
+    //hbar
+    float r3 = abs(pointcoord.y - 0.5)*size;
+    float r4 = abs(pointcoord.x - 0.5)*size - $v_size/2;
+    float hbar = max(r3,r4);
+    return min(vbar, hbar);
+}
+"""
+
 _marker_dict = {
     'disc': disc,
     'arrow': arrow,
@@ -468,6 +483,7 @@ _marker_dict = {
     # aliases
     'o': disc,
     '+': cross,
+    '++': cross_lines,
     's': square,
     '-': hbar,
     '|': vbar,


### PR DESCRIPTION
A new marker in MarkersVisual that looks like a 'skinny' version of the already existing 'cross' marker.

The red cross is an example of this marker:
![image](https://user-images.githubusercontent.com/40632281/130950266-4db2347d-7564-4ded-9c11-89365d6daab5.png)
