### PR TITLE
Use stacklevel in DeprecationWarnings.

### DIFF
--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -105,9 +105,12 @@ class BaseTexture(GLObject):
         GLObject.__init__(self)
         if resizeable is not None:
             resizable = resizeable
-            warnings.warn('resizeable has been deprecated in favor of '
-                          'resizable and will be removed next release',
-                          DeprecationWarning)
+            warnings.warn(
+                "resizeable has been deprecated in favor of "
+                "resizable and will be removed next release",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Init shape and format
         self._resizable = True  # at least while we're in init

--- a/vispy/visuals/cube.py
+++ b/vispy/visuals/cube.py
@@ -30,7 +30,7 @@ class CubeVisual(BoxVisual):
     def __init__(self, size=1.0, vertex_colors=None, face_colors=None,
                  color=(0.5, 0.5, 1, 1), edge_color=None, **kwargs):
         warnings.warn("The CubeVisual is deprecated in favor of BoxVisual",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         if isinstance(size, tuple):
             width, height, depth = size
         else:

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -681,13 +681,19 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if scaling is not None:
-            warnings.warn('The scaling parameter is deprecated. Use MarkersVisual.scaling instead',
-                          DeprecationWarning)
+            warnings.warn(
+                "The scaling parameter is deprecated. Use MarkersVisual.scaling instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.scaling = scaling
 
         if symbol is not None:
-            warnings.warn('The symbol parameter is deprecated. Use MarkersVisual.symbol instead',
-                          DeprecationWarning)
+            warnings.warn(
+                "The symbol parameter is deprecated. Use MarkersVisual.symbol instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.symbol = symbol
 
         edge_color = ColorArray(edge_color).rgba


### PR DESCRIPTION
That give the correct location most of the time for where the fix/update
should be instead of pointing into vispy codebase.

That make updates by consumer easier (and thus more likely),
And in turn should make you more confident about removing deprecated
things.