### PR TITLE
Set depth buffer in Volume plane rendering

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -306,7 +306,7 @@ def test_plane_depth():
         # two planes at 45 degrees relative to the camera. If depth is set correctly, we should see one half
         # of the screen red and the other half white
         scene.visuals.Volume(
-            np.ones((40, 40, 40)),
+            np.ones((40, 40, 40), dtype=np.uint8),
             interpolation="nearest",
             clim=(0, 1),
             cmap="grays",
@@ -316,7 +316,7 @@ def test_plane_depth():
         )
 
         scene.visuals.Volume(
-            np.ones((40, 40, 40)),
+            np.ones((40, 40, 40), dtype=np.uint8),
             interpolation="nearest",
             clim=(0, 1),
             cmap="reds",
@@ -329,8 +329,8 @@ def test_plane_depth():
         rendered = c.render()
         left = rendered[20, 10]
         right = rendered[20, 30]
-        assert np.array_equal(left, [0, 0, 0, 255])
-        assert np.array_equal(right, [255, 0, 0, 255])
+        assert np.array_equal(left, [255, 0, 0, 255])
+        assert np.array_equal(right, [255, 255, 255, 255])
 
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -292,6 +292,7 @@ def test_changing_cmap():
             with pytest.raises(AssertionError):
                 np.testing.assert_allclose(grays, current_cmap)
 
+
 @requires_pyopengl()
 @requires_application()
 def test_plane_depth():
@@ -304,7 +305,7 @@ def test_plane_depth():
 
         # two planes at 45 degrees relative to the camera. If depth is set correctly, we should see one half
         # of the screen red and the other half white
-        plane1 = scene.visuals.Volume(
+        scene.visuals.Volume(
             np.ones((40, 40, 40)),
             interpolation="nearest",
             clim=(0, 1),
@@ -314,7 +315,7 @@ def test_plane_depth():
             parent=v.scene,
         )
 
-        plane2 = scene.visuals.Volume(
+        scene.visuals.Volume(
             np.ones((40, 40, 40)),
             interpolation="nearest",
             clim=(0, 1),
@@ -330,7 +331,6 @@ def test_plane_depth():
         right = rendered[20, 30]
         assert np.array_equal(left, [0, 0, 0, 255])
         assert np.array_equal(right, [255, 0, 0, 255])
-
 
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -292,5 +292,45 @@ def test_changing_cmap():
             with pytest.raises(AssertionError):
                 np.testing.assert_allclose(grays, current_cmap)
 
+@requires_pyopengl()
+@requires_application()
+def test_plane_depth():
+    with TestingCanvas(size=(40, 40)) as c:
+        v = c.central_widget.add_view(border_width=0)
+        v.camera = 'arcball'
+        v.camera.fov = 0
+        v.camera.center = (20, 20, 20)
+        v.camera.scale_factor = 40.0
+
+        # two planes at 45 degrees relative to the camera. If depth is set correctly, we should see one half
+        # of the screen red and the other half white
+        plane1 = scene.visuals.Volume(
+            np.ones((40, 40, 40)),
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="grays",
+            raycasting_mode="plane",
+            plane_normal=(0, 1, 1),
+            parent=v.scene,
+        )
+
+        plane2 = scene.visuals.Volume(
+            np.ones((40, 40, 40)),
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="reds",
+            raycasting_mode="plane",
+            plane_normal=(0, 1, -1),
+            parent=v.scene,
+        )
+
+        # render with grays colormap
+        rendered = c.render()
+        left = rendered[20, 10]
+        right = rendered[20, 30]
+        assert np.array_equal(left, [0, 0, 0, 255])
+        assert np.array_equal(right, [255, 0, 0, 255])
+
+
 
 run_tests_if_main()

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -228,6 +228,12 @@ void main() {
     // Calculate unit vector pointing in the view direction through this
     // fragment.
     view_ray = normalize(farpos.xyz - nearpos.xyz);
+
+    // Keep track of wheter a surface was found (used for depth)
+    // Need to do it before raycasting setup because the "plane" mode needs to set
+    // the depth during that phase.
+    vec3 surface_point;
+    bool surface_found = false;
     
     // Set up the ray casting
     // This snippet must define three variables:
@@ -251,10 +257,6 @@ void main() {
 
     // Keep track of whether texture has been sampled
     int texture_sampled = 0;
-
-    // Keep track of wheter a surface was found (used for depth)
-    vec3 surface_point;
-    bool surface_found = false;
 
     while (iter < nsteps) {
         for (iter=iter; iter<nsteps; iter++)
@@ -358,6 +360,10 @@ _RAYCASTING_SETUP_PLANE = """
     vec3 N = normalize(u_plane_normal);
     vec3 step = N / u_shape;
     vec3 start_loc = intersection_tex - ((step * f_nsteps) / 2);
+
+    // Set depth value
+    surface_point = intersection;
+    surface_found = true;
 """
 
 


### PR DESCRIPTION
This PR adds a few lines to set the depth buffer when rendering a volume with the `plane` raycasting mode.

Before/after:

https://user-images.githubusercontent.com/23482191/151813078-d36ce3a3-8d38-4eef-95ae-19709a42c16e.mp4

https://user-images.githubusercontent.com/23482191/151813074-80e989d9-ee5d-4847-bf24-818bb2d8d07d.mp4
