### PR TITLE
Fix panzoom camera center setter

### DIFF
--- a/vispy/geometry/rect.py
+++ b/vispy/geometry/rect.py
@@ -113,6 +113,12 @@ class Rect(object):
         return (self.pos[0] + self.size[0] * 0.5,
                 self.pos[1] + self.size[1] * 0.5)
 
+    @center.setter
+    def center(self, value):
+        delta_x = value[0] - self.center[0]
+        delta_y = value[1] - self.center[1]
+        self.pos = (self.pos[0] + delta_x, self.pos[1] + delta_y)
+
     def padded(self, padding):
         """Return a new Rect padded (smaller) by padding on all sides
 

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -162,17 +162,7 @@ class PanZoomCamera(BaseCamera):
         if not (isinstance(center, (tuple, list)) and len(center) in (2, 3)):
             raise ValueError('center must be a 2 or 3 element tuple')
         rect = Rect(self.rect) or Rect(*DEFAULT_RECT_TUPLE)
-        # Get half-ranges
-        x2 = rect.center[0]
-        y2 = rect.center[1]
-        # Apply new ranges
-        x1 = center[0]
-        y1 = center[1]
-        rect.left = x1 - x2
-        rect.right = x1 + x2
-        rect.bottom = y1 - y2
-        rect.top = y1 + y2
-        #
+        rect.center = center[:2]
         self.rect = rect
 
     def _set_range(self, init):


### PR DESCRIPTION
from @jni and myself - here is a fix for napari/napari#3723, we added a center setter to the `Rect` class and use this rather than specific logic in the panzoom camera center setter.

The logic in the previous setter was incorrectly setting the rectangle coordinates to the delta between centers, rather than shifting by that delta.