### PR TITLE
Remove "Jupyter Widget" section part

### DIFF
--- a/doc/dev_guide/contributor_guide.rst
+++ b/doc/dev_guide/contributor_guide.rst
@@ -239,8 +239,8 @@ Which will attempt to run all example scripts.
   "one truth" for passing tests until tests are made more flexible for
   differences in systems.
 
-Sphinx Documentation and Jupyter Widget
----------------------------------------
+Sphinx Documentation
+--------------------
 
 VisPy's documentation website is a `Sphinx <https://www.sphinx-doc.org/>`_
 project stored in the "doc" directory of the repository. To generate the


### PR DESCRIPTION
Noticed while helping with #2232 that the "and Jupyter Widget" isn't needed. It was moved to its own section below this section.

...gotta get those hacktoberfest PRs. :wink: 