### PR TITLE
MNT: add documentation of usage of Triangle/triangle, see #1029

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
         sudo apt-get update;
         cat ci/requirements/linux_full_deps_apt.txt | xargs sudo apt-get -y install
         # Additional latex dependencies
-        sudo apt-get -y install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+        sudo apt-get -y install texlive-latex-base texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
         sudo apt-get -y install dvipng
         # Start xvfb daemon
         export DISPLAY=:99.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,11 +49,19 @@ apidoc_separate_modules = True
 
 # Sphinx Gallery
 from sphinx_gallery.sorting import FileNameSortKey
+
+# the following files are ignored from gallery processing
+ignore_files = ['plotting/export.py',
+                'gloo/geometry_shader.py',
+                ]
+ignore_pattern_regex = [re.escape(os.sep) + f for f in ignore_files]
+ignore_pattern_regex = "|".join(ignore_pattern_regex)
+
 sphinx_gallery_conf = {
     'examples_dirs': ['../examples/gloo', '../examples/scene', '../examples/plotting'],
     'gallery_dirs': ['gallery/gloo', 'gallery/scene', 'gallery/plotting'],
     'filename_pattern': re.escape(os.sep),
-    'ignore_pattern': re.escape(os.sep) + 'plotting/export.py',
+    'ignore_pattern': ignore_pattern_regex,
     'only_warn_on_example_error': True,
     'image_scrapers': ('vispy',),
     'reset_modules': tuple(),  # remove default matplotlib/seaborn resetters

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -67,6 +67,7 @@ Optional dependencies
 VisPy has various optional dependencies to support features that may not be relevant for all users. The below is a list of dependencies that you may want to install to use the functionality mentioned.
 
 * **pillow**: Pillow (imported as PIL) is used to read image files. Some VisPy examples will use Pillow to load the image data that will then be shown by VisPy.
+* **triangle**: `Triangle <https://www.cs.cmu.edu/~quake/triangle.html>`_ is used via it's Python bindings package `triangle <https://github.com/drufat/triangle>`_. Please acknowledge and adhere to the licensing terms of both packages. Within VisPy `triangle`, if installed, is used to calculate a constrained Delaunay triangulation for `PolygonCollections`.
 
 Hardware requirements
 =====================

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -67,7 +67,7 @@ Optional dependencies
 VisPy has various optional dependencies to support features that may not be relevant for all users. The below is a list of dependencies that you may want to install to use the functionality mentioned.
 
 * **pillow**: Pillow (imported as PIL) is used to read image files. Some VisPy examples will use Pillow to load the image data that will then be shown by VisPy.
-* **triangle**: `Triangle <https://www.cs.cmu.edu/~quake/triangle.html>`_ is used via it's Python bindings package `triangle <https://github.com/drufat/triangle>`_. Please acknowledge and adhere to the licensing terms of both packages. Within VisPy `triangle`, if installed, is used to calculate a constrained Delaunay triangulation for `PolygonCollections`.
+* **triangle**: The `Triangle C package <https://www.cs.cmu.edu/~quake/triangle.html>`_ is used via it's `triangle python <https://github.com/drufat/triangle>`_ bindings. Please acknowledge and adhere to the licensing terms of both packages. Within VisPy `triangle`, if installed, is used to calculate a constrained Delaunay triangulation for `PolygonCollections`.
 
 Hardware requirements
 =====================

--- a/examples/gloo/geometry_shader.py
+++ b/examples/gloo/geometry_shader.py
@@ -7,6 +7,8 @@
 Use a Geometry Shader
 =====================
 
+NOTE: This example is currently not processed in CI.
+
 """
 
 import numpy as np

--- a/examples/gloo/geometry_shader.py
+++ b/examples/gloo/geometry_shader.py
@@ -7,6 +7,8 @@
 Use a Geometry Shader
 =====================
 
+Simple geometry shader: Takes one point as input emits one triangle as output.
+
 NOTE: This example is currently not processed in CI.
 
 """
@@ -37,8 +39,6 @@ void main (void) {
 GEOM_SHADER = """
 #version 330
 
-// Simple geometry shader: takes one point as input,
-// emits one triangle as output.
 layout (points) in;
 layout (triangle_strip, max_vertices=3) out;
 

--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -820,7 +820,16 @@ def _triangulate_cpp(vertices_2d, segments):
 
 
 def triangulate(vertices):
-    """Triangulate a set of vertices
+    """Triangulate a set of vertices.
+
+    This uses a pure Python implementation based on [1]_.
+
+    If `Triangle` by Jonathan R. Shewchuk [2]_ and the Python bindings `triangle` [3]_
+    are installed, this will be used instead. Users need to acknowledge and adhere to
+    the licensing terms of these packages.
+
+    In the VisPy `PolygonCollection Example` [4]_ a speedup of 97% using
+    `Triangle`/`triangle` can be achieved compared to the pure Python implementation.
 
     Parameters
     ----------
@@ -831,8 +840,20 @@ def triangulate(vertices):
     -------
     vertices : array-like
         The vertices.
-    tringles : array-like
+    triangles : array-like
         The triangles.
+
+    References
+    ----------
+    .. [1] Domiter, V. and Žalik, B. Sweep‐line algorithm for constrained
+       Delaunay triangulation
+    .. [2] Shewchuk J.R. (1996) Triangle: Engineering a 2D quality mesh generator and
+       Delaunay triangulator. In: Lin M.C., Manocha D. (eds) Applied Computational
+       Geometry Towards Geometric Engineering. WACG 1996. Lecture Notes in Computer
+       Science, vol 1148. Springer, Berlin, Heidelberg.
+       https://doi.org/10.1007/BFb0014497
+    .. [3] https://rufat.be/triangle/
+    .. [4] https://github.com/vispy/vispy/blob/main/examples/collections/polygon_collection.py
     """
     n = len(vertices)
     vertices = np.asarray(vertices)
@@ -844,8 +865,10 @@ def triangulate(vertices):
     try:
         import triangle  # noqa: F401
     except (ImportError, AssertionError):
+        print("triangulate Python")
         vertices_2d, triangles = _triangulate_python(vertices_2d, segments)
     else:
+        print("triangulate C++")
         segments_2d = segments.reshape((-1, 2))
         vertices_2d, triangles = _triangulate_cpp(vertices_2d, segments_2d)
 

--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -865,10 +865,8 @@ def triangulate(vertices):
     try:
         import triangle  # noqa: F401
     except (ImportError, AssertionError):
-        print("triangulate Python")
         vertices_2d, triangles = _triangulate_python(vertices_2d, segments)
     else:
-        print("triangulate C++")
         segments_2d = segments.reshape((-1, 2))
         vertices_2d, triangles = _triangulate_cpp(vertices_2d, segments_2d)
 


### PR DESCRIPTION
This adds documentation on the usage of `Triangle`/`triangle` as discussed in #1029.

Here are some findings I made:

- triangle is only used in class https://github.com/vispy/vispy/blob/e2df393fffaf9512dd1e945b213b7ce2eb4bf794/vispy/visuals/collections/raw_polygon_collection.py#L13
- unfortunately tiger-demo (https://github.com/vispy/vispy/blob/e2df393fffaf9512dd1e945b213b7ce2eb4bf794/examples/collections/tiger.py) segfaults with triangle
- The speedup for https://github.com/vispy/vispy/blob/e2df393fffaf9512dd1e945b213b7ce2eb4bf794/examples/collections/polygon_collection.py is 97% (472ms internal Python implementation, 13ms triangle).

closes: #1029