### PR TITLE
Fix clipping planes logic for `Volume` and `PlanesClipper`

### DIFF
--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -26,8 +26,6 @@ view = canvas.central_widget.add_view()
 # Create the visuals
 vol = np.load(io.load_data_file('volume/stent.npz'))['arr_0']
 volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
-volume2 = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
-volume2.transform = scene.STTransform(translate=(32, 32, 32))
 
 np.random.seed(1)
 points = np.random.rand(100, 3) * (128, 128, 128)
@@ -68,14 +66,12 @@ def add_clip(mode):
         return
     clipping_planes = np.concatenate([volume.clipping_planes, clip_modes[mode]])
     volume.clipping_planes = clipping_planes
-    volume2.clipping_planes = clipping_planes
     clipper.clipping_planes = clipping_planes
 
 
 def remove_clip():
     if volume.clipping_planes.shape[0] > 0:
         volume.clipping_planes = volume.clipping_planes[:-1]
-        volume2.clipping_planes = volume.clipping_planes[:-1]
         clipper.clipping_planes = clipper.clipping_planes[:-1]
 
 

--- a/examples/scene/clipping_planes.py
+++ b/examples/scene/clipping_planes.py
@@ -26,6 +26,8 @@ view = canvas.central_widget.add_view()
 # Create the visuals
 vol = np.load(io.load_data_file('volume/stent.npz'))['arr_0']
 volume = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
+volume2 = scene.visuals.Volume(vol, parent=view.scene, threshold=0.225)
+volume2.transform = scene.STTransform(translate=(32, 32, 32))
 
 np.random.seed(1)
 points = np.random.rand(100, 3) * (128, 128, 128)
@@ -66,12 +68,14 @@ def add_clip(mode):
         return
     clipping_planes = np.concatenate([volume.clipping_planes, clip_modes[mode]])
     volume.clipping_planes = clipping_planes
+    volume2.clipping_planes = clipping_planes
     clipper.clipping_planes = clipping_planes
 
 
 def remove_clip():
     if volume.clipping_planes.shape[0] > 0:
         volume.clipping_planes = volume.clipping_planes[:-1]
+        volume2.clipping_planes = volume.clipping_planes[:-1]
         clipper.clipping_planes = clipper.clipping_planes[:-1]
 
 

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -2,6 +2,10 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
+from __future__ import annotations
+
+from typing import Optional
+
 from functools import lru_cache
 
 import numpy as np
@@ -37,7 +41,7 @@ class PlanesClipper(Filter):
     }
     """
 
-    def __init__(self, clipping_planes=None, coord_system='scene'):
+    def __init__(self, clipping_planes: Optional[np.ndarray] = None, coord_system: str = 'scene'):
         tr = ['visual', 'scene', 'document', 'canvas', 'framebuffer', 'render']
         if coord_system not in tr:
             raise ValueError(f'Invalid coordinate system {coord_system}. Must be one of {tr}.')
@@ -55,7 +59,7 @@ class PlanesClipper(Filter):
         self.clipping_planes = clipping_planes
 
     @property
-    def coord_system(self):
+    def coord_system(self) -> str:
         """
         Coordinate system used by the clipping planes (see visuals.transforms.transform_system.py)
         """
@@ -68,7 +72,7 @@ class PlanesClipper(Filter):
 
     @staticmethod
     @lru_cache(maxsize=10)
-    def _build_clipping_planes_glsl(n_planes):
+    def _build_clipping_planes_glsl(n_planes: int) -> str:
         """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc) {{
@@ -90,14 +94,14 @@ class PlanesClipper(Filter):
         return formatted_code
 
     @property
-    def clipping_planes(self):
+    def clipping_planes(self) -> np.ndarray:
         """Get the set of planes used to clip the mesh.
         Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3)
         """
         return self._clipping_planes
 
     @clipping_planes.setter
-    def clipping_planes(self, value):
+    def clipping_planes(self, value: Optional[np.ndarray]):
         if value is None:
             value = np.empty([0, 2, 3])
         self._clipping_planes = value

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -68,7 +68,7 @@ class PlanesClipper(Filter):
 
     @staticmethod
     @lru_cache(maxsize=10)
-    def _build_clipping_planes_func(n_planes):
+    def _build_clipping_planes_glsl(n_planes):
         """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc) {{
@@ -87,7 +87,7 @@ class PlanesClipper(Filter):
         for idx in range(n_planes):
             all_clips.append(clip_template.format(idx=idx))
         formatted_code = func_template.format(clips=''.join(all_clips))
-        return Function(formatted_code)
+        return formatted_code
 
     @property
     def clipping_planes(self):
@@ -102,7 +102,7 @@ class PlanesClipper(Filter):
             value = np.empty([0, 2, 3])
         self._clipping_planes = value
 
-        clip_func = self._build_clipping_planes_func(len(value))
+        clip_func = Function(self._build_clipping_planes_glsl(len(value)))
         self.fshader['clip_with_planes'] = clip_func
 
         for idx, plane in enumerate(value):

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -883,7 +883,7 @@ class VolumeVisual(Visual):
 
     @staticmethod
     @lru_cache(maxsize=10)
-    def _build_clipping_planes_func(n_planes):
+    def _build_clipping_planes_glsl(n_planes):
         """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc, vec3 vol_shape) {{
@@ -929,7 +929,7 @@ class VolumeVisual(Visual):
             value = np.empty([0, 2, 3])
         self._clipping_planes = value
 
-        self._clip_func = Function(self._build_clipping_planes_func(len(value)))
+        self._clip_func = Function(self._build_clipping_planes_glsl(len(value)))
         self.shared_program.frag['clip_with_planes'] = self._clip_func
 
         self._clip_func['clip_transform'] = self._clip_transform

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -34,6 +34,9 @@ The ray is expressed in coordinates local to the volume (i.e. texture
 coordinates).
 
 """
+from __future__ import annotations
+
+from typing import Optional
 from functools import lru_cache
 
 from ._scalable_textures import CPUScaledTexture3D, GPUScaledTextured3D
@@ -883,7 +886,7 @@ class VolumeVisual(Visual):
 
     @staticmethod
     @lru_cache(maxsize=10)
-    def _build_clipping_planes_glsl(n_planes):
+    def _build_clipping_planes_glsl(n_planes: int) -> str:
         """Build the code snippet used to clip the volume based on self.clipping_planes."""
         func_template = '''
             float clip_planes(vec3 loc, vec3 vol_shape) {{
@@ -906,7 +909,7 @@ class VolumeVisual(Visual):
         return formatted_code
 
     @property
-    def clipping_planes(self):
+    def clipping_planes(self) -> np.ndarray:
         """The set of planes used to clip the volume. Values on the negative side of the normal are discarded.
 
         Each plane is defined by a position and a normal vector (magnitude is irrelevant). Shape: (n_planes, 2, 3).
@@ -924,7 +927,7 @@ class VolumeVisual(Visual):
         return self._clipping_planes
 
     @clipping_planes.setter
-    def clipping_planes(self, value):
+    def clipping_planes(self, value: Optional[np.ndarray]):
         if value is None:
             value = np.empty([0, 2, 3])
         self._clipping_planes = value
@@ -939,7 +942,7 @@ class VolumeVisual(Visual):
         self.update()
 
     @property
-    def clipping_planes_coord_system(self):
+    def clipping_planes_coord_system(self) -> str:
         """
         Coordinate system used by the clipping planes (see visuals.transforms.transform_system.py)
         """


### PR DESCRIPTION
In napari/napari#4503, @ch-n noticed something wrong with the behaviour of clipping planes and the `Volume` visual. This PR fixes that issue.

EDIT: I added changes to the example for testing, but those should probably be reverted before merging!

Specifically, the problem was introduced with #2197, where the ability of using any coordinate space for clipping planes was added, and I messed up the math :P We need to convert the texture coordinate to the chosen space *after* reshaping, and then clip by simply comparing the pure clip coordinates with the new location. Instead, I was doing a weird messy mix that only worked because all the tests were with a non-transformed volume. Once again, I'm getting burned by non-generalized testing :/

Additionally, this PR changes  `_build_clipping_planes_func` to return just code, instead of a function object; before, the *same* function object would be returned due to the use of `lru_cache`, which broke the ability to use multiple image visuals with different clipping planes.

The two issues above combined in the following behaviour (this is just the `examples/scene/clipping_planes.py` with an additional translated volume):

Before (notice how clipping is not working for *both* volumes, even the one that normally worked; this is due to the cached `Function`):

https://user-images.githubusercontent.com/23482191/167415065-eefb244d-e836-4a7f-bf1d-bb754194f125.mp4

After:

https://user-images.githubusercontent.com/23482191/167415083-88218102-12cc-493e-87bf-9c1dfe7c004c.mp4

