### PR TITLE
Fix MeshNormals and WireframeFilter with empty MeshData

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -61,6 +61,13 @@ You can also use a Jupyter notebook with visualizations appearing inline with th
 
    You only need to have one of these packages, no need to install them all!
 
+Optional dependencies
+=====================
+
+VisPy has various optional dependencies to support features that may not be relevant for all users. The below is a list of dependencies that you may want to install to use the functionality mentioned.
+
+* **pillow**: Pillow (imported as PIL) is used to read image files. Some VisPy examples will use Pillow to load the image data that will then be shown by VisPy.
+
 Hardware requirements
 =====================
 

--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -654,3 +654,6 @@ class MeshData(object):
             if isinstance(state[k], list):
                 state[k] = np.array(state[k])
             setattr(self, k, state[k])
+
+    def is_empty(self):
+        return self._faces is None

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -721,8 +721,10 @@ class WireframeFilter(Filter):
         self.fshader['width'] = self._width
         self.fshader['wireframe_only'] = 1 if self._wireframe_only else 0
         self.fshader['faces_only'] = 1 if self._faces_only else 0
-        faces = self._visual.mesh_data.get_faces()
-        n_faces = len(faces)
+        if self._visual.mesh_data.is_empty():
+            n_faces = 0
+        else:
+            n_faces = len(self._visual.mesh_data.get_faces())
         bc = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype='float')
         bc = np.tile(bc[None, ...], (n_faces, 1, 1))
         self._bc.set_data(bc, convert=True)

--- a/vispy/visuals/filters/tests/__init__.py
+++ b/vispy/visuals/filters/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*- 
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.

--- a/vispy/visuals/filters/tests/test_wireframe_filter.py
+++ b/vispy/visuals/filters/tests/test_wireframe_filter.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from vispy.visuals.mesh import Mesh
+from vispy.visuals.mesh import MeshVisual
 from vispy.visuals.filters import WireframeFilter
 
 
 def test_empty_mesh_wireframe():
     """Test that an empty mesh does not cause issues with wireframe filter"""
-    mesh = Mesh()
+    mesh = MeshVisual()
     wf = WireframeFilter()
     mesh.attach(wf)
 

--- a/vispy/visuals/filters/tests/test_wireframe_filter.py
+++ b/vispy/visuals/filters/tests/test_wireframe_filter.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*- 
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
 from vispy.visuals.mesh import MeshVisual
 from vispy.visuals.filters import WireframeFilter

--- a/vispy/visuals/filters/tests/test_wireframe_filter.py
+++ b/vispy/visuals/filters/tests/test_wireframe_filter.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from vispy.visuals.mesh import Mesh
+from vispy.visuals.filters import WireframeFilter
+
+
+def test_empty_mesh_wireframe():
+    """Test that an empty mesh does not cause issues with wireframe filter"""
+    mesh = Mesh()
+    wf = WireframeFilter()
+    mesh.attach(wf)
+
+    # trigger update of filter
+    wf.enabled = True

--- a/vispy/visuals/mesh_normals.py
+++ b/vispy/visuals/mesh_normals.py
@@ -74,7 +74,7 @@ class MeshNormalsVisual(LineVisual):
     >>> MeshNormalsVisual(..., length_method='max_extent', length_scale=0.1)
     """
 
-    def __init__(self, meshdata, primitive='face', length=None,
+    def __init__(self, meshdata=None, primitive='face', length=None,
                  length_method='median_edge', length_scale=1.0, **kwargs):
         self._previous_meshdata = None
         super().__init__(connect='segments')
@@ -106,7 +106,7 @@ class MeshNormalsVisual(LineVisual):
         if meshdata is None:
             meshdata = self._previous_meshdata
 
-        if meshdata.is_empty():
+        if meshdata is None or meshdata.is_empty():
             normals = None
         elif primitive == 'face':
             normals = meshdata.get_face_normals()

--- a/vispy/visuals/mesh_normals.py
+++ b/vispy/visuals/mesh_normals.py
@@ -103,25 +103,21 @@ class MeshNormalsVisual(LineVisual):
             Extra arguments to define the appearance of lines. Refer to
             :class:`~vispy.visuals.line.line.LineVisual`.
         """
-        if primitive not in ('face', 'vertex'):
-            raise ValueError('primitive must be "face" or "vertex", got %s'
-                             % primitive)
-        # remove connect from kwargs to make sure we don't change it
-        kwargs.pop('connect', None)
-
         if meshdata is None:
             meshdata = self._previous_meshdata
 
-        if primitive == 'face':
-            if meshdata._faces is None:
-                normals = None
-            else:
-                normals = meshdata.get_face_normals()
+        if meshdata.is_empty():
+            normals = None
+        elif primitive == 'face':
+            normals = meshdata.get_face_normals()
         elif primitive == 'vertex':
-            if meshdata._vertices is None:
-                normals = None
-            else:
-                normals = meshdata.get_vertex_normals()
+            normals = meshdata.get_vertex_normals()
+        else:
+            raise ValueError('primitive must be "face" or "vertex", got %s'
+                             % primitive)
+
+        # remove connect from kwargs to make sure we don't change it
+        kwargs.pop('connect', None)
 
         if normals is None:
             super().set_data(pos=np.empty((0, 3), dtype=np.float32), connect='segments', **kwargs)

--- a/vispy/visuals/mesh_normals.py
+++ b/vispy/visuals/mesh_normals.py
@@ -76,14 +76,59 @@ class MeshNormalsVisual(LineVisual):
 
     def __init__(self, meshdata, primitive='face', length=None,
                  length_method='median_edge', length_scale=1.0, **kwargs):
+        self._previous_meshdata = None
+        super().__init__(connect='segments')
+        self.set_data(meshdata, primitive, length, length_method, length_scale, **kwargs)
+
+    def set_data(self, meshdata=None, primitive='face', length=None,
+                 length_method='median_edge', length_scale=1.0, **kwargs):
+        """Set the data used to draw this visual
+
+        Parameters
+        ----------
+        meshdata : instance of :class:`~vispy.geometry.meshdata.MeshData`
+            The mesh data.
+        primitive : {'face', 'vertex'}
+            The primitive type on which to compute and display the normals.
+        length : None or float or array-like, optional
+            The length(s) of the normals. If None, the length is computed with
+            `length_method`.
+        length_method : {'median_edge', 'max_extent'}, default='median_edge'
+            The method to compute the length of the normals (when `length=None`).
+            Methods: 'median_edge', the median edge length; 'max_extent', the
+            maximum side length of the bounding box of the mesh.
+        length_scale : float, default=1.0
+            A scale factor applied to the length computed with `length_method`.
+        **kwargs : dict, optional
+            Extra arguments to define the appearance of lines. Refer to
+            :class:`~vispy.visuals.line.line.LineVisual`.
+        """
         if primitive not in ('face', 'vertex'):
             raise ValueError('primitive must be "face" or "vertex", got %s'
                              % primitive)
+        # remove connect from kwargs to make sure we don't change it
+        kwargs.pop('connect', None)
+
+        if meshdata is None:
+            meshdata = self._previous_meshdata
 
         if primitive == 'face':
-            normals = meshdata.get_face_normals()
+            if meshdata._faces is None:
+                normals = None
+            else:
+                normals = meshdata.get_face_normals()
         elif primitive == 'vertex':
-            normals = meshdata.get_vertex_normals()
+            if meshdata._vertices is None:
+                normals = None
+            else:
+                normals = meshdata.get_vertex_normals()
+
+        if normals is None:
+            super().set_data(pos=np.empty((0, 3), dtype=np.float32), connect='segments', **kwargs)
+            return
+
+        self._previous_meshdata = meshdata
+
         norms = np.sqrt((normals ** 2).sum(axis=-1, keepdims=True))
         unit_normals = normals / norms
 
@@ -115,4 +160,4 @@ class MeshNormalsVisual(LineVisual):
         ends = origins + length * unit_normals
         segments = np.hstack((origins, ends)).reshape(-1, 3)
 
-        LineVisual.__init__(self, pos=segments, connect='segments', **kwargs)
+        super().set_data(pos=segments, connect='segments', **kwargs)

--- a/vispy/visuals/tests/test_mesh_normals.py
+++ b/vispy/visuals/tests/test_mesh_normals.py
@@ -211,13 +211,8 @@ def test_mesh_normals_length_method(length_method):
 
 
 def test_mesh_normals_empty():
-    size = (45, 40)
-    with TestingCanvas(size=size, bgcolor="k") as c:
-        v = c.central_widget.add_view(border_width=0)
-        # Create visual.
-        mesh = scene.visuals.Mesh()
-        v.add(mesh)
-        scene.visuals.MeshNormals(mesh.mesh_data)
+    mesh = scene.visuals.Mesh()
+    scene.visuals.MeshNormals(mesh.mesh_data)
 
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_mesh_normals.py
+++ b/vispy/visuals/tests/test_mesh_normals.py
@@ -210,4 +210,14 @@ def test_mesh_normals_length_method(length_method):
         _ = c.render()
 
 
+def test_mesh_normals_empty():
+    size = (45, 40)
+    with TestingCanvas(size=size, bgcolor="k") as c:
+        v = c.central_widget.add_view(border_width=0)
+        # Create visual.
+        mesh = scene.visuals.Mesh()
+        v.add(mesh)
+        scene.visuals.MeshNormals(mesh.mesh_data)
+
+
 run_tests_if_main()


### PR DESCRIPTION
When MeshNormal is provided an empty `MeshData` object, all sorts of issues arise, crashing the program. This is especially problematic if one wants to automatically update a `MeshNormals` based on a `Mesh`, which is totally fine with empty data.

I tried fixing this by making the methods in `MeshData` used by `MeshNormals` (such as `get_vertex_normals`) more resilient, but I encountered all sorts of issues. The most straight forward way to solve it ended up being this.

As an added bonus, this PR allows to use `set_data` to update properties of the `MeshNormals` object which are not accounted for by the `LineVisual` (for example, `length`).

~It's missing some tests, but it should be funcional.~

EDT: I added a similar check for `WireframeFilter`, which was failing when `_update_data` was getting triggered (for example by setting `enabled = True`) if `MeshData` was empty. Added a test for this which fails on main.