### PR TITLE
Fix numpy error with array edge_width in Markers

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -676,11 +676,11 @@ class MarkersVisual(Visual):
 
         if edge_width is not None:
             edge_width = np.asarray(edge_width)
-            if np.all(edge_width < 0):
+            if np.any(edge_width < 0):
                 raise ValueError('edge_width cannot be negative')
         else:
             edge_width_rel = np.asarray(edge_width_rel)
-            if np.all(edge_width_rel < 0):
+            if np.any(edge_width_rel < 0):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if scaling is not None:

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -673,11 +673,14 @@ class MarkersVisual(Visual):
         if (edge_width is not None) + (edge_width_rel is not None) != 1:
             raise ValueError('exactly one of edge_width and edge_width_rel '
                              'must be non-None')
+
         if edge_width is not None:
-            if edge_width < 0:
+            edge_width = np.asarray(edge_width)
+            if np.all(edge_width < 0):
                 raise ValueError('edge_width cannot be negative')
         else:
-            if edge_width_rel < 0:
+            edge_width_rel = np.asarray(edge_width_rel)
+            if np.all(edge_width_rel < 0):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if scaling is not None:

--- a/vispy/visuals/tests/test_markers.py
+++ b/vispy/visuals/tests/test_markers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+import pytest
 from vispy.scene.visuals import Markers
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
@@ -25,5 +26,23 @@ def test_markers():
         marker.set_data(data)
         assert_image_approved(c.render(), "visuals/markers.png")
 
+
+def test_markers_edge_width():
+    data = np.random.rand(10, 3)
+    edge_width = np.random.rand(10)
+    marker = Markers()
+
+    with pytest.raises(ValueError):
+        marker.set_data(pos=data, edge_width_rel=1, edge_width=1)
+
+    marker.set_data(pos=data, edge_width=2)
+    marker.set_data(pos=data, edge_width=edge_width)
+    with pytest.raises(ValueError):
+        marker.set_data(pos=data, edge_width=-1)
+
+    marker.set_data(pos=data, edge_width_rel=edge_width, edge_width=None)
+    marker.set_data(pos=data, edge_width_rel=edge_width + 1, edge_width=None)
+    with pytest.raises(ValueError):
+        marker.set_data(pos=data, edge_width_rel=edge_width - 1, edge_width=None)
 
 run_tests_if_main()


### PR DESCRIPTION
When passing an array to `Markers.edge_width`, a `ValueError` is raised:

```python
    if edge_width < 0:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```

This PR fixes this by using `np.all`.

Also, if a `list` is passed, the comparison fails because

```python
TypeError: '<' not supported between instances of 'list' and 'int'
```

Therefore, I added a line to cast to array first.
