### PR TITLE
Spherical (3D-looking) `Markers` symbols

### DIFF
--- a/examples/scene/marker_spheres.py
+++ b/examples/scene/marker_spheres.py
@@ -25,12 +25,12 @@ colors = np.concatenate([colors, [[1, 0, 0]]], axis=0)
 # Create and show visual
 vis = scene.visuals.Markers(
     pos=data,
-    size=size,
+    size=100,
     symbol='sphere',
     antialias=0,
     face_color=colors,
     edge_color='white',
-    edge_width=1,
+    edge_width=30,
     scaling=True,
 )
 vis.parent = view.scene

--- a/examples/scene/marker_spheres.py
+++ b/examples/scene/marker_spheres.py
@@ -26,12 +26,12 @@ colors = np.concatenate([colors, [[1, 0, 0]]], axis=0)
 vis = scene.visuals.Markers(
     pos=data,
     size=100,
-    symbol='sphere',
     antialias=0,
     face_color=colors,
     edge_color='white',
     edge_width=0,
     scaling=True,
+    spherical=True,
 )
 vis.parent = view.scene
 

--- a/examples/scene/marker_spheres.py
+++ b/examples/scene/marker_spheres.py
@@ -1,6 +1,6 @@
 """
-Show some spheres and sticks
-============================
+Spheres and Sticks
+==================
 """
 import numpy as np
 from vispy import app, scene
@@ -30,7 +30,7 @@ vis = scene.visuals.Markers(
     antialias=0,
     face_color=colors,
     edge_color='white',
-    edge_width=30,
+    edge_width=0,
     scaling=True,
 )
 vis.parent = view.scene

--- a/examples/scene/marker_spheres.py
+++ b/examples/scene/marker_spheres.py
@@ -1,0 +1,49 @@
+"""
+Show some spheres and sticks
+============================
+"""
+import numpy as np
+from vispy import app, scene
+
+# Create canvas and view
+canvas = scene.SceneCanvas(keys='interactive', size=(600, 600), show=True)
+view = canvas.central_widget.add_view()
+view.camera = scene.cameras.ArcballCamera(fov=0)
+view.camera.scale_factor = 500
+
+# Prepare data
+np.random.seed(57983)
+data = np.random.normal(size=(40, 3), loc=0, scale=100)
+size = np.random.rand(40) * 100
+colors = np.random.rand(40, 3)
+
+data = np.concatenate([data, [[0, 0, 0]]], axis=0)
+size = np.concatenate([size, [100]], axis=0)
+colors = np.concatenate([colors, [[1, 0, 0]]], axis=0)
+
+
+# Create and show visual
+vis = scene.visuals.Markers(
+    pos=data,
+    size=size,
+    symbol='sphere',
+    antialias=0,
+    face_color=colors,
+    edge_color='white',
+    edge_width=1,
+    scaling=True,
+)
+vis.parent = view.scene
+
+lines = np.array([[data[i], data[-1]]
+                  for i in range(len(data) - 1)])
+line_vis = []
+
+for line in lines:
+    vis2 = scene.visuals.Tube(line, radius=5)
+    vis2.parent = view.scene
+    line_vis.append(vis2)
+
+
+# Run example
+app.run()

--- a/examples/scene/marker_spheres.py
+++ b/examples/scene/marker_spheres.py
@@ -44,6 +44,5 @@ for line in lines:
     vis2.parent = view.scene
     line_vis.append(vis2)
 
-
-# Run example
-app.run()
+if __name__ == "__main__":
+    app.run()

--- a/examples/scene/point_cloud.py
+++ b/examples/scene/point_cloud.py
@@ -23,20 +23,21 @@ view = canvas.central_widget.add_view()
 
 
 # generate data
-pos = np.random.normal(size=(100000, 3), scale=0.2)
+pos = np.random.normal(size=(10000, 3), scale=0.2)
 # one could stop here for the data generation, the rest is just to make the
 # data look more interesting. Copied over from magnify.py
 centers = np.random.normal(size=(50, 3))
-indexes = np.random.normal(size=100000, loc=centers.shape[0]/2.,
+indexes = np.random.normal(size=10000, loc=centers.shape[0]/2.,
                            scale=centers.shape[0]/3.)
 indexes = np.clip(indexes, 0, centers.shape[0]-1).astype(int)
 scales = 10**(np.linspace(-2, 0.5, centers.shape[0]))[indexes][:, np.newaxis]
 pos *= scales
 pos += centers[indexes]
+pos *= 1000
 
 # create scatter object and fill in the data
 scatter = visuals.Markers()
-scatter.set_data(pos, edge_color=None, face_color=(1, 1, 1, .5), size=5)
+scatter.set_data(pos, edge_color='blue', edge_width=2, face_color=(1, 1, 1, .5), size=20, scaling=True)
 
 view.add(scatter)
 

--- a/examples/scene/point_cloud.py
+++ b/examples/scene/point_cloud.py
@@ -23,21 +23,20 @@ view = canvas.central_widget.add_view()
 
 
 # generate data
-pos = np.random.normal(size=(10000, 3), scale=0.2)
+pos = np.random.normal(size=(100000, 3), scale=0.2)
 # one could stop here for the data generation, the rest is just to make the
 # data look more interesting. Copied over from magnify.py
 centers = np.random.normal(size=(50, 3))
-indexes = np.random.normal(size=10000, loc=centers.shape[0]/2.,
+indexes = np.random.normal(size=100000, loc=centers.shape[0]/2.,
                            scale=centers.shape[0]/3.)
 indexes = np.clip(indexes, 0, centers.shape[0]-1).astype(int)
 scales = 10**(np.linspace(-2, 0.5, centers.shape[0]))[indexes][:, np.newaxis]
 pos *= scales
 pos += centers[indexes]
-pos *= 1000
 
 # create scatter object and fill in the data
 scatter = visuals.Markers()
-scatter.set_data(pos, edge_color='blue', edge_width=2, face_color=(1, 1, 1, .5), size=20, scaling=True)
+scatter.set_data(pos, edge_color=None, face_color=(1, 1, 1, .5), size=5)
 
 view.add(scatter)
 

--- a/vispy/visuals/graphs/graph.py
+++ b/vispy/visuals/graphs/graph.py
@@ -63,6 +63,7 @@ class GraphVisual(CompoundVisual):
     _arrow_kw_trans = dict(line_color='color', line_width='width')
     _node_kw_trans = dict(node_symbol='symbol', node_size='size',
                           border_color='edge_color', border_width='edge_width')
+    _node_properties = ('symbol',)
 
     def __init__(self, adjacency_mat=None, directed=False, layout=None,
                  animate=False, line_color=None, line_width=None,
@@ -75,6 +76,7 @@ class GraphVisual(CompoundVisual):
 
         self._arrow_data = {}
         self._node_data = {}
+        self._node_properties = {}
 
         self._adjacency_mat = None
 
@@ -145,6 +147,9 @@ class GraphVisual(CompoundVisual):
             return True
 
         self._nodes.set_data(pos=node_vertices, **self._node_data)
+        for k, v in self._node_properties.items():
+            setattr(self._nodes, k, v)
+
         self._edges.set_data(pos=line_vertices, arrows=arrows,
                              **self._arrow_data)
 
@@ -167,6 +172,9 @@ class GraphVisual(CompoundVisual):
             pass
 
         self._nodes.set_data(pos=node_vertices, **self._node_data)
+        for k, v in self._node_properties.items():
+            setattr(self._nodes, k, v)
+
         self._edges.set_data(pos=line_vertices, arrows=arrows,
                              **self._arrow_data)
 
@@ -216,10 +224,17 @@ class GraphVisual(CompoundVisual):
             raise TypeError("%s.set_data() got invalid keyword arguments: %s"
                             % (self.__class__.__name__, list(kwargs.keys())))
 
+        # some attributes should be set as properties
+        node_properties = {}
+        for k, v in list(node_kwargs.items()):
+            if k in (self._node_properties):
+                node_properties[k] = node_kwargs.pop(k)
+
         # The actual data is set in GraphVisual.animate_layout or
         # GraphVisual.set_final_layout
         self._arrow_data = arrow_kwargs
         self._node_data = node_kwargs
+        self._node_properties = node_properties
 
         if not self._animate:
             self.set_final_layout()

--- a/vispy/visuals/graphs/graph.py
+++ b/vispy/visuals/graphs/graph.py
@@ -63,7 +63,7 @@ class GraphVisual(CompoundVisual):
     _arrow_kw_trans = dict(line_color='color', line_width='width')
     _node_kw_trans = dict(node_symbol='symbol', node_size='size',
                           border_color='edge_color', border_width='edge_width')
-    _node_properties = ('symbol',)
+    _node_properties_args = ('symbol',)
 
     def __init__(self, adjacency_mat=None, directed=False, layout=None,
                  animate=False, line_color=None, line_width=None,
@@ -227,7 +227,7 @@ class GraphVisual(CompoundVisual):
         # some attributes should be set as properties
         node_properties = {}
         for k, v in list(node_kwargs.items()):
-            if k in (self._node_properties):
+            if k in (self._node_properties_args):
                 node_properties[k] = node_kwargs.pop(k)
 
         # The actual data is set in GraphVisual.animate_layout or

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -108,6 +108,7 @@ void main()
     // [-e/2-a, -e/2+a] antialising face-edge
     // [-e/2+a, e/2-a] core edge (center 0, diameter e-2a = 2t)
     // [e/2-a, e/2+a] antialising edge-background
+    // use max because we don't want negative transition zone
     float t = max(0.5*v_edgewidth - u_antialias, 0);
     float d = abs(r) - t;
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -601,9 +601,9 @@ class MarkersVisual(Visual):
         symbol : str
             The style of symbol to draw (see Notes).
         size : float or array
-            The symbol size in px.
+            The symbol size in screen (or data, if scaling is on) px.
         edge_width : float | None
-            The width of the symbol outline in pixels.
+            The width of the symbol outline in screen (or data, if scaling is on) px.
         edge_width_rel : float | None
             The width as a fraction of marker size. Exactly one of
             `edge_width` and `edge_width_rel` must be supplied.

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -813,7 +813,7 @@ class MarkersVisual(Visual):
         view.view_program.vert['framebuffer_to_render'] = view.get_transform('framebuffer', 'render')
 
     def _prepare_draw(self, view):
-        if self._symbol is None:
+        if self._data is None or self._symbol is None:
             return False
         view.view_program['u_px_scale'] = view.transforms.pixel_scale
         view.view_program['u_scaling'] = self.scaling

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -5,6 +5,8 @@
 # -----------------------------------------------------------------------------
 """Marker Visual and shader definitions."""
 
+import warnings
+
 import numpy as np
 
 from ..color import ColorArray
@@ -628,7 +630,8 @@ class MarkersVisual(Visual):
         self.freeze()
 
     def set_data(self, pos=None, size=10., edge_width=1., edge_width_rel=None,
-                 edge_color='black', face_color='white'):
+                 edge_color='black', face_color='white',
+                 symbol=None, scaling=None):
         """Set the data used to display this visual.
 
         Parameters
@@ -656,6 +659,17 @@ class MarkersVisual(Visual):
         else:
             if edge_width_rel < 0:
                 raise ValueError('edge_width_rel cannot be negative')
+
+        if scaling is not None:
+            warnings.warn('The scaling parameter is deprecated. Use MarkersVisual.scaling instead',
+                          DeprecationWarning)
+            self.scaling = scaling
+
+        if symbol is not None:
+            warnings.warn('The symbol parameter is deprecated. Use MarkersVisual.symbol instead',
+                          DeprecationWarning)
+            self.symbol = symbol
+
 
         edge_color = ColorArray(edge_color).rgba
         if len(edge_color) == 1:

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -561,11 +561,35 @@ class MarkersVisual(Visual):
 
     Parameters
     ----------
+    pos : array
+        The array of locations to display each symbol.
+    size : float or array
+        The symbol size in screen (or data, if scaling is on) px.
+    edge_width : float or array or None
+        The width of the symbol outline in screen (or data, if scaling is on) px.
+    edge_width_rel : float or array or None
+        The width as a fraction of marker size. Exactly one of
+        `edge_width` and `edge_width_rel` must be supplied.
+    edge_color : Color | ColorArray
+        The color used to draw each symbol outline.
+    face_color : Color | ColorArray
+        The color used to draw each symbol interior.
     symbol : str
         The style of symbol to draw (see Notes).
     scaling : bool
         If set to True, marker scales when rezooming.
-    ...
+    alpha : float
+        The opacity level of the visual.
+    antialias : float
+        Antialiasing amount (in px).
+    spherical : bool
+        Whether to add a spherical effect on the marker using lighting.
+    light_color : Color | ColorArray
+        The color of the light used to create the spherical effect.
+    light_position : array
+        The coordinates of the light used to create the spherical effect.
+    light_ambient : float
+        The amount of ambient light used to create the spherical effect.
 
     Notes
     -----
@@ -573,8 +597,8 @@ class MarkersVisual(Visual):
     vbar, hbar, cross, tailed_arrow, x, triangle_up, triangle_down,
     and star.
     """
-    def __init__(self, symbol='o', scaling=False, light_color='white', light_position=(1, -1, 1),
-                 light_ambient=0.3, alpha=1, antialias=1, spherical=False, **kwargs):
+    def __init__(self, symbol='o', scaling=False, alpha=1, antialias=1, spherical=False,
+                 light_color='white', light_position=(1, -1, 1), light_ambient=0.3, **kwargs):
         self._vbo = VertexBuffer()
         self._marker_fun = None
         self._symbol = None
@@ -613,9 +637,9 @@ class MarkersVisual(Visual):
             The array of locations to display each symbol.
         size : float or array
             The symbol size in screen (or data, if scaling is on) px.
-        edge_width : float | None
+        edge_width : float or array or None
             The width of the symbol outline in screen (or data, if scaling is on) px.
-        edge_width_rel : float | None
+        edge_width_rel : float or array or None
             The width as a fraction of marker size. Exactly one of
             `edge_width` and `edge_width_rel` must be supplied.
         edge_color : Color | ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -738,26 +738,37 @@ class MarkersVisual(Visual):
 
     @property
     def scaling(self):
+        """
+        If set to True, marker scales when rezooming.
+        """
         return self._scaling
 
     @scaling.setter
     def scaling(self, value):
+        value = bool(value)
         self.shared_program['u_scaling'] = value
         self._scaling = value
         self.update()
 
     @property
     def antialias(self):
+        """
+        Antialiasing amount (in px).
+        """
         return self._antialias
 
     @antialias.setter
     def antialias(self, value):
+        value = float(value)
         self.shared_program['u_antialias'] = value
         self._antialias = value
         self.update()
 
     @property
     def light_position(self):
+        """
+        The coordinates of the light used to create the spherical effect.
+        """
         return self._light_position
 
     @light_position.setter
@@ -769,6 +780,9 @@ class MarkersVisual(Visual):
 
     @property
     def light_ambient(self):
+        """
+        The amount of ambient light used to create the spherical effect.
+        """
         return self._light_ambient
 
     @light_ambient.setter
@@ -779,6 +793,9 @@ class MarkersVisual(Visual):
 
     @property
     def light_color(self):
+        """
+        The color of the light used to create the spherical effect.
+        """
         return self._light_color
 
     @light_color.setter
@@ -789,6 +806,9 @@ class MarkersVisual(Visual):
 
     @property
     def alpha(self):
+        """
+        The opacity level of the visual.
+        """
         return self._alpha
 
     @alpha.setter
@@ -799,6 +819,9 @@ class MarkersVisual(Visual):
 
     @property
     def spherical(self):
+        """
+        Whether to add a spherical effect on the marker using lighting.
+        """
         return self._spherical
 
     @spherical.setter

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -670,7 +670,6 @@ class MarkersVisual(Visual):
                           DeprecationWarning)
             self.symbol = symbol
 
-
         edge_color = ColorArray(edge_color).rgba
         if len(edge_color) == 1:
             edge_color = edge_color[0]

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -235,9 +235,9 @@ float clobber(vec2 pointcoord, float size)
 {
     const float PI = 3.14159265358979323846264;
     const float t1 = -PI/2;
-    float circle_size = 0.32 * $v_size;
+    float circle_radius = 0.32 * $v_size;
     float center_shift = 0.36/sqrt3 * $v_size;
-    //total size (horizontal) = 2*circle_size + sqrt3*center_shirt = $v_size
+    //total size (horizontal) = 2*circle_radius + sqrt3*center_shirt = $v_size
     vec2  c1 = vec2(cos(t1),sin(t1))*center_shift;
     const float t2 = t1+2*PI/3;
     vec2  c2 = vec2(cos(t2),sin(t2))*center_shift;
@@ -245,9 +245,9 @@ float clobber(vec2 pointcoord, float size)
     vec2  c3 = vec2(cos(t3),sin(t3))*center_shift;
     //xy is shift to center marker vertically
     vec2 xy = (pointcoord.xy-vec2(0.5,0.5))*size + vec2(0.,-0.25*center_shift);
-    float r1 = length(xy - c1) - circle_size;
-    float r2 = length(xy - c2) - circle_size;
-    float r3 = length(xy - c3) - circle_size;
+    float r1 = length(xy - c1) - circle_radius;
+    float r2 = length(xy - c2) - circle_radius;
+    float r3 = length(xy - c3) - circle_radius;
     float r = min(min(r1,r2),r3);
     return r;
 }
@@ -552,6 +552,7 @@ _marker_dict = {
     '^': triangle_up,
     'v': triangle_down,
     '*': star,
+    'oo': disc,
 }
 marker_types = tuple(sorted(list(_marker_dict.keys())))
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -16,7 +16,8 @@ from .visual import Visual
 vert = """
 uniform float u_antialias;
 uniform float u_px_scale;
-uniform float u_scale;
+uniform bool u_scaling;
+uniform bool u_sphere;
 
 attribute vec3 a_position;
 attribute vec4 a_fg_color;
@@ -27,26 +28,65 @@ attribute float a_size;
 varying vec4 v_fg_color;
 varying vec4 v_bg_color;
 varying float v_edgewidth;
-varying float v_antialias;
+varying float v_depth_middle;
+varying float v_alias_ratio;
+
+float big_float = 1e10; // prevents numerical imprecision
 
 void main (void) {
-    $v_size = a_size * u_px_scale * u_scale;
-    v_edgewidth = a_edgewidth * float(u_px_scale);
-    v_antialias = u_antialias;
     v_fg_color  = a_fg_color;
     v_bg_color  = a_bg_color;
-    gl_Position = $transform(vec4(a_position,1.0));
-    float edgewidth = max(v_edgewidth, 1.0);
-    gl_PointSize = ($v_size) + 4.*(edgewidth + 1.5*v_antialias);
+
+    vec4 pos = vec4(a_position, 1);
+    vec4 fb_pos = $visual_to_framebuffer(pos);
+    gl_Position = $framebuffer_to_render(fb_pos);
+
+    // NOTE: gl_stuff uses framebuffer coords!
+
+    if (u_scaling == true) {
+        // calculate point size from visual to framebuffer coords to determine size
+        vec4 x = $framebuffer_to_visual(fb_pos + vec4(big_float, 0, 0, 0));
+        x = (x - pos);
+        vec4 size_vec = $visual_to_framebuffer(pos + normalize(x) * a_size);
+        $v_size = size_vec.x / size_vec.w - fb_pos.x / fb_pos.w;
+        v_edgewidth = ($v_size / a_size) * a_edgewidth;
+    }
+    else {
+        $v_size = a_size * u_px_scale;
+        v_edgewidth = a_edgewidth * u_px_scale;
+    }
+
+    // gl_PointSize is the diameter
+    gl_PointSize = $v_size + 4. * (v_edgewidth + 1.5 * u_antialias);
+
+    if (u_sphere == true) {
+        // Get the framebuffer z direction relative to this sphere in visual coords
+        vec4 z = $framebuffer_to_visual(fb_pos + vec4(0, 0, big_float, 0));
+        z = (z - pos);
+        // Get the depth of the sphere in its middle point on the screen
+        // size/2 because we need the radius, not the diameter
+        vec4 depth_z_vec = $visual_to_framebuffer(pos + normalize(z) * a_size / 2);
+        v_depth_middle = depth_z_vec.z / depth_z_vec.w - fb_pos.z / fb_pos.w;
+        // size ratio between aliased and non-aliased, needed for correct depth
+        v_alias_ratio = gl_PointSize / $v_size;
+    }
 }
 """
 
 
 frag = """#version 120
+uniform vec3 u_light_position;
+uniform vec3 u_light_color;
+uniform float u_light_ambient;
+uniform float u_alpha;
+uniform float u_antialias;
+uniform bool u_sphere;
+
 varying vec4 v_fg_color;
 varying vec4 v_bg_color;
 varying float v_edgewidth;
-varying float v_antialias;
+varying float v_depth_middle;
+varying float v_alias_ratio;
 
 void main()
 {
@@ -54,68 +94,103 @@ void main()
     if ($v_size <= 0.)
         discard;
 
-    float edgewidth = max(v_edgewidth, 1.0);
     float edgealphafactor = min(v_edgewidth, 1.0);
 
-    float size = $v_size + 4.*(edgewidth + 1.5*v_antialias);
+    float size = $v_size + 4.*(v_edgewidth + 1.5*u_antialias);
     // factor 6 for acute edge angles that need room as for star marker
 
     // The marker function needs to be linked with this shader
     float r = $marker(gl_PointCoord, size);
 
     // it takes into account an antialising layer
-    // of size v_antialias inside the edge
+    // of size u_antialias inside the edge
     // r:
     // [-e/2-a, -e/2+a] antialising face-edge
     // [-e/2+a, e/2-a] core edge (center 0, diameter e-2a = 2t)
     // [e/2-a, e/2+a] antialising edge-background
-    float t = 0.5*v_edgewidth - v_antialias;
+    float t = max(0.5*v_edgewidth - u_antialias, 0);
     float d = abs(r) - t;
 
-    vec4 edgecolor = vec4(v_fg_color.rgb, edgealphafactor*v_fg_color.a);
-
-    if (r > 0.5*v_edgewidth + v_antialias)
+    if (r > 0.5*v_edgewidth + u_antialias)
     {
         // out of the marker (beyond the outer edge of the edge
         // including transition zone due to antialiasing)
         discard;
     }
-    else if (d < 0.0)
+
+    vec4 facecolor = v_bg_color;
+    vec4 edgecolor = vec4(v_fg_color.rgb, edgealphafactor*v_fg_color.a);
+    float depth_change = 0;
+
+    // change color and depth if sphere mode is active
+    if (u_sphere == true) {
+        // multiply by alias_ratio and then clamp, so we're back to non-alias coordinates
+        // and the aliasing ring has the same coordinates as the point just inside,
+        // which is important for lighting
+        vec2 texcoord = (gl_PointCoord * 2 - 1) * v_alias_ratio;
+        float x = clamp(texcoord.x, -1, 1);
+        float y = clamp(texcoord.y, -1, 1);
+        float z = sqrt(clamp(1 - x*x - y*y, 0, 1));
+        vec3 normal = vec3(x, y, z);
+
+        // Diffuse color
+        float diffuse = dot(u_light_position, normal);
+        // clamp, because 0 < theta < pi/2
+        diffuse = clamp(diffuse, 0, 1);
+        vec3 diffuse_color = u_light_ambient + u_light_color * diffuse;
+
+        // Specular color
+        //   reflect light wrt normal for the reflected ray, then
+        //   find the angle made with the eye
+        vec3 eye = vec3(0, 0, -1);
+        float specular = dot(reflect(u_light_position, normal), eye);
+        specular = clamp(specular, 0, 1);
+        // raise to the material's shininess, multiply with a
+        // small factor for spread
+        specular = pow(specular, 80);
+        vec3 specular_color = u_light_color * specular;
+
+        facecolor = vec4(facecolor.rgb * diffuse_color + specular_color, facecolor.a * u_alpha);
+        edgecolor = vec4(edgecolor.rgb * diffuse_color + specular_color, edgecolor.a * u_alpha);
+        // TODO: figure out why this 0.5 is needed, despite already having the radius, not diameter
+        depth_change = -0.5 * z * v_depth_middle;
+    }
+
+    if (d < 0.0)
     {
         // inside the width of the edge
         // (core, out of the transition zone for antialiasing)
         gl_FragColor = edgecolor;
     }
+    else if (v_edgewidth == 0.)
+    {// no edge
+        if (r > -u_antialias)
+        {// outside
+            float alpha = 1.0 + r/u_antialias;
+            alpha = exp(-alpha*alpha);
+            gl_FragColor = vec4(facecolor.rgb, alpha*facecolor.a);
+        }
+        else
+        {// inside
+            gl_FragColor = facecolor;
+        }
+    }
     else
-    {
-        if (v_edgewidth == 0.)
-        {// no edge
-            if (r > -v_antialias)
-            {
-                float alpha = 1.0 + r/v_antialias;
-                alpha = exp(-alpha*alpha);
-                gl_FragColor = vec4(v_bg_color.rgb, alpha*v_bg_color.a);
-            }
-            else
-            {
-                gl_FragColor = v_bg_color;
-            }
+    {// non-zero edge
+        float alpha = d/u_antialias;
+        alpha = exp(-alpha*alpha);
+        if (r > 0.)
+        {
+            // outer part of the edge: fade out into the background...
+            gl_FragColor = vec4(edgecolor.rgb, alpha*edgecolor.a);
         }
         else
         {
-            float alpha = d/v_antialias;
-            alpha = exp(-alpha*alpha);
-            if (r > 0.)
-            {
-                // outer part of the edge: fade out into the background...
-                gl_FragColor = vec4(edgecolor.rgb, alpha*edgecolor.a);
-            }
-            else
-            {
-                gl_FragColor = mix(v_bg_color, edgecolor, alpha);
-            }
+            // inner part of the edge: fade into the face color
+            gl_FragColor = mix(facecolor, edgecolor, alpha);
         }
     }
+    gl_FragDepth = gl_FragCoord.z + depth_change;
 }
 """
 
@@ -160,9 +235,9 @@ float clobber(vec2 pointcoord, float size)
 {
     const float PI = 3.14159265358979323846264;
     const float t1 = -PI/2;
-    float circle_radius = 0.32 * $v_size;
+    float circle_size = 0.32 * $v_size;
     float center_shift = 0.36/sqrt3 * $v_size;
-    //total size (horizontal) = 2*circle_radius + sqrt3*center_shirt = $v_size
+    //total size (horizontal) = 2*circle_size + sqrt3*center_shirt = $v_size
     vec2  c1 = vec2(cos(t1),sin(t1))*center_shift;
     const float t2 = t1+2*PI/3;
     vec2  c2 = vec2(cos(t2),sin(t2))*center_shift;
@@ -170,9 +245,9 @@ float clobber(vec2 pointcoord, float size)
     vec2  c3 = vec2(cos(t3),sin(t3))*center_shift;
     //xy is shift to center marker vertically
     vec2 xy = (pointcoord.xy-vec2(0.5,0.5))*size + vec2(0.,-0.25*center_shift);
-    float r1 = length(xy - c1) - circle_radius;
-    float r2 = length(xy - c2) - circle_radius;
-    float r3 = length(xy - c3) - circle_radius;
+    float r1 = length(xy - c1) - circle_size;
+    float r2 = length(xy - c2) - circle_size;
+    float r3 = length(xy - c3) - circle_size;
     float r = min(min(r1,r2),r3);
     return r;
 }
@@ -465,6 +540,7 @@ _marker_dict = {
     'triangle_up': triangle_up,
     'triangle_down': triangle_down,
     'star': star,
+    'sphere': disc,
     # aliases
     'o': disc,
     '+': cross,
@@ -485,25 +561,36 @@ class MarkersVisual(Visual):
 
     def __init__(self, **kwargs):
         self._vbo = VertexBuffer()
-        self._v_size_var = Variable('varying float v_size')
         self._symbol = None
         self._marker_fun = None
         self._data = None
-        self.antialias = 1
-        self.scaling = False
+        self._scaling = None
+        self._antialias = None
+        self._light_color = None
+        self._light_ambient = None
+        self._light_position = None
+        self._alpha = None
+        self._v_size_var = Variable('varying float v_size')
+
         Visual.__init__(self, vcode=vert, fcode=frag)
+
         self.shared_program.vert['v_size'] = self._v_size_var
         self.shared_program.frag['v_size'] = self._v_size_var
+        self.shared_program['u_sphere'] = False
+
         self.set_gl_state(depth_test=True, blend=True,
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
         self._draw_mode = 'points'
+
         if len(kwargs) > 0:
             self.set_data(**kwargs)
+
         self.freeze()
 
     def set_data(self, pos=None, symbol='o', size=10., edge_width=1.,
                  edge_width_rel=None, edge_color='black', face_color='white',
-                 scaling=False):
+                 scaling=False, light_color='white', light_position=(1, -1, 1),
+                 light_ambient=0.3, alpha=1, antialias=1):
         """Set the data used to display this visual.
 
         Parameters
@@ -541,8 +628,14 @@ class MarkersVisual(Visual):
         else:
             if edge_width_rel < 0:
                 raise ValueError('edge_width_rel cannot be negative')
+
         self.symbol = symbol
         self.scaling = scaling
+        self.antialias = antialias
+        self.light_color = light_color
+        self.light_position = light_position
+        self.light_ambient = light_ambient
+        self.alpha = alpha
 
         edge_color = ColorArray(edge_color).rgba
         if len(edge_color) == 1:
@@ -567,10 +660,9 @@ class MarkersVisual(Visual):
             if edge_width is not None:
                 data['a_edgewidth'] = edge_width
             else:
-                data['a_edgewidth'] = size*edge_width_rel
+                data['a_edgewidth'] = size * edge_width_rel
             data['a_position'][:, :pos.shape[1]] = pos
             data['a_size'] = size
-            self.shared_program['u_antialias'] = self.antialias  # XXX make prop
             self._data = data
             if self._symbol is not None:
                 # If we have no symbol set, we skip drawing (_prepare_draw
@@ -609,23 +701,83 @@ class MarkersVisual(Visual):
             self._marker_fun = Function(_marker_dict[symbol])
             self._marker_fun['v_size'] = self._v_size_var
             self.shared_program.frag['marker'] = self._marker_fun
+            if symbol == 'sphere':
+                self.shared_program['u_sphere'] = True
+            else:
+                self.shared_program['u_sphere'] = False
+        self.update()
+
+    @property
+    def scaling(self):
+        return self._scaling
+
+    @scaling.setter
+    def scaling(self, value):
+        self.shared_program['u_scaling'] = value
+        self._scaling = value
+        self.update()
+
+    @property
+    def antialias(self):
+        return self._antialias
+
+    @antialias.setter
+    def antialias(self, value):
+        self.shared_program['u_antialias'] = value
+        self._antialias = value
+        self.update()
+
+    @property
+    def light_position(self):
+        return self._light_position
+
+    @light_position.setter
+    def light_position(self, value):
+        value = np.array(value)
+        self.shared_program['u_light_position'] = value / np.linalg.norm(value)
+        self._light_position = value
+        self.update()
+
+    @property
+    def light_ambient(self):
+        return self._light_ambient
+
+    @light_ambient.setter
+    def light_ambient(self, value):
+        self.shared_program['u_light_ambient'] = value
+        self._light_ambient = value
+        self.update()
+
+    @property
+    def light_color(self):
+        return self._light_color
+
+    @light_color.setter
+    def light_color(self, value):
+        self.shared_program['u_light_color'] = ColorArray(value).rgb
+        self._light_color = value
+        self.update()
+
+    @property
+    def alpha(self):
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, value):
+        self.shared_program['u_alpha'] = value
+        self._alpha = value
         self.update()
 
     def _prepare_transforms(self, view):
-        xform = view.transforms.get_transform()
-        view.view_program.vert['transform'] = xform
+        view.view_program.vert['visual_to_framebuffer'] = view.get_transform('visual', 'framebuffer')
+        view.view_program.vert['framebuffer_to_visual'] = view.get_transform('framebuffer', 'visual')
+        view.view_program.vert['framebuffer_to_render'] = view.get_transform('framebuffer', 'render')
 
     def _prepare_draw(self, view):
         if self._symbol is None:
             return False
         view.view_program['u_px_scale'] = view.transforms.pixel_scale
-        if self.scaling:
-            tr = view.transforms.get_transform('visual', 'document').simplified
-            mat = tr.map(np.eye(3)) - tr.map(np.zeros((3, 3)))
-            scale = np.linalg.norm(mat[:, :3])
-            view.view_program['u_scale'] = scale
-        else:
-            view.view_program['u_scale'] = 1
+        view.view_program['u_scaling'] = self.scaling
 
     def _compute_bounds(self, axis, view):
         pos = self._data['a_position']


### PR DESCRIPTION
Turns out getting #2204 into the `Markers` visual was doable. This is an alternative implementation of that PR: ~instead of creating a new visual, I used the infrastructure of `Markers` and added another symbol called `sphere`. In pratice, this symbol uses the same cropping function as `disc`, but adds all the lighting stuff that #2204 introduced.~

This implements a `spherical` attribute in the `MarkersVisual` that add a sphere-like shading to the markers. It's applicable to all the symbols, but particularly useful with `disc`, because it results in depth-correct spheres.

Due to the significant changes to the shaders, this PR would in practice also supersede #2198.

This is the render from the added example:

https://user-images.githubusercontent.com/23482191/133228329-f1bc3482-dac5-40a7-ac3d-8c6ba036b211.mp4

## Differences
- ~Compared to the other implementation, this shoudl make it easier for people to convert markers into spheres. However, some minor changes to the api might be introduced. Nothing is exactly breaking, but since marker sizes were inconsistent between scaling and non-scaling mode, some examples might break, especially due to the performance issue when zoomed in a lot.~
- This PR also has antialiasing (albeit ugly when markers overlap, see #2208).
- Due to using markers, this PR also allows to show an `edge`.

## Questions
- I'm not a huge fan of how `set_data` reinitializes everything unless specified. This means that to update one parameter we need to pass all the previous values manually. Should I split out some things from it (e.g: anything "global"?). My feeling is that the default should be that nothing gets changed (all `None`?)
- antialias is kind of ok in 2D, if not many points overlap, but is basically unusable in 3D. Should we default to off until #2039 is merged? 