### PR TITLE
Noop on clicking both mouse buttons

### DIFF
--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -214,6 +214,8 @@ class Base3DRotationCamera(PerspectiveCamera):
         elif event.type == 'mouse_move':
             if event.press_event is None:
                 return
+            if 1 in event.buttons and 2 in event.buttons:
+                return
 
             modifiers = event.mouse_event.modifiers
             p1 = event.mouse_event.press_event.pos


### PR DESCRIPTION
Small change to 3D cameras mouse event callback to prevent firing a million warnings when accidentally pressing both right and left mouse buttons: napari/napari#3518.

I'm not sure if we prefer a noop (as I did in this PR) or just ignoring the second click, though the second option requires a bit more refactoring I think.