### PR TITLE
Fixed Typo in Nested Viewbox Name

### DIFF
--- a/examples/scene/nested_viewbox.py
+++ b/examples/scene/nested_viewbox.py
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 # vispy: gallery 2
 """
-Nexted Viewboxes
+Nested Viewboxes
 ================
 
 Simple test of nested viewboxes, demonstrating the three methods that


### PR DESCRIPTION
Changed "Nexted Viewboxes" --> "Nested Viewboxes" 

This leads to more serious typos in user generated docs ( see: https://vispy.org/gallery/scene/nested_viewbox.html title and label in right pane)