### PR TITLE
Fix link to CHANGELOG.md in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ large datasets. Applications of VisPy include:
 Releases
 --------
 
-See [CHANGELOG.md](./CHANGELOG.md).
+See `CHANGELOG.md <./CHANGELOG.md>`_.
 
 Announcements
 -------------


### PR DESCRIPTION
The README.rst is using .md syntax for the link to the CHANGELOG.md.
This fixes it to use .rst syntax, so the link works.