### PR TITLE
Add `blend_equation` (add) to GL_PRESETS

### DIFF
--- a/vispy/app/tests/test_canvas.py
+++ b/vispy/app/tests/test_canvas.py
@@ -69,3 +69,38 @@ def test_canvas_render(blend_func):
         else:
             # the alpha should have some transparency
             assert (rgba_result[..., 3] != 255).any()
+
+
+@requires_application()
+@pytest.mark.parametrize(
+    'preset',
+    [
+        'opaque', 'additive', 'translucent',
+    ])
+def test_blend_presets(preset):
+    """Test blending presets a canvas to an array.
+
+    Different blending presets are used to test that they properly set
+    blend equations.
+
+    """
+    with Canvas(size=(125, 125), show=True, title='run') as c:
+        im1 = np.zeros((100, 100, 4)).astype(np.float32)
+        im1[:, :, 1] = 1
+        im1[:, :, 3] = .4
+        # Create the image
+        image1 = ImageVisual(im1)
+        image1.transform = STTransform(translate=(20, 20, -1))
+        image1.transforms.configure(canvas=c, viewport=(0, 0, 125, 125))
+        
+        gloo.set_state(blend_equation='min')
+        image1.set_gl_state(preset)
+
+        @c.events.draw.connect
+        def on_draw(ev):
+            gloo.clear('black')
+            gloo.set_viewport(0, 0, *c.physical_size)
+            image1.draw()
+            
+        rgba_result = c.render()
+        assert not np.allclose(rgba_result[..., :3], 0)

--- a/vispy/app/tests/test_canvas.py
+++ b/vispy/app/tests/test_canvas.py
@@ -68,6 +68,8 @@ def test_canvas_render(blend_func):
             np.testing.assert_allclose(rgba_result[..., 3], 255)
         else:
             # the alpha should have some transparency
+            # this part of this test fails on macOS 12 at the moment
+            # see https://github.com/vispy/vispy/pull/2324#issuecomment-1163350672
             assert (rgba_result[..., 3] != 255).any()
 
 

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -43,12 +43,14 @@ GL_PRESETS = {
         depth_test=True,
         cull_face=False,
         blend=True,
-        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one')),
+        blend_func=('src_alpha', 'one_minus_src_alpha', 'zero', 'one'),
+        blend_equation='func_add'),
     'additive': dict(
         depth_test=False,
         cull_face=False,
         blend=True,
-        blend_func=('src_alpha', 'one')),
+        blend_func=('src_alpha', 'one'),
+        blend_equation='func_add'),
 }
 
 

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -2,7 +2,7 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-from vispy import scene
+from vispy import gloo, scene
 from vispy.testing import requires_application, TestingCanvas
 from vispy.visuals.transforms import STTransform
 
@@ -88,3 +88,32 @@ def test_picking_basic():
             assert len(picked_visuals) == 2
             assert any(isinstance(vis, scene.ViewBox) for vis in picked_visuals)
             assert any(isinstance(vis, scene.Line) for vis in picked_visuals)
+
+
+@requires_application()
+@pytest.mark.parametrize(
+    'preset',
+    [
+        'opaque', 'additive', 'translucent',
+    ])
+def test_blend_presets(preset):
+    """Test blending presets render a canvas to an array.
+
+    Different blending presets are used to test that they properly set
+    blend equations.
+
+    """
+    with TestingCanvas(size=(125, 125), show=True, title='run') as c:
+        view = c.central_widget.add_view()
+        im1 = np.zeros((100, 100, 4)).astype(np.float32)
+        im1[:, :, 1] = 1
+        im1[:, :, 3] = .4
+        # Create the image
+        image1 = scene.visuals.Image(im1, parent=view.scene)
+        image1.transform = STTransform(translate=(20, 20, -1))
+
+        gloo.set_state(blend_equation='min')
+        image1.set_gl_state(preset)
+
+        rgba_result = c.render()
+        assert not np.allclose(rgba_result[..., :3], 0)


### PR DESCRIPTION
In https://github.com/vispy/vispy/pull/2320 new `blend_equation` options were added. 🎉 
But existing presets (`GL_PRESETS`) don't explicitly set `func_add` as the `blend_equation`—it is the default though. Meanwhile, `set_state` essentially toggles functionality (`glBlendEquation` in this case), so if a different `blend_equation` is explicitly specified and then a preset is used currently, the blend equation is re-used for the preset, because the preset does not re-enable the default. 
I think this behavior is unintuitive and should be considered a bug.

This PR explicitly sets `blend_equation='func_add'` in the `translucent` and `additive` GL_PRESETS so use of the preset alone always sets the correct `blend_equation`. The user can still override, as usual.

Try this from the examples:
```
#!/usr/bin/env python
# -*- coding: utf-8 -*-

import sys
import numpy as np
from vispy import app, gloo
from vispy.visuals.collections import PointCollection
from vispy.visuals.transforms import PanZoomTransform

canvas = app.Canvas(size=(800, 600), show=True, keys="interactive")
gloo.set_viewport(0, 0, canvas.size[0], canvas.size[1])
# Set a `blend_equation` explicitly
gloo.set_state(blend=True, blend_equation="min")
# Use a preset
gloo.set_state("translucent", depth_test=False)

panzoom = PanZoomTransform(canvas)

points = PointCollection("agg", color="shared", transform=panzoom)
points.append(np.random.normal(0.0, 0.5, (10000, 3)), itemsize=5000)
points["color"] = (1, 0, 0, 1), (0, 0, 1, 1)
points.update.connect(canvas.update)

@canvas.connect
def on_draw(event):
    gloo.clear("white")
    points.draw()

@canvas.connect
def on_resize(event):
    width, height = event.size
    gloo.set_viewport(0, 0, width, height)

if __name__ == "__main__" and sys.flags.interactive == 0:
    app.run()
```
On main, this will keep the `min` blending, even though `translucent` was set afterwards, because the preset `translucent` doesn't explicitly state that `func_add` should be used—it's just the default—so the `min` `blend_equation` is not overwritten.
With this PR, the proper `translucent` blending should be observed.

Tests should be unaffected, I get the same results of a local pytest run on my mac (13 fails, btw arm64 macOS 12.3.1).