### PR TITLE
Fix "Edit this page" links for API docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'sdl2': ['PySDL2'],
         'wx': ['wxPython'],
         'tk': ['pyopengltk'],
-        'doc': ['pydata-sphinx-theme', 'numpydoc', 'sphinxcontrib-apidoc'],
+        'doc': ['pydata-sphinx-theme', 'numpydoc', 'sphinxcontrib-apidoc', 'sphinx-gallery'],
         'io': ['meshio', 'Pillow'],
     },
     packages=find_packages(exclude=['make']),


### PR DESCRIPTION
See #2219 for where this issue was first discovered. The summary is that the sphinx site shows "Edit this page" buttons on the right which leads to a GitHub edit page for that particular `.rst` document in the repository. This doesn't work for our API docs as they are dynamically generated and don't live in the repository. This PR does two things:

1. Removes the old `linkcode` logic to point to the external source files. This was used when the docs and code repos were separate, but now that they are one the links should just work.
2. Adds some hacky custom URL stuff to the pydata-sphinx-theme context so that when the file being referenced is an API document then generate a different URL for it that points to the actual python source.