### PR TITLE
Fix TypeError for membership test of KeyboardModifiers

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -97,7 +97,7 @@ elif qt_lib == 'pyqt5':
         else:
             from PyQt5.QtOpenGL import QGLWidget, QGLFormat
     from PyQt5 import QtGui, QtCore, QtWidgets, QtTest
-    QWidget, QApplication = QtWidgets.QWidget, QtWidgets.QApplication  # 
+    QWidget, QApplication = QtWidgets.QWidget, QtWidgets.QApplication  # Compat
 elif qt_lib == 'pyqt6':
     _check_imports('PyQt6')
     if not USE_EGL:
@@ -630,7 +630,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
                      [qt_keyboard_modifiers.ControlModifier, keys.CONTROL],
                      [qt_keyboard_modifiers.AltModifier, keys.ALT],
                      [qt_keyboard_modifiers.MetaModifier, keys.META]):
-            if q & qtmod:
+            if qtmod & q:
                 mod += (v,)
         return mod
 


### PR DESCRIPTION
KeyboardModifiers follows from C++ QFlags<> which is closer to set-like semantics,
even if its implementation may be a bit field. Swapping to `qtmod & q` lets it
perform properly as a result.

This was triggering in SIFT 1.2.3 on mouseMove events as
```
TypeError: unsupported operand type(s) for &: 'KeyboardModifier' and 'KeyboardModifiers'
```

Also a minor comment fix to a presumed-missing "Compat" comment since it follows from nearby kin.

Closes #2212 
