### PR TITLE
Fix PyQt5 backend gesture event handling

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -574,7 +574,8 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         if t == qt_event_types.TouchEnd:
             self._vispy_canvas.events.touch(type='end')
         if t == qt_event_types.Gesture:
-            gesture = ev.gesture(qt_event_types.PinchGesture)
+            pinch_gesture = QtCore.Qt.GestureType.PinchGesture if PYQT6_API else QtCore.Qt.PinchGesture
+            gesture = ev.gesture(pinch_gesture)
             if gesture:
                 (x, y) = _get_qpoint_pos(gesture.centerPoint())
                 scale = gesture.scaleFactor()


### PR DESCRIPTION
Closes #2201 

This was caused by a mistake in #2172. Enum access has changed in PyQt6 so we need to be careful. Gesture types are in their own type outside of normal event types.

CC @kevinyamauchi for testing