### PR TITLE
Remove unnecessary if clauses from Volume

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -953,11 +953,6 @@ class VolumeVisual(Visual):
             raise ValueError('Volume render method should be in %r, not %r' %
                              (known_methods, method))
         self._method = method
-        # Get rid of specific variables - they may become invalid
-        if 'u_threshold' in self.shared_program:
-            self.shared_program['u_threshold'] = None
-        if 'u_attenuation' in self.shared_program:
-            self.shared_program['u_attenuation'] = None
 
         # $sample needs to be unset and re-set, since it's present inside the snippets.
         #       Program should probably be able to do this automatically
@@ -1003,8 +998,7 @@ class VolumeVisual(Visual):
     @threshold.setter
     def threshold(self, value):
         self._threshold = float(value)
-        if 'u_threshold' in self.shared_program:
-            self.shared_program['u_threshold'] = self._threshold
+        self.shared_program['u_threshold'] = self._threshold
         self.update()
 
     @property
@@ -1015,8 +1009,7 @@ class VolumeVisual(Visual):
     @attenuation.setter
     def attenuation(self, value):
         self._attenuation = float(value)
-        if 'u_attenuation' in self.shared_program:
-            self.shared_program['u_attenuation'] = self._attenuation
+        self.shared_program['u_attenuation'] = self._attenuation
         self.update()
 
     @property


### PR DESCRIPTION
Over at napari we're trying to migrate to the latest vispy. This brought up a strange bug that we noticed in the past and fixed by removing the if clause in the attenuation propertysetter (as I did in this PR). [Here's a breakdown of the bug](https://github.com/napari/napari/pull/3494#issuecomment-948661318), which is odd; my best guess is that it's caused by some events being fired in the wrong order in napari.

While we're not sure yet on why the bug arises, we can fix it by removing this if clause. As far as I can tell, it serves no purpose in vispy either:
- `u_attenuation` is always defined, since it's hardcoded in the shader, so setting it can never fail
- setting it it does not trigger recompilation, so it has no performance cost

I thought I'd create a PR here to see if anything fails, and what people think. If this can't work out here, we can always patch the method in napari.