### PR TITLE
Set depth in `VolumeVisual` for `mip`/`minip`/`attenuated_mip` rendering modes

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -380,7 +380,7 @@ def test_volume_depth():
         greens = np.sum(rendered[:, :, 1])
         blues = np.sum(rendered[:, :, 2])
         assert reds > 0
-        assert np.allclose(greens, 0)
+        np.testing.assert_allclose(greens, 0)
         assert blues > 0
 
 

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -341,6 +341,16 @@ def test_volume_depth():
     Render a volume with a blue ball in front of a red plane in front of a
     blue plane, checking that the output image contains both red and blue pixels.
     """
+    # A blue strip behind a red strip
+    # If depth is set correctly, we should see only red pixels
+    # the screen
+    blue_vol = np.zeros((40, 40, 40), dtype=np.uint8)
+    blue_vol[:, 39, :] = 1  # back plane blue
+    blue_vol[15:25, 15:25, 15:25] = 1  # blue in center
+
+    red_vol = np.zeros((40, 40, 40), dtype=np.uint8)
+    red_vol[:, 35, :] = 1  # red plane in front of blue plane
+
     with TestingCanvas(size=(40, 40)) as c:
         v = c.central_widget.add_view(border_width=0)
         v.camera = 'arcball'
@@ -348,29 +358,19 @@ def test_volume_depth():
         v.camera.center = (20, 20, 20)
         v.camera.scale_factor = 40.0
 
-        # A blue strip behind a red strip
-        # If depth is set correctly, we should see only red pixels
-        # the screen
-        blue_vol = np.zeros((40, 40, 40), dtype=np.uint8)
-        blue_vol[:, 39, :] = 1  # back plane blue
-        blue_vol[15:25, 15:25, 15:25] = 1  # blue in center
-
-        red_vol = np.zeros((40, 40, 40), dtype=np.uint8)
-        red_vol[:, 35, :] = 1  # red plane in front of blue plane
+        scene.visuals.Volume(
+            red_vol,
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="reds",
+            parent=v.scene,
+        )
 
         scene.visuals.Volume(
             blue_vol,
             interpolation="nearest",
             clim=(0, 1),
             cmap="blues",
-            parent=v.scene,
-        )
-
-        scene.visuals.Volume(
-            red_vol,
-            interpolation="nearest",
-            clim=(0, 1),
-            cmap="reds",
             parent=v.scene,
         )
 

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -358,7 +358,6 @@ def test_volume_depth():
         red_vol = np.zeros((40, 40, 40), dtype=np.uint8)
         red_vol[:, 35, :] = 1  # red plane in front of blue plane
 
-
         scene.visuals.Volume(
             blue_vol,
             interpolation="nearest",

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -374,7 +374,7 @@ def test_volume_depth():
             parent=v.scene,
         )
 
-        # render with grays colormap
+        # render
         rendered = c.render()
         reds = np.sum(rendered[:, :, 0])
         blues = np.sum(rendered[:, :, 2])

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -333,4 +333,54 @@ def test_plane_depth():
         assert np.array_equal(right, [255, 255, 255, 255])
 
 
+@requires_pyopengl()
+@requires_application()
+def test_volume_depth():
+    """Check that depth setting is properly performed for the volume visual
+
+    Render a volume with a blue ball in front of a red plane in front of a
+    blue plane, checking that the output image contains both red and blue pixels.
+    """
+    with TestingCanvas(size=(40, 40)) as c:
+        v = c.central_widget.add_view(border_width=0)
+        v.camera = 'arcball'
+        v.camera.fov = 0
+        v.camera.center = (20, 20, 20)
+        v.camera.scale_factor = 40.0
+
+        # A blue strip behind a red strip
+        # If depth is set correctly, we should see only red pixels
+        # the screen
+        blue_vol = np.zeros((40, 40, 40), dtype=np.uint8)
+        blue_vol[:, 39, :] = 1  # back plane blue
+        blue_vol[15:25, 15:25, 15:25] = 1  # blue in center
+
+        red_vol = np.zeros((40, 40, 40), dtype=np.uint8)
+        red_vol[:, 35, :] = 1  # red plane in front of blue plane
+
+
+        scene.visuals.Volume(
+            blue_vol,
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="blues",
+            parent=v.scene,
+        )
+
+        scene.visuals.Volume(
+            red_vol,
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="reds",
+            parent=v.scene,
+        )
+
+        # render with grays colormap
+        rendered = c.render()
+        reds = np.sum(rendered[:, :, 0])
+        blues = np.sum(rendered[:, :, 2])
+        assert reds > 0
+        assert blues > 0
+
+
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -296,17 +296,17 @@ def test_changing_cmap():
 @requires_pyopengl()
 @requires_application()
 def test_plane_depth():
-    with TestingCanvas(size=(40, 40)) as c:
+    with TestingCanvas(size=(80, 80)) as c:
         v = c.central_widget.add_view(border_width=0)
         v.camera = 'arcball'
         v.camera.fov = 0
-        v.camera.center = (20, 20, 20)
-        v.camera.scale_factor = 40.0
+        v.camera.center = (40, 40, 40)
+        v.camera.scale_factor = 80.0
 
         # two planes at 45 degrees relative to the camera. If depth is set correctly, we should see one half
         # of the screen red and the other half white
         scene.visuals.Volume(
-            np.ones((40, 40, 40), dtype=np.uint8),
+            np.ones((80, 80, 80), dtype=np.uint8),
             interpolation="nearest",
             clim=(0, 1),
             cmap="grays",
@@ -316,7 +316,7 @@ def test_plane_depth():
         )
 
         scene.visuals.Volume(
-            np.ones((40, 40, 40), dtype=np.uint8),
+            np.ones((80, 80, 80), dtype=np.uint8),
             interpolation="nearest",
             clim=(0, 1),
             cmap="reds",
@@ -327,8 +327,8 @@ def test_plane_depth():
 
         # render with grays colormap
         rendered = c.render()
-        left = rendered[20, 10]
-        right = rendered[20, 30]
+        left = rendered[40, 20]
+        right = rendered[40, 60]
         assert np.array_equal(left, [255, 0, 0, 255])
         assert np.array_equal(right, [255, 255, 255, 255])
 
@@ -344,19 +344,19 @@ def test_volume_depth():
     # A blue strip behind a red strip
     # If depth is set correctly, we should see only red pixels
     # the screen
-    blue_vol = np.zeros((40, 40, 40), dtype=np.uint8)
-    blue_vol[:, 39, :] = 1  # back plane blue
-    blue_vol[15:25, 15:25, 15:25] = 1  # blue in center
+    blue_vol = np.zeros((80, 80, 80), dtype=np.uint8)
+    blue_vol[:, -1, :] = 1  # back plane blue
+    blue_vol[30:50, 30:50, 30:50] = 1  # blue in center
 
-    red_vol = np.zeros((40, 40, 40), dtype=np.uint8)
-    red_vol[:, 35, :] = 1  # red plane in front of blue plane
+    red_vol = np.zeros((80, 80, 80), dtype=np.uint8)
+    red_vol[:, -5, :] = 1  # red plane in front of blue plane
 
-    with TestingCanvas(size=(40, 40)) as c:
+    with TestingCanvas(size=(80, 80)) as c:
         v = c.central_widget.add_view(border_width=0)
         v.camera = 'arcball'
         v.camera.fov = 0
-        v.camera.center = (20, 20, 20)
-        v.camera.scale_factor = 40.0
+        v.camera.center = (40, 40, 40)
+        v.camera.scale_factor = 80.0
 
         scene.visuals.Volume(
             red_vol,

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -377,8 +377,10 @@ def test_volume_depth():
         # render
         rendered = c.render()
         reds = np.sum(rendered[:, :, 0])
+        greens = np.sum(rendered[:, :, 1])
         blues = np.sum(rendered[:, :, 2])
         assert reds > 0
+        assert np.allclose(greens, 0)
         assert blues > 0
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -380,6 +380,7 @@ _MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = -99999.0; // The maximum encountered value
         int maxi = -1;  // Where the maximum value was encountered
+        set_frag_depth = true;
         """,
     in_loop="""
         if( val > maxval ) {
@@ -390,14 +391,49 @@ _MIP_SNIPPETS = dict(
     after_loop="""
         // Refine search for max value, but only if anything was found
         if ( maxi > -1 ) {
-            loc = start_loc + step * (float(maxi) - 0.5);
+            // Calculate starting location of ray for sampling               
+            vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);  
+            loc = start_loc_refine;
+            
+            // Variables to keep track of current value and where max was encountered
+            vec3 max_loc_tex;  
+                           
             for (int i=0; i<10; i++) {
-                maxval = max(maxval, $sample(u_volumetex, loc).r);
+                float val = $sample(u_volumetex, loc).r;
+                if ( val > maxval) {
+                    maxval = val;
+                    max_loc_tex = start_loc_refine + (step * 0.1 * i);
+                }
                 loc += step * 0.1;
             }
+            frag_depth_point = max_loc_tex * u_shape;
             gl_FragColor = applyColormap(maxval);
         }
         """,
+    # after_loop="""
+    # // Refine search for max value, but only if anything was found
+    # if ( maxi > -1 ) {
+    #     // Calculate starting location of ray for sampling
+    #     vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);
+    #
+    #     // Set current sampling point
+    #     loc = start_loc_refine;
+    #
+    #     // Keep track of where max was encountered
+    #     vec3 max_loc_tex;
+    #
+    #     for (int i=0; i<10; i++) {
+    #         val = $sample(u_volumetex, loc).r;
+    #         if( val > maxval ) {
+    #             maxval = val;
+    #             max_loc_tex = start_loc_refine + (step * 0.1 * i);
+    #         }
+    #         loc += step * 0.1;
+    #     }
+    #     frag_depth_point = max_loc_tex * u_shape;
+    #     gl_FragColor = applyColormap(maxval);
+    # }
+    # """,
 )
 
 _ATTENUATED_MIP_SNIPPETS = dict(

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -372,7 +372,6 @@ _RAYCASTING_SETUP_PLANE = """
     // Ensure that frag depth value will be set to plane intersection
     rendering_as_plane = true;
     set_frag_depth = true;
-    frag_depth_point = intersection;
 """
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -410,30 +410,6 @@ _MIP_SNIPPETS = dict(
             gl_FragColor = applyColormap(maxval);
         }
         """,
-    # after_loop="""
-    # // Refine search for max value, but only if anything was found
-    # if ( maxi > -1 ) {
-    #     // Calculate starting location of ray for sampling
-    #     vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);
-    #
-    #     // Set current sampling point
-    #     loc = start_loc_refine;
-    #
-    #     // Keep track of where max was encountered
-    #     vec3 max_loc_tex;
-    #
-    #     for (int i=0; i<10; i++) {
-    #         val = $sample(u_volumetex, loc).r;
-    #         if( val > maxval ) {
-    #             maxval = val;
-    #             max_loc_tex = start_loc_refine + (step * 0.1 * i);
-    #         }
-    #         loc += step * 0.1;
-    #     }
-    #     frag_depth_point = max_loc_tex * u_shape;
-    #     gl_FragColor = applyColormap(maxval);
-    # }
-    # """,
 )
 
 _ATTENUATED_MIP_SNIPPETS = dict(

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -234,8 +234,10 @@ void main() {
     vec3 frag_depth_point;
     bool set_frag_depth = false;
     
-    // Also keep track of whether plane rendering is enabled.
+    // Variables to keep track of whether plane rendering is enabled and
+    // ray-plane intersection
     bool rendering_as_plane = false;
+    vec3 intersection = vec3(0, 0, 0);
     
     // Set up the ray casting
     // This snippet must define three variables:
@@ -286,10 +288,14 @@ void main() {
     
     $after_loop
 
+    // set the depth buffer
+    if (rendering_as_plane == true) {
+        frag_depth_point = intersection;
+    }
     if (set_frag_depth == true) {
         // if a surface was found, use it to set the depth buffer
-        vec4 position2 = vec4(frag_depth_point, 1);
-        vec4 iproj = $viewtransformf(position2);
+        vec4 frag_depth_vector = vec4(frag_depth_point, 1);
+        vec4 iproj = $viewtransformf(frag_depth_vector);
         iproj.z /= iproj.w;
         gl_FragDepth = (iproj.z+1.0)/2.0;
     }
@@ -330,7 +336,7 @@ _RAYCASTING_SETUP_VOLUME = """
 _RAYCASTING_SETUP_PLANE = """
     // find intersection of view ray with plane in data coordinates
     // 0.5 offset needed to get back to correct texture coordinates (vispy#2239)
-    vec3 intersection = intersectLinePlane(v_position.xyz, view_ray,
+    intersection = intersectLinePlane(v_position.xyz, view_ray,
                                            u_plane_position, u_plane_normal);
     // and texture coordinates
     vec3 intersection_tex = (intersection + 0.5) / u_shape;

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -276,9 +276,8 @@ void main() {
         }
     }
 
-    if ( texture_sampled == false ) {
+    if (!texture_sampled)
         discard;
-    }
 
     $after_loop
 
@@ -337,9 +336,8 @@ _RAYCASTING_SETUP_PLANE = """
     out_of_bounds += float(intersection_tex.z > 1);
     out_of_bounds += float(intersection_tex.z < 0);
 
-    if (out_of_bounds > 0) {
+    if (out_of_bounds > 0)
         discard;
-    }
 
 
     // Decide how many steps to take
@@ -513,6 +511,7 @@ _ISO_SNIPPETS = dict(
         vec4 color3 = vec4(0.0);  // final color
         vec3 dstep = 1.5 / u_shape;  // step to sample derivative
         gl_FragColor = vec4(0.0);
+        bool discard_fragment = true;
     """,
     in_loop="""
         if (val > u_threshold-0.2) {
@@ -526,6 +525,7 @@ _ISO_SNIPPETS = dict(
 
                     // set the variables for the depth buffer
                     frag_depth_point = iloc * u_shape;
+                    discard_fragment = false;
 
                     iter = nsteps;
                     break;
@@ -533,11 +533,11 @@ _ISO_SNIPPETS = dict(
                 iloc += step * 0.1;
             }
         }
-        else {
-            discard;
-        }
         """,
-    after_loop="""""",
+    after_loop="""
+        if (discard_fragment)
+            discard;
+    """,
 )
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -450,11 +450,22 @@ _MINIP_SNIPPETS = dict(
     after_loop="""
         // Refine search for min value, but only if anything was found
         if ( mini > -1 ) {
-            loc = start_loc + step * (float(mini) - 0.5);
+            // Calculate starting location of ray for sampling               
+            vec3 start_loc_refine = start_loc + step * (float(mini) - 0.5);  
+            loc = start_loc_refine;
+            
+            // Variables to keep track of current value and where max was encountered
+            vec3 min_loc_tex;  
+                           
             for (int i=0; i<10; i++) {
-                minval = min(minval, $sample(u_volumetex, loc).r);
+                float val = $sample(u_volumetex, loc).r;
+                if ( val < minval) {
+                    minval = val;
+                    min_loc_tex = start_loc_refine + (step * 0.1 * i);
+                }
                 loc += step * 0.1;
             }
+            frag_depth_point = min_loc_tex * u_shape;
             gl_FragColor = applyColormap(minval);
         }
         """,

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -418,7 +418,8 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         float sumval = 0.0; // The sum of the encountered values
         float scaled = 0.0; // The scaled value
         int maxi = 0;  // Where the maximum value was encountered
-        vec3 maxloc = vec3(0.0);  // Location where the maximum value was encountered
+        vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
+        set_frag_depth = true;
         """,
     in_loop="""
         sumval = sumval + val;
@@ -426,10 +427,11 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         if( scaled > maxval ) {
             maxval = scaled;
             maxi = iter;
-            maxloc = loc;
+            max_loc_tex = loc;
         }
         """,
     after_loop="""
+        frag_depth_point = max_loc_tex * u_shape;
         gl_FragColor = applyColormap(maxval);
         """,
 )


### PR DESCRIPTION
This PR sets the depth buffer correctly in the `mip`/`minip`/`attenuated_mip` rendering modes of the `VolumeVisual` - if in plane rendering mode the depth is always set to the ray-plane intersection as before (#2289)

https://user-images.githubusercontent.com/7307488/156226184-e0146fd2-a0af-4e02-8148-1aa8c6af5200.mp4

This allows us to compose multiple volumes in the same space in opaque blending modes (excuse the lack of alpha in the cmap)

https://user-images.githubusercontent.com/7307488/156226373-7dbd943d-5be9-4dd1-b5e8-23927e6e6e64.mp4

cc @brisvag 


 