### PR TITLE
Add cutoff to mip and minip volume projection for fragment discard

### DIFF
--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -336,15 +336,15 @@ def test_plane_depth():
 @requires_pyopengl()
 @requires_application()
 def test_mip_cutoff():
-    with TestingCanvas(size=(40, 40)) as c:
+    with TestingCanvas(size=(80, 80)) as c:
         v = c.central_widget.add_view(border_width=0)
         v.camera = 'arcball'
         v.camera.fov = 0
-        v.camera.center = (20, 20, 20)
-        v.camera.scale_factor = 40.0
+        v.camera.center = (40, 40, 40)
+        v.camera.scale_factor = 80.0
 
         vol = scene.visuals.Volume(
-            np.ones((40, 40, 40), dtype=np.uint8),
+            np.ones((80, 80, 80), dtype=np.uint8),
             interpolation="nearest",
             clim=(0, 1),
             cmap="grays",
@@ -353,12 +353,12 @@ def test_mip_cutoff():
 
         # we should see white
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+        assert np.array_equal(rendered[40, 40], [255, 255, 255, 255])
 
         vol.mip_cutoff = 10
         # we should see black
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+        assert np.array_equal(rendered[40, 40], [0, 0, 0, 255])
 
         # repeat for attenuated_mip
         vol.method = 'attenuated_mip'
@@ -366,41 +366,46 @@ def test_mip_cutoff():
 
         # we should see white
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+        assert np.array_equal(rendered[40, 40], [255, 255, 255, 255])
 
         vol.mip_cutoff = 10
         # we should see black
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+        assert np.array_equal(rendered[40, 40], [0, 0, 0, 255])
 
 
 @requires_pyopengl()
 @requires_application()
 def test_minip_cutoff():
-    with TestingCanvas(size=(40, 40)) as c:
+    with TestingCanvas(size=(80, 80)) as c:
         v = c.central_widget.add_view(border_width=0)
         v.camera = 'arcball'
         v.camera.fov = 0
-        v.camera.center = (20, 20, 20)
-        v.camera.scale_factor = 40.0
+        v.camera.center = (40, 40, 40)
+        v.camera.scale_factor = 120.0
+
+        # just surface of the cube is ones, but it should win over the twos inside
+        data = np.ones((80, 80, 80), dtype=np.uint8)
+        data[1:-1, 1:-1, 1:-1] = 2
 
         vol = scene.visuals.Volume(
-            np.zeros((40, 40, 40), dtype=np.uint8),
+            data,
             interpolation="nearest",
-            clim=(0, 1),
+            method='minip',
+            clim=(0, 2),
             cmap="grays",
             parent=v.scene,
         )
 
-        # we should see white
+        # we should see gray (half of cmap)
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+        assert np.array_equal(rendered[40, 40], [128, 128, 128, 255])
 
         # discard fragments above -10 (everything)
         vol.minip_cutoff = -10
         # we should see black
         rendered = c.render()
-        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+        assert np.array_equal(rendered[40, 40], [0, 0, 0, 255])
 
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -333,4 +333,74 @@ def test_plane_depth():
         assert np.array_equal(right, [255, 255, 255, 255])
 
 
+@requires_pyopengl()
+@requires_application()
+def test_mip_cutoff():
+    with TestingCanvas(size=(40, 40)) as c:
+        v = c.central_widget.add_view(border_width=0)
+        v.camera = 'arcball'
+        v.camera.fov = 0
+        v.camera.center = (20, 20, 20)
+        v.camera.scale_factor = 40.0
+
+        vol = scene.visuals.Volume(
+            np.ones((40, 40, 40), dtype=np.uint8),
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="grays",
+            parent=v.scene,
+        )
+
+        # we should see white
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+
+        vol.mip_cutoff = 10
+        # we should see black
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+
+        # repeat for attenuated_mip
+        vol.method = 'attenuated_mip'
+        vol.mip_cutoff = None
+
+        # we should see white
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+
+        vol.mip_cutoff = 10
+        # we should see black
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+
+
+@requires_pyopengl()
+@requires_application()
+def test_minip_cutoff():
+    with TestingCanvas(size=(40, 40)) as c:
+        v = c.central_widget.add_view(border_width=0)
+        v.camera = 'arcball'
+        v.camera.fov = 0
+        v.camera.center = (20, 20, 20)
+        v.camera.scale_factor = 40.0
+
+        vol = scene.visuals.Volume(
+            np.zeros((40, 40, 40), dtype=np.uint8),
+            interpolation="nearest",
+            clim=(0, 1),
+            cmap="grays",
+            parent=v.scene,
+        )
+
+        # we should see white
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [255, 255, 255, 255])
+
+        # discard fragments above -10 (everything)
+        vol.minip_cutoff = -10
+        # we should see black
+        rendered = c.render()
+        assert np.array_equal(rendered[20, 20], [0, 0, 0, 255])
+
+
 run_tests_if_main()

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -1105,6 +1105,11 @@ class VolumeVisual(Visual):
 
     @property
     def mip_cutoff(self):
+        """The lower cutoff value for `mip` and `attenuated_mip`.
+
+        When using the `mip` or `attenuated_mip` rendering methods, fragments
+        with values below the cutoff will be discarded.
+        """
         return self._mip_cutoff
 
     @mip_cutoff.setter
@@ -1115,6 +1120,11 @@ class VolumeVisual(Visual):
 
     @property
     def minip_cutoff(self):
+        """The upper cutoff value for `minip`.
+
+        When using the `minip` rendering method, fragments
+        with values above the cutoff will be discarded.
+        """
         return self._minip_cutoff
 
     @minip_cutoff.setter

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -87,6 +87,7 @@ uniform float u_threshold;
 uniform float u_attenuation;
 uniform float u_relative_step_size;
 uniform float u_mip_cutoff;
+uniform float u_minip_cutoff;
 
 //varyings
 varying vec3 v_position;

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -644,8 +644,8 @@ class VolumeVisual(Visual):
                  gamma=1.0, interpolation='linear', texture_format=None,
                  raycasting_mode='volume', plane_position=None,
                  plane_normal=None, plane_thickness=1.0, clipping_planes=None,
-                 clipping_planes_coord_system='scene', mip_cutoff=-99999,
-                 minip_cutoff=99999):
+                 clipping_planes_coord_system='scene', mip_cutoff=None,
+                 minip_cutoff=None):
 
         tr = ['visual', 'scene', 'document', 'canvas', 'framebuffer', 'render']
         if clipping_planes_coord_system not in tr:
@@ -1114,6 +1114,8 @@ class VolumeVisual(Visual):
 
     @mip_cutoff.setter
     def mip_cutoff(self, value):
+        if value is None:
+            value = 1.175494351e-38
         self._mip_cutoff = float(value)
         self.shared_program['u_mip_cutoff'] = self._mip_cutoff
         self.update()
@@ -1129,6 +1131,8 @@ class VolumeVisual(Visual):
 
     @minip_cutoff.setter
     def minip_cutoff(self, value):
+        if value is None:
+            value = 3.402823466e+38
         self._minip_cutoff = float(value)
         self.shared_program['u_minip_cutoff'] = self._minip_cutoff
         self.update()

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -398,8 +398,7 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         float maxval = u_mip_cutoff; // The maximum encountered value
         float sumval = 0.0; // The sum of the encountered values
         float scaled = 0.0; // The scaled value
-        int maxi = 0;  // Where the maximum value was encountered
-        vec3 maxloc = vec3(0.0);  // Location where the maximum value was encountered
+        int maxi = -1;  // Where the maximum value was encountered
         """,
     in_loop="""
         sumval = sumval + val;
@@ -407,11 +406,12 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         if( scaled > maxval ) {
             maxval = scaled;
             maxi = iter;
-            maxloc = loc;
         }
         """,
     after_loop="""
-        gl_FragColor = applyColormap(maxval);
+        if (maxi > -1) {
+            gl_FragColor = applyColormap(maxval);
+        }
         """,
 )
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -231,12 +231,10 @@ void main() {
     // fragment.
     view_ray = normalize(farpos.xyz - nearpos.xyz);
 
-    // Keep track of wheter a surface was found (used for depth)
-    // Need to do it before raycasting setup because the "plane" mode needs to set
-    // the depth during that phase.
-    vec3 surface_point;
-    bool surface_found = false;
-    
+    // Variables to keep track of where to set the frag depth.
+    // frag_depth_point is in data coordinates.
+    vec3 frag_depth_point;
+
     // Set up the ray casting
     // This snippet must define three variables:
     // vec3 start_loc - the starting location of the ray in texture coordinates
@@ -257,8 +255,9 @@ void main() {
     vec3 loc = start_loc;
     int iter = 0;
 
-    // Keep track of whether texture has been sampled
-    int texture_sampled = 0;
+    // keep track if the texture is ever sampled; if not, fragment will be discarded
+    // this allows us to discard fragments that only traverse clipped parts of the texture
+    bool texture_sampled = false;
 
     while (iter < nsteps) {
         for (iter=iter; iter<nsteps; iter++)
@@ -270,7 +269,7 @@ void main() {
                 // Get sample color
                 vec4 color = $sample(u_volumetex, loc);
                 float val = color.r;
-                texture_sampled = 1;
+                texture_sampled = true;
 
                 $in_loop
             }
@@ -278,28 +277,18 @@ void main() {
             loc += step;
         }
     }
-    
-    // discard fragment if texture not sampled
-    if ( texture_sampled != 1 ) {
+
+    if (!texture_sampled)
         discard;
-    }
-    
+
     $after_loop
 
-    if (surface_found == true) {
-        // if a surface was found, use it to set the depth buffer
-        vec4 position2 = vec4(surface_point, 1);
-        vec4 iproj = $viewtransformf(position2);
-        iproj.z /= iproj.w;
-        gl_FragDepth = (iproj.z+1.0)/2.0;
-    }
-    else {
-        gl_FragDepth = gl_FragCoord.z;
-    }
-
+    // set frag depth
+    vec4 frag_depth_vector = vec4(frag_depth_point, 1);
+    vec4 iproj = $viewtransformf(frag_depth_vector);
+    iproj.z /= iproj.w;
+    gl_FragDepth = (iproj.z+1.0)/2.0;
 }
-
-
 """  # noqa
 
 _RAYCASTING_SETUP_VOLUME = """
@@ -325,6 +314,9 @@ _RAYCASTING_SETUP_VOLUME = """
     vec3 step = ((v_position - front) / u_shape) / f_nsteps;
     // 0.5 offset needed to get back to correct texture coordinates (vispy#2239)
     vec3 start_loc = (front + 0.5) / u_shape;
+
+    // set frag depth to the cube face; this can be overridden by projection snippets
+    frag_depth_point = front;
 """
 
 _RAYCASTING_SETUP_PLANE = """
@@ -346,9 +338,8 @@ _RAYCASTING_SETUP_PLANE = """
     out_of_bounds += float(intersection_tex.z > 1);
     out_of_bounds += float(intersection_tex.z < 0);
 
-    if (out_of_bounds > 0) {
+    if (out_of_bounds > 0)
         discard;
-    }
 
 
     // Decide how many steps to take
@@ -363,9 +354,8 @@ _RAYCASTING_SETUP_PLANE = """
     vec3 step = N / u_shape;
     vec3 start_loc = intersection_tex - ((step * f_nsteps) / 2);
 
-    // Set depth value
-    surface_point = intersection;
-    surface_found = true;
+    // Ensure that frag depth value will be set to plane intersection
+    frag_depth_point = intersection;
 """
 
 
@@ -383,12 +373,27 @@ _MIP_SNIPPETS = dict(
     after_loop="""
         // Refine search for max value, but only if anything was found
         if ( maxi > -1 ) {
-            loc = start_loc + step * (float(maxi) - 0.5);
+            // Calculate starting location of ray for sampling
+            vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);
+            loc = start_loc_refine;
+
+            // Variables to keep track of current value and where max was encountered
+            vec3 max_loc_tex = start_loc_refine;
+
+            vec3 small_step = step * 0.1;
             for (int i=0; i<10; i++) {
-                maxval = max(maxval, $sample(u_volumetex, loc).r);
-                loc += step * 0.1;
+                float val = $sample(u_volumetex, loc).r;
+                if ( val > maxval) {
+                    maxval = val;
+                    max_loc_tex = start_loc_refine + (small_step * i);
+                }
+                loc += small_step;
             }
+            frag_depth_point = max_loc_tex * u_shape;
             gl_FragColor = applyColormap(maxval);
+        }
+        else {
+            discard;
         }
         """,
 )
@@ -399,6 +404,7 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         float sumval = 0.0; // The sum of the encountered values
         float scaled = 0.0; // The scaled value
         int maxi = -1;  // Where the maximum value was encountered
+        vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
         """,
     in_loop="""
         sumval = sumval + val;
@@ -409,8 +415,12 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         }
         """,
     after_loop="""
-        if (maxi > -1) {
+        if ( maxi > -1 ) {
+            frag_depth_point = max_loc_tex * u_shape;
             gl_FragColor = applyColormap(maxval);
+        }
+        else {
+            discard;
         }
         """,
 )
@@ -429,12 +439,27 @@ _MINIP_SNIPPETS = dict(
     after_loop="""
         // Refine search for min value, but only if anything was found
         if ( mini > -1 ) {
-            loc = start_loc + step * (float(mini) - 0.5);
+            // Calculate starting location of ray for sampling
+            vec3 start_loc_refine = start_loc + step * (float(mini) - 0.5);
+            loc = start_loc_refine;
+
+            // Variables to keep track of current value and where max was encountered
+            vec3 min_loc_tex = start_loc_refine;
+
+            vec3 small_step = step * 0.1;
             for (int i=0; i<10; i++) {
-                minval = min(minval, $sample(u_volumetex, loc).r);
-                loc += step * 0.1;
+                float val = $sample(u_volumetex, loc).r;
+                if ( val < minval) {
+                    minval = val;
+                    min_loc_tex = start_loc_refine + (small_step * i);
+                }
+                loc += small_step;
             }
+            frag_depth_point = min_loc_tex * u_shape;
             gl_FragColor = applyColormap(minval);
+        }
+        else {
+            discard;
         }
         """,
 )
@@ -444,24 +469,24 @@ _TRANSLUCENT_SNIPPETS = dict(
         vec4 integrated_color = vec4(0., 0., 0., 0.);
         """,
     in_loop="""
-            color = applyColormap(val);
-            float a1 = integrated_color.a;
-            float a2 = color.a * (1 - a1);
-            float alpha = max(a1 + a2, 0.001);
+        color = applyColormap(val);
+        float a1 = integrated_color.a;
+        float a2 = color.a * (1 - a1);
+        float alpha = max(a1 + a2, 0.001);
 
-            // Doesn't work.. GLSL optimizer bug?
-            //integrated_color = (integrated_color * a1 / alpha) +
-            //                   (color * a2 / alpha);
-            // This should be identical but does work correctly:
-            integrated_color *= a1 / alpha;
-            integrated_color += color * a2 / alpha;
+        // Doesn't work.. GLSL optimizer bug?
+        //integrated_color = (integrated_color * a1 / alpha) +
+        //                   (color * a2 / alpha);
+        // This should be identical but does work correctly:
+        integrated_color *= a1 / alpha;
+        integrated_color += color * a2 / alpha;
 
-            integrated_color.a = alpha;
+        integrated_color.a = alpha;
 
-            if( alpha > 0.99 ){
-                // stop integrating if the fragment becomes opaque
-                iter = nsteps;
-            }
+        if( alpha > 0.99 ){
+            // stop integrating if the fragment becomes opaque
+            iter = nsteps;
+        }
         """,
     after_loop="""
         gl_FragColor = integrated_color;
@@ -487,6 +512,7 @@ _ISO_SNIPPETS = dict(
         vec4 color3 = vec4(0.0);  // final color
         vec3 dstep = 1.5 / u_shape;  // step to sample derivative
         gl_FragColor = vec4(0.0);
+        bool discard_fragment = true;
     """,
     in_loop="""
         if (val > u_threshold-0.2) {
@@ -499,8 +525,8 @@ _ISO_SNIPPETS = dict(
                     gl_FragColor = applyColormap(color.r);
 
                     // set the variables for the depth buffer
-                    surface_point = iloc * u_shape;
-                    surface_found = true;
+                    frag_depth_point = iloc * u_shape;
+                    discard_fragment = false;
 
                     iter = nsteps;
                     break;
@@ -510,12 +536,9 @@ _ISO_SNIPPETS = dict(
         }
         """,
     after_loop="""
-
-        if (!surface_found) {
+        if (discard_fragment)
             discard;
-        }
-
-        """,
+    """,
 )
 
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -1115,7 +1115,7 @@ class VolumeVisual(Visual):
     @mip_cutoff.setter
     def mip_cutoff(self, value):
         if value is None:
-            value = 1.175494351e-38
+            value = np.finfo('float32').min
         self._mip_cutoff = float(value)
         self.shared_program['u_mip_cutoff'] = self._mip_cutoff
         self.update()
@@ -1132,7 +1132,7 @@ class VolumeVisual(Visual):
     @minip_cutoff.setter
     def minip_cutoff(self, value):
         if value is None:
-            value = 3.402823466e+38
+            value = np.finfo('float32').max
         self._minip_cutoff = float(value)
         self.shared_program['u_minip_cutoff'] = self._minip_cutoff
         self.update()


### PR DESCRIPTION
This PR takes out some code from the solution to the issues in #2305.

Specifically, see [this comment](https://github.com/vispy/vispy/pull/2305#issuecomment-1059240483) and [this other comment](https://github.com/vispy/vispy/pull/2305#issuecomment-1059272289).

In practice, the new attributes allow to set a lower bound to MIP projection (and higher bound to MINIP) beyond which fragments are discarded.
