### PR TITLE
Add PlanesClipper filter for visually clipping visuals by a 2D plane

### DIFF
--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -5,8 +5,8 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 """
-Volume rendering with clipping planes
-=====================================
+Clipping planes with volume and markers
+=======================================
 Controls:
 - x/y/z/o - add new clipping plane with normal along x/y/z or [1,1,1] oblique axis
 - r - remove a clipping plane
@@ -16,9 +16,7 @@ import numpy as np
 
 from vispy import app, scene, io
 from vispy.visuals.transforms import STTransform
-
-# Read volume
-vol = np.load(io.load_data_file('volume/stent.npz'))['arr_0']
+from vispy.visuals.filters.clipping_planes import PlanesClipper
 
 # Prepare canvas
 canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
@@ -26,9 +24,20 @@ canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 # Set up a viewbox to display the image with interactive pan/zoom
 view = canvas.central_widget.add_view()
 
-# Create the volume visual
-volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225, clipping_planes_coord_system='visual')
-volume.transform = scene.STTransform(translate=(64, 64, 0))
+# Create the visuals
+vol = np.load(io.load_data_file('volume/stent.npz'))['arr_0']
+volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
+
+np.random.seed(1)
+points = np.random.rand(100, 3) * (128, 128, 128)
+markers = scene.visuals.Markers(pos=points, parent=view.scene)
+# add a transform to markers, to show clipping is in scene coordinates
+markers.transform = scene.STTransform(translate=(0, 0, 128))
+
+# Create the clipping planes filter for the markers (Volume has its own clipping logic)
+clipper = PlanesClipper()
+# and attach it to the markers
+markers.attach(clipper)
 
 # Create and set the camera
 fov = 60.
@@ -60,8 +69,10 @@ def on_mouse_move(event):
         axis.transform.translate((50., 50.))
         axis.update()
 
+
 volume_center = (np.array(vol.shape) / 2)
 
+# clipping planes around the origin
 clip_modes = {
     'x': np.array([[volume_center, [0, 0, 1]]]),
     'y': np.array([[volume_center, [0, 1, 0]]]),
@@ -70,34 +81,32 @@ clip_modes = {
 }
 
 
-def add_clip(vol, mode):
+def add_clip(mode):
     if mode not in clip_modes:
         return
     new_plane = clip_modes[mode]
-    if vol.clipping_planes is None:
-        vol.clipping_planes = new_plane
+    if volume.clipping_planes is None:
+        clipping_planes = new_plane
     else:
-        vol.clipping_planes = np.concatenate([vol.clipping_planes, new_plane])
+        clipping_planes = np.concatenate([volume.clipping_planes, new_plane])
+    volume.clipping_planes = clipping_planes
+    clipper.clipping_planes = clipping_planes
 
 
-def remove_clip(vol):
-    if vol.clipping_planes is not None:
-        vol.clipping_planes = vol.clipping_planes[:-1]
+def remove_clip():
+    if volume.clipping_planes is not None:
+        volume.clipping_planes = volume.clipping_planes[:-1]
+        clipper.clipping_planes = clipper.clipping_planes[:-1]
 
 
 # Implement key presses
 @canvas.events.key_press.connect
 def on_key_press(event):
     if event.text in 'xyzo':
-        add_clip(volume, event.text)
+        add_clip(event.text)
     elif event.text == 'r':
-        remove_clip(volume)
+        remove_clip()
 
-
-# for testing performance
-# @canvas.connect
-# def on_draw(ev):
-# canvas.update()
 
 if __name__ == '__main__':
     print(__doc__)

--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -15,7 +15,6 @@ Controls:
 import numpy as np
 
 from vispy import app, scene, io
-from vispy.visuals.transforms import STTransform
 from vispy.visuals.filters.clipping_planes import PlanesClipper
 
 # Prepare canvas

--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -49,13 +49,15 @@ cam = scene.cameras.TurntableCamera(
 view.camera = cam
 
 
-volume_center = (np.array(vol.shape) / 2)
+# since volume data is in 'zyx' coordinates, we have to reverse the coordinates
+# we use as a center
+volume_center = (np.array(vol.shape) / 2)[::-1]
 
 # clipping planes around the origin
 clip_modes = {
-    'x': np.array([[volume_center, [0, 0, 1]]]),
+    'x': np.array([[volume_center, [1, 0, 0]]]),
     'y': np.array([[volume_center, [0, 1, 0]]]),
-    'z': np.array([[volume_center, [1, 0, 0]]]),
+    'z': np.array([[volume_center, [0, 0, 1]]]),
     'o': np.array([[volume_center, [1, 1, 1]]]),
 }
 
@@ -63,17 +65,13 @@ clip_modes = {
 def add_clip(mode):
     if mode not in clip_modes:
         return
-    new_plane = clip_modes[mode]
-    if volume.clipping_planes is None:
-        clipping_planes = new_plane
-    else:
-        clipping_planes = np.concatenate([volume.clipping_planes, new_plane])
+    clipping_planes = np.concatenate([volume.clipping_planes, clip_modes[mode]])
     volume.clipping_planes = clipping_planes
     clipper.clipping_planes = clipping_planes
 
 
 def remove_clip():
-    if volume.clipping_planes is not None:
+    if volume.clipping_planes.shape[0] > 0:
         volume.clipping_planes = volume.clipping_planes[:-1]
         clipper.clipping_planes = clipper.clipping_planes[:-1]
 

--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -48,27 +48,6 @@ cam = scene.cameras.TurntableCamera(
 )
 view.camera = cam
 
-# Create an XYZAxis visual
-axis = scene.visuals.XYZAxis(parent=view)
-s = STTransform(translate=(50, 50), scale=(50, 50, 50, 1))
-affine = s.as_matrix()
-axis.transform = affine
-
-
-# Implement axis connection with cam2
-@canvas.events.mouse_move.connect
-def on_mouse_move(event):
-    if event.button == 1 and event.is_dragging:
-        axis.transform.reset()
-
-        axis.transform.rotate(cam.roll, (0, 0, 1))
-        axis.transform.rotate(cam.elevation, (1, 0, 0))
-        axis.transform.rotate(cam.azimuth, (0, 1, 0))
-
-        axis.transform.scale((50, 50, 0.001))
-        axis.transform.translate((50., 50.))
-        axis.update()
-
 
 volume_center = (np.array(vol.shape) / 2)
 

--- a/examples/scene/volume_clipping.py
+++ b/examples/scene/volume_clipping.py
@@ -27,7 +27,7 @@ canvas = scene.SceneCanvas(keys='interactive', size=(800, 600), show=True)
 view = canvas.central_widget.add_view()
 
 # Create the volume visual
-volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
+volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225, clipping_planes_coord_system='visual')
 volume.transform = scene.STTransform(translate=(64, 64, 0))
 
 # Create and set the camera

--- a/vispy/gloo/__init__.py
+++ b/vispy/gloo/__init__.py
@@ -49,7 +49,7 @@ from .wrappers import *  # noqa
 from .context import (GLContext, get_default_config,  # noqa
                       get_current_canvas)  # noqa
 from .globject import GLObject  # noqa
-from .buffer import VertexBuffer, IndexBuffer, DataBuffer  # noqa
+from .buffer import VertexBuffer, IndexBuffer  # noqa
 from .texture import Texture1D, Texture2D, TextureAtlas, Texture3D, TextureCube, TextureEmulated3D  # noqa
 from .program import Program  # noqa
 from .framebuffer import FrameBuffer, RenderBuffer  # noqa

--- a/vispy/gloo/__init__.py
+++ b/vispy/gloo/__init__.py
@@ -49,7 +49,7 @@ from .wrappers import *  # noqa
 from .context import (GLContext, get_default_config,  # noqa
                       get_current_canvas)  # noqa
 from .globject import GLObject  # noqa
-from .buffer import VertexBuffer, IndexBuffer  # noqa
+from .buffer import VertexBuffer, IndexBuffer, DataBuffer  # noqa
 from .texture import Texture1D, Texture2D, TextureAtlas, Texture3D, TextureCube, TextureEmulated3D  # noqa
 from .program import Program  # noqa
 from .framebuffer import FrameBuffer, RenderBuffer  # noqa

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+
+from functools import lru_cache
+from abc import ABC, abstractstaticmethod
+
+import numpy as np
+
+from ..shaders import Function, FunctionChain, Varying, Variable
+from ...gloo import DataBuffer
+from .base_filter import Filter
+
+
+class PlanesClipper(ABC, Filter):
+    """Clips visual output based on arbitrary clipping planes."""
+
+    VERT_CODE = """
+    void clip() {
+        // this is here to allow to set v_is_shown
+        $v_is_shown;
+        // Transform back to visual coordinates and clip based on that
+        $clip_with_planes($itransform(gl_Position).xyz);
+    }
+    """
+
+    FRAG_CODE = """
+    void clip() {
+        if ($v_is_shown < 0.)
+            discard;
+    }
+    """
+
+    def __init__(self, clipping_planes=None):
+        super().__init__(
+            vcode=Function(self.VERT_CODE), vhook='post', vpos=1,
+            fcode=Function(self.FRAG_CODE), fhook='pre', fpos=1,
+        )
+
+        self.v_is_shown = Varying('v_is_shown', 'float')
+        self.vshader['v_is_shown'] = self.v_is_shown
+        self.fshader['v_is_shown'] = self.v_is_shown
+
+        self.clipping_planes = clipping_planes
+
+    # @abstractstaticmethod
+    @staticmethod
+    def _get_itransform(visual):
+        """
+        get the transform from gl_Position to visual coordinates
+        """
+        return visual.get_transform('render', 'visual')
+
+    def _attach(self, visual):
+        super()._attach(visual)
+        self.vshader['itransform'] = self._get_itransform(visual)
+
+    @lru_cache(maxsize=10)
+    def _build_clipping_planes_func(self, n_planes):
+        """Build the function used to clip, based on the number of clipping planes.
+
+        Each plane is defined by a position and a normal vector; the vertex is considered
+        clipped if on the "negative" side of the plane
+        """
+
+        NOOP = """
+        vec3 clip_noop(vec3 position) {
+            return position;
+        }
+        """
+
+        CLIP_CODE = """
+        vec3 clip_with_plane(vec3 position) {
+            vec3 relative_vec = position - $clipping_plane_pos;
+            float is_shown = dot(relative_vec, $clipping_plane_norm);
+            $v_is_shown = min(is_shown, $v_is_shown);
+            // this return statement lets us construct a FunctionChain easily
+            return position;
+        }
+        """
+
+        clips = [Function(NOOP)]
+        for _ in range(n_planes):
+            clip = Function(CLIP_CODE)
+            clip['v_is_shown'] = self.v_is_shown
+            clips.append(clip)
+
+        func = FunctionChain('clip_with_planes', clips)
+        return func
+
+    @property
+    def clipping_planes(self):
+        """Get the set of planes used to clip the mesh.
+        Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
+        """
+        return self._clipping_planes[:, :, ::-1]
+
+    @clipping_planes.setter
+    def clipping_planes(self, value):
+        if value is None:
+            value = np.empty([0, 2, 3])
+        value = value[:, :, ::-1]
+        self._clipping_planes = value
+
+        clipping_func = self._build_clipping_planes_func(len(value))
+
+        for func, plane in zip(clipping_func[1:], value):  # skip noop func
+            func['clipping_plane_pos'] = tuple(plane[0])
+            func['clipping_plane_norm'] = tuple(plane[1])
+
+        self.vshader['clip_with_planes'] = clipping_func
+
+
+class MarkersPlanesClipper(PlanesClipper):
+    def _get_itransform(self, visual):
+        return visual.get_transform('render', 'visual')
+
+
+class MeshPlanesClipper(PlanesClipper):
+    def _get_itransform(self, visual):
+        return visual.get_transform('render', 'visual')

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -3,16 +3,14 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 from functools import lru_cache
-from abc import ABC, abstractstaticmethod
 
 import numpy as np
 
-from ..shaders import Function, FunctionChain, Varying, Variable
-from ...gloo import DataBuffer
+from ..shaders import Function, FunctionChain, Varying
 from .base_filter import Filter
 
 
-class PlanesClipper(ABC, Filter):
+class PlanesClipper(Filter):
     """Clips visual output based on arbitrary clipping planes."""
 
     VERT_CODE = """
@@ -43,7 +41,6 @@ class PlanesClipper(ABC, Filter):
 
         self.clipping_planes = clipping_planes
 
-    # @abstractstaticmethod
     @staticmethod
     def _get_itransform(visual):
         """
@@ -109,13 +106,3 @@ class PlanesClipper(ABC, Filter):
             func['clipping_plane_norm'] = tuple(plane[1])
 
         self.vshader['clip_with_planes'] = clipping_func
-
-
-class MarkersPlanesClipper(PlanesClipper):
-    def _get_itransform(self, visual):
-        return visual.get_transform('render', 'visual')
-
-
-class MeshPlanesClipper(PlanesClipper):
-    def _get_itransform(self, visual):
-        return visual.get_transform('render', 'visual')

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -56,7 +56,7 @@ class PlanesClipper(Filter):
         """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc) {{
-                float is_shown = 1.0;
+                float is_shown = 3.4e38; // max float
                 {clips};
                 return is_shown;
             }}

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -11,7 +11,16 @@ from .base_filter import Filter
 
 
 class PlanesClipper(Filter):
-    """Clips visual output based on arbitrary clipping planes."""
+    """Clips visual output based on arbitrary clipping planes.
+
+    Parameters
+    ----------
+    cliping_planes : ArrayLike
+        Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
+    coord_system : str
+        Coordinate system used by the clipping planes (see visuals.transforms.transform_system.py)
+
+    """
 
     VERT_CODE = """
     void clip() {
@@ -46,6 +55,9 @@ class PlanesClipper(Filter):
 
     @property
     def coord_system(self):
+        """
+        Coordinate system used by the clipping planes (see visuals.transforms.transform_system.py)
+        """
         # unsettable cause we can't update the transform after being attached
         return self._coord_system
 

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -99,7 +99,6 @@ class PlanesClipper(Filter):
     def clipping_planes(self, value):
         if value is None:
             value = np.empty([0, 2, 3])
-        value = value
         self._clipping_planes = value
 
         clip_func = self._build_clipping_planes_func(len(value))

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -93,13 +93,13 @@ class PlanesClipper(Filter):
         """Get the set of planes used to clip the mesh.
         Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
         """
-        return self._clipping_planes[:, :, ::-1]
+        return self._clipping_planes
 
     @clipping_planes.setter
     def clipping_planes(self, value):
         if value is None:
             value = np.empty([0, 2, 3])
-        value = value[:, :, ::-1]
+        value = value
         self._clipping_planes = value
 
         clip_func = self._build_clipping_planes_func(len(value))

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -63,7 +63,7 @@ class PlanesClipper(Filter):
         '''
         # the vertex is considered clipped if on the "negative" side of the plane
         clip_template = '''
-            vec3 relative_vec{idx} = loc - ( $clipping_plane_pos{idx} );
+            vec3 relative_vec{idx} = loc - $clipping_plane_pos{idx};
             float is_shown{idx} = dot(relative_vec{idx}, $clipping_plane_norm{idx});
             is_shown = min(is_shown{idx}, is_shown);
             '''

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -53,7 +53,7 @@ class PlanesClipper(Filter):
     @staticmethod
     @lru_cache(maxsize=10)
     def _build_clipping_planes_func(n_planes):
-        """Build the code snippet used to clip the mesh based on self.clipping_planes."""
+        """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc) {{
                 float is_shown = 1.0;

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 
 import numpy as np
 
-from ..shaders import Function, FunctionChain, Varying
+from ..shaders import Function, Varying
 from .base_filter import Filter
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -856,10 +856,11 @@ class VolumeVisual(Visual):
         Example: one plane in position (0, 0, 0) and with normal (0, 0, 1),
         and a plane in position (1, 1, 1) with normal (0, 1, 0):
 
-            volume.clipping_planes = np.array([
-                [[0, 0, 0], [0, 0, 1]],
-                [[1, 1, 1], [0, 1, 0]],
-            ])
+        >>> volume.clipping_planes = np.array([
+        >>>     [[0, 0, 0], [0, 0, 1]],
+        >>>     [[1, 1, 1], [0, 1, 0]],
+        >>> ])
+
         """
         return self._clipping_planes[:, :, ::-1]
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -877,7 +877,6 @@ class VolumeVisual(Visual):
     def clipping_planes(self, value):
         if value is None:
             value = np.empty([0, 2, 3])
-        value = value
         self._clipping_planes = value
 
         self._clip_func = self._build_clipping_planes_func(len(value))

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -838,7 +838,7 @@ class VolumeVisual(Visual):
         # the vertex is considered clipped if on the "negative" side of the plane
         clip_template = '''
             vec3 relative_vec{idx} = loc - ( $clipping_plane_pos{idx} / vol_shape );
-            float is_shown{idx} = dot(relative_vec{idx}, $clipping_plane_norm{idx});
+            float is_shown{idx} = dot(relative_vec{idx}, ($clipping_plane_norm{idx} * vol_shape));
             is_shown = min(is_shown{idx}, is_shown);
             '''
         all_clips = []

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -827,7 +827,7 @@ class VolumeVisual(Visual):
     @staticmethod
     @lru_cache(maxsize=10)
     def _build_clipping_planes_func(n_planes):
-        """Build the code snippet used to clip the mesh based on self.clipping_planes."""
+        """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc, vec3 vol_shape) {{
                 float is_shown = 1.0;
@@ -849,9 +849,16 @@ class VolumeVisual(Visual):
 
     @property
     def clipping_planes(self):
-        """Get the set of planes used to clip the volume.
+        """Get the set of planes used to clip the volume. Values on the negative side of the normal are discarded.
 
         Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
+
+        Example: one plane in position (0, 0, 0) and with normal (0, 0, 1),
+                 and a plane in position (1, 1, 1) with normal (0, 1, 0):
+                 volume.clipping_planes = np.array([
+                     [[0, 0, 0], [0, 0, 1]],
+                     [[1, 1, 1], [0, 1, 0]],
+                 ])
         """
         return self._clipping_planes[:, :, ::-1]
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -262,8 +262,8 @@ void main() {
         for (iter=iter; iter<nsteps; iter++)
         {
             // Only sample volume if loc is not clipped by clipping planes
-            float is_shown = $clip_with_planes(loc, u_shape);
-            if (is_shown >= 0)
+            float distance_from_clip = $clip_with_planes(loc, u_shape);
+            if (distance_from_clip >= 0)
             {
                 // Get sample color
                 vec4 color = $sample(u_volumetex, loc);
@@ -838,16 +838,16 @@ class VolumeVisual(Visual):
         func_template = '''
             float clip_planes(vec3 loc, vec3 vol_shape) {{
                 vec3 loc_transf = $clip_transform(vec4(loc, 1)).xyz;
-                float is_shown = 1.0;
+                float distance_from_clip = 1.0;
                 {clips};
-                return is_shown;
+                return distance_from_clip;
             }}
         '''
         # the vertex is considered clipped if on the "negative" side of the plane
         clip_template = '''
             vec3 relative_vec{idx} = loc_transf - ( $clipping_plane_pos{idx} / vol_shape );
-            float is_shown{idx} = dot(relative_vec{idx}, ($clipping_plane_norm{idx} * vol_shape));
-            is_shown = min(is_shown{idx}, is_shown);
+            float distance_from_clip{idx} = dot(relative_vec{idx}, ($clipping_plane_norm{idx} * vol_shape));
+            distance_from_clip = min(distance_from_clip{idx}, distance_from_clip);
             '''
         all_clips = []
         for idx in range(n_planes):

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -890,6 +890,9 @@ class VolumeVisual(Visual):
 
     @property
     def clipping_planes_coord_system(self):
+        """
+        Coordinate system used by the clipping planes (see visuals.transforms.transform_system.py)
+        """
         return self._clipping_planes_coord_system
 
     @property

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -854,11 +854,12 @@ class VolumeVisual(Visual):
         Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
 
         Example: one plane in position (0, 0, 0) and with normal (0, 0, 1),
-                 and a plane in position (1, 1, 1) with normal (0, 1, 0):
-                 volume.clipping_planes = np.array([
-                     [[0, 0, 0], [0, 0, 1]],
-                     [[1, 1, 1], [0, 1, 0]],
-                 ])
+        and a plane in position (1, 1, 1) with normal (0, 1, 0):
+
+            volume.clipping_planes = np.array([
+                [[0, 0, 0], [0, 0, 1]],
+                [[1, 1, 1], [0, 1, 0]],
+            ])
         """
         return self._clipping_planes[:, :, ::-1]
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -857,9 +857,10 @@ class VolumeVisual(Visual):
 
     @property
     def clipping_planes(self):
-        """Get the set of planes used to clip the volume. Values on the negative side of the normal are discarded.
+        """The set of planes used to clip the volume. Values on the negative side of the normal are discarded.
 
-        Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
+        Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3).
+        The order is xyz, as opposed to data's zyx (for consistency with the rest of vispy)
 
         Example: one plane in position (0, 0, 0) and with normal (0, 0, 1),
         and a plane in position (1, 1, 1) with normal (0, 1, 0):
@@ -870,13 +871,13 @@ class VolumeVisual(Visual):
         >>> ])
 
         """
-        return self._clipping_planes[:, :, ::-1]
+        return self._clipping_planes
 
     @clipping_planes.setter
     def clipping_planes(self, value):
         if value is None:
             value = np.empty([0, 2, 3])
-        value = value[:, :, ::-1]
+        value = value
         self._clipping_planes = value
 
         self._clip_func = self._build_clipping_planes_func(len(value))


### PR DESCRIPTION
Following suggestions in #2176 and #2177, I'm attempting to use filters for the same application.

~Things *seem* to work, but I get weird visual artifacts. I'm not sure how to debug them, and I would like some suggestions.~

EDIT: this now works as intended! See https://github.com/napari/napari/pull/3252 for a cool application :) Tested and worked with:
- lines
- markers
- meshes

https://user-images.githubusercontent.com/23482191/131091370-c673a384-ec49-4158-9b8f-96a7618349f7.mp4

Try out this code in ipython:

```python
from vispy.visuals.filters.clipping_planes import PlanesClipper
import numpy as np

clip = PlanesClipper()
clip.clipping_planes = np.array([[[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0, 1, 0]]])

%run examples/scene/mesh_shading.py
mesh.attach(clip)
```