### PR TITLE
Add typing to `create_visual_node`

### DIFF
--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -18,6 +18,10 @@ import weakref
 from .. import visuals
 from .node import Node
 from ..visuals.filters import Alpha, PickingFilter
+from typing import TypeVar
+
+
+_T = TypeVar("_T")
 
 
 class VisualNode(Node):
@@ -99,7 +103,7 @@ class VisualNode(Node):
         self._visual_superclass.draw(self)
 
 
-def create_visual_node(subclass):
+def create_visual_node(subclass: _T) -> _T:
     # Create a new subclass of Node.
 
     # Decide on new class name


### PR DESCRIPTION
small change that makes it much easier to work with vispy classes in an IDE.

currently, since `create_visual_node` dynamically creates a type, you pretty much lose all type hinting and autocompletion in an IDE when working with visual nodes. 

<img width="126" alt="Untitled3" src="https://user-images.githubusercontent.com/1609449/143775736-bed66f2e-db25-448d-a566-ac3445641299.png">

With this change, you at least retain the methods and constructor on the corresponding Visual, (though, due to the dynamic type creation, it's still not possible to retain the merged attributes of both the `VisualNode` and the underlying `Visual`).

<img width="547" alt="Untitled1" src="https://user-images.githubusercontent.com/1609449/143775807-3e267c46-9ee0-40fa-a829-474b25006685.png">

<img width="478" alt="Untitled2" src="https://user-images.githubusercontent.com/1609449/143775813-2cd543b9-353d-442e-b34d-b04f91bce471.png">

