### PR TITLE
Fix sphinx generation for new versions of numpydoc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -348,8 +348,8 @@ numpydoc_show_class_members = False
 _python_doc_base = 'https://docs.python.org/3.9'
 intersphinx_mapping = {
     _python_doc_base: None,
-    'https://docs.scipy.org/doc/numpy': None,
-    'https://docs.scipy.org/doc/scipy/reference': None,
+    'https://numpy.org/doc/stable/': None,
+    'https://scipy.github.io/devdocs/': None,
 }
 
 

--- a/vispy/io/stl.py
+++ b/vispy/io/stl.py
@@ -33,7 +33,7 @@ def load_stl(file_obj, file_type=None):
     file_type: not used
 
     Returns
-    ----------
+    -------
     loaded: kwargs for a Trimesh constructor with keys:
               vertices:     (n,3) float, vertices
               faces:        (m,3) int, indexes of vertices
@@ -65,7 +65,7 @@ def load_stl_binary(file_obj):
     file_obj: open file- like object
 
     Returns
-    ----------
+    -------
     loaded: kwargs for a Trimesh constructor with keys:
               vertices:     (n,3) float, vertices
               faces:        (m,3) int, indexes of vertices
@@ -124,7 +124,7 @@ def load_stl_ascii(file_obj):
     file_obj: open file- like object
 
     Returns
-    ----------
+    -------
     loaded: kwargs for a Trimesh constructor with keys:
               vertices:     (n,3) float, vertices
               faces:        (m,3) int, indexes of vertices

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -423,7 +423,7 @@ class Node(object):
             If true, add information about node transform types.
 
         Returns
-        ----------
+        -------
         tree : str
             The tree diagram.
         """


### PR DESCRIPTION
Closes #2295. Realized today that the website generation CI job is failing. Seems to be related to an update in some dependency, likely numpydoc. This PR fixes a few of the complains from numpydoc as well as updates the intersphinx URLs to scipy and numpy. I'm a little worried because the scipy URL says "devdocs" in it which may not be the final/stable version of the documentation. We'll see...