### PR TITLE
Update clims in color transform whenever texture._data_limits changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -252,7 +252,7 @@ jobs:
           export DISPLAY=:99.0
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then
-          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so;
+          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa.so;
           export VISPY_GL_LIB=$OSMESA_LIBRARY
         fi
         micromamba list
@@ -270,7 +270,7 @@ jobs:
           make examples
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then
-          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so
+          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa.so
           export VISPY_GL_LIB=$OSMESA_LIBRARY
           make osmesa
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -252,7 +252,7 @@ jobs:
           export DISPLAY=:99.0
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then
-          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa.so;
+          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so;
           export VISPY_GL_LIB=$OSMESA_LIBRARY
         fi
         micromamba list
@@ -270,7 +270,7 @@ jobs:
           make examples
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then
-          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa.so
+          export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so
           export VISPY_GL_LIB=$OSMESA_LIBRARY
           make osmesa
         fi

--- a/ci/requirements/linux_osmesa_deps_conda.txt
+++ b/ci/requirements/linux_osmesa_deps_conda.txt
@@ -1,7 +1,7 @@
 coveralls
 cython
 libglu
-mesalib
+mesalib <21.0.0
 meshio
 numpy
 pillow

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -276,6 +276,10 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
             raise RuntimeError("Can't return 'auto' normalized color limits "
                                "until data has been set. Call "
                                "'scale_and_set_data' first.")
+        if self._data_limits is None:
+            raise RuntimeError("Can't return normalized color limits until "
+                               "data has been set. Call "
+                               "'scale_and_set_data' first.")
 
         range_min, range_max = self._data_limits
         clim_min, clim_max = self.clim

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -125,6 +125,10 @@ class _ScaledTextureMixin:
             raise RuntimeError("Can't return 'auto' normalized color limits "
                                "until data has been set. Call "
                                "'scale_and_set_data' first.")
+        if self._data_dtype is None:
+            raise RuntimeError("Can't return normalized color limits until "
+                               "data has been set. Call "
+                               "'scale_and_set_data' first.")
         if self.clim[0] == self.clim[1]:
             return self.clim[0], np.inf
         # if the internalformat of the texture is normalized we need to

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -530,13 +530,11 @@ class ImageVisual(Visual):
         # new color limits need to be assigned if the normalized clims changed
         # otherwise, the original color transform should be fine
         # Note that this assumes that if clim changed, clim_normalized changed
-        new_if = post_internalformat != pre_internalformat
-        new_cl = post_lims != pre_lims
-        if not new_if and new_cl and not self._need_colortransform_update:
+        if post_internalformat != pre_internalformat:
+            self._need_colortransform_update = True
+        elif post_lims != pre_lims and not self._need_colortransform_update:
             # shortcut so we don't have to rebuild the whole color transform
             self.shared_program.frag['color_transform'][1]['clim'] = self._texture.clim_normalized
-        elif new_if:
-            self._need_colortransform_update = True
         self._need_texture_upload = False
 
     def _compute_bounds(self, axis, view):

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -527,7 +527,7 @@ class ImageVisual(Visual):
         post_lims = getattr(self._texture, '_data_limits', None)
         post_internalformat = self._texture.internalformat
         # color transform needs rebuilding if the internalformat was changed
-        # new color limits need to be assigned if the normalized clims changed
+        # new color limits need to be assigned if the texture data limits changed
         # otherwise, the original color transform should be fine
         # Note that this assumes that if clim changed, clim_normalized changed
         if post_internalformat != pre_internalformat:

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -528,7 +528,7 @@ class ImageVisual(Visual):
         # new color limits need to be assigned if the data limits of the texture changed
         # otherwise, the original color transform should be fine
         # Note that this assumes that if clim changed, clim_normalized changed
-        if  self._texture.internalformat != pre_internalformat:
+        if self._texture.internalformat != pre_internalformat:
             self._need_colortransform_update = True
         elif self._texture._data_limits != pre_lims and not self._need_colortransform_update:
             # shortcut so we don't have to rebuild the whole color transform

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -521,18 +521,22 @@ class ImageVisual(Visual):
         self._prepare_transforms(view)
 
     def _build_texture(self):
-        pre_lims = self._texture._data_limits
+        pre_lims = getattr(self._texture, '_data_limits', None)
         pre_internalformat = self._texture.internalformat
         self._texture.scale_and_set_data(self._data)
+        post_lims = getattr(self._texture, '_data_limits', None)
+        post_internalformat = self._texture.internalformat
         # color transform needs rebuilding if the internalformat was changed
-        # new color limits need to be assigned if the data limits of the texture changed
+        # new color limits need to be assigned if the normalized clims changed
         # otherwise, the original color transform should be fine
         # Note that this assumes that if clim changed, clim_normalized changed
-        if self._texture.internalformat != pre_internalformat:
-            self._need_colortransform_update = True
-        elif self._texture._data_limits != pre_lims and not self._need_colortransform_update:
+        new_if = post_internalformat != pre_internalformat
+        new_cl = post_lims != pre_lims
+        if not new_if and new_cl and not self._need_colortransform_update:
             # shortcut so we don't have to rebuild the whole color transform
             self.shared_program.frag['color_transform'][1]['clim'] = self._texture.clim_normalized
+        elif new_if:
+            self._need_colortransform_update = True
         self._need_texture_upload = False
 
     def _compute_bounds(self, axis, view):

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -5,8 +5,6 @@
 
 from __future__ import division
 
-import contextlib
-
 import numpy as np
 
 from ..gloo import Texture2D, VertexBuffer
@@ -523,15 +521,18 @@ class ImageVisual(Visual):
         self._prepare_transforms(view)
 
     def _build_texture(self):
+        pre_lims = self._texture._data_limits
         pre_internalformat = self._texture.internalformat
         self._texture.scale_and_set_data(self._data)
         # color transform needs rebuilding if the internalformat was changed
-        # otherwise just update the color transform clims
-        if self._texture.internalformat != pre_internalformat:
+        # new color limits need to be assigned if the data limits of the texture changed
+        # otherwise, the original color transform should be fine
+        # Note that this assumes that if clim changed, clim_normalized changed
+        if  self._texture.internalformat != pre_internalformat:
             self._need_colortransform_update = True
-        else:
-            with contextlib.suppress(KeyError):  # if the shared_program isn't created yet.
-                self.shared_program.frag['color_transform'][1]['clim'] = self._texture.clim_normalized
+        elif self._texture._data_limits != pre_lims and not self._need_colortransform_update:
+            # shortcut so we don't have to rebuild the whole color transform
+            self.shared_program.frag['color_transform'][1]['clim'] = self._texture.clim_normalized
         self._need_texture_upload = False
 
     def _compute_bounds(self, axis, view):

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -526,7 +526,7 @@ class ImageVisual(Visual):
         pre_internalformat = self._texture.internalformat
         self._texture.scale_and_set_data(self._data)
         # color transform needs rebuilding if the internalformat was changed
-        # otherwise just update the whole color transform clims
+        # otherwise just update the color transform clims
         if self._texture.internalformat != pre_internalformat:
             self._need_colortransform_update = True
         else:

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -264,20 +264,28 @@ def test_image_vertex_updates():
 
 
 @requires_application()
-def test_change_clim_float():
-    """
-    Test that with an image of floats, clim is correctly set from the first try
+@pytest.mark.parametrize(
+    ("dtype", "init_clim"),
+    [
+        (np.float32, "auto"),
+        (np.float32, (0, 5)),
+        (np.uint8, "auto"),
+        (np.uint8, (0, 5)),
+    ]
+)
+def test_change_clim_float(dtype, init_clim):
+    """Test that with an image of floats, clim is correctly set from the first try.
 
-    see https://github.com/vispy/vispy/pull/2245
+    See https://github.com/vispy/vispy/pull/2245.
     """
     size = (40, 40)
     np.random.seed(0)
-    data = np.random.rand(*size) * 100
+    data = (np.random.rand(*size) * 100).astype(dtype)
 
     with TestingCanvas(size=size[::-1], bgcolor="w") as c:
-        image = Image(data=data, parent=c.scene)
+        image = Image(data=data, clim=init_clim, parent=c.scene)
 
-        # needed to properly initalize the canvas
+        # needed to properly initialize the canvas
         c.render()
 
         image.clim = 0, 10


### PR DESCRIPTION
fixes #2229.

looks like the `if not new_if and new_cl and not self._need_colortransform_update:` conditional in the current `_build_texture` method is a little too strict.   Back in https://github.com/vispy/vispy/pull/1911, we fully updated the color transform whenever the image texture was rebuilt.  #1920 tried to make that a little more performant, by only updating when necessary, but it looks like the heuristic isn't perfect.  This is somewhere in the middle, only rebuilding the color transform when the internal format has changed, otherwise updating the texture clims stored in the color transform (which have likely changed during the `scale_and_set_data` call)

with the time available, I wasn't able to determine a better way to _know_ for certain whether those texture clims have changed.  but that could perhaps be a future improvement.  As is, updating `self.shared_program.frag['color_transform'][1]['clim']` took 10s of microseconds on my computer... which is probably a fraction of the cost of the full `_build_texture` method anyway.

cc @brisvag