### PR TITLE
Fix cibuildwheel failing on skipping old python versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.1.1
       env:
-        CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* pp* *-win32 *-manylinux_i686"
+        CIBW_SKIP: "cp36-* pp* *-win32 *-manylinux_i686"
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}
         CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow sphinx_gallery imageio"
         CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""


### PR DESCRIPTION
cibuildwheel no longer recognizes python version specifiers older than Python 3.6. This means we no longer need to skip Python 2.7, 3.4, and 3.5. In fact, cibuildwheel was failing because we were specifying them. Let's see how this CI goes...