### PR TITLE
remove utf-8 encode in _vispy_set_title

### DIFF
--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -320,7 +320,7 @@ class CanvasBackend(BaseCanvasBackend):
         if self._id is None:
             return
         # Set the window title. Has no effect for widgets
-        glfw.set_window_title(self._id, title.encode('utf-8'))
+        glfw.set_window_title(self._id, title)
 
     def _vispy_set_size(self, w, h):
         if self._id is None:


### PR DESCRIPTION
the encoding is already done in glfw.set_window_title through a call to _to_char_p (at least since glfw 2.3.0 )