### PR TITLE
Fix test examples on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,6 +267,8 @@ jobs:
         if [ "${{ matrix.test }}" == 'examples' ]; then
           export DISPLAY=:99.0
           export XDG_RUNTIME_DIR=/tmp/runtime-runner
+          mkdir -p $XDG_RUNTIME_DIR
+          chmod 0700 $XDG_RUNTIME_DIR
           make examples
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then


### PR DESCRIPTION
Small change attempting to fix the testing workflow on the examples run, which currently fails with a bunch of:

```
WARNING: QStandardPaths: XDG_RUNTIME_DIR points to non-existing path '/tmp/runtime-runner', please create it with 0700 permissions.
```

I don't know why this showed up now, maybe some newer version of Qt is not automatically creating this, while it used to?
