### PR TITLE
[WIP] Remove border from central widget

### DIFF
--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -168,7 +168,7 @@ class SceneCanvas(app.Canvas, Frozen):
         canvas.
         """
         if self._central_widget is None:
-            self._central_widget = Widget(size=self.size, parent=self.scene)
+            self._central_widget = Widget(size=self.size, parent=self.scene, border_width=0)
         return self._central_widget
 
     @property


### PR DESCRIPTION
This makes the `border_width` of `SceneCanvas.central_widget` 0. By default a `Widget`'s border width is 1, which probably makes sense for things like `Grid` and `ViewBox`, but maybe less sense for `Widget.central_widget` (though feel free to correct my understanding here!). The other problem is that `central_widget` is a property, so there's no way to pass through a `border_width` like in the constructor of `Widget` or in something like `Widget.add_view`.

The issue fixed by this PR originally came up in [#3357 on napari](https://github.com/napari/napari/issues/3357), though it was easy enough to workaround by overriding `SceneCanvas.central_widget` in napari's `VispyCanvas`.

I marked this as WIP mostly because I'm new to vispy and don't have much confidence in my changes yet.