### PR TITLE
Expand docs on panzoom rect setter

### DIFF
--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -133,7 +133,8 @@ class PanZoomCamera(BaseCamera):
     @property
     def rect(self):
         """The rectangular border of the ViewBox visible area, expressed in
-        the coordinate system of the scene.
+        the coordinate system of the scene. See `~vispy.geometry.rect.Rect`
+        for different ways this can be specified.
 
         Note that the rectangle can have negative width or height, in
         which case the corresponding dimension is flipped (this flipping

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -132,9 +132,11 @@ class PanZoomCamera(BaseCamera):
 
     @property
     def rect(self):
-        """The rectangular border of the ViewBox visible area, expressed in
-        the coordinate system of the scene. See `~vispy.geometry.rect.Rect`
-        for different ways this can be specified.
+        """The rectangular border of the ViewBox visible area.
+        
+        This is expressed in the coordinate system of the scene.
+        See :class:`~vispy.geometry.rect.Rect` for different ways this can
+        be specified.
 
         Note that the rectangle can have negative width or height, in
         which case the corresponding dimension is flipped (this flipping


### PR DESCRIPTION
This adds a reference to the ways the view rectangle can be specified, clearing up potential confusion. Fixes https://github.com/vispy/vispy/issues/2316.