### PR TITLE
add alias cubic=bicubic for image interpolation

### DIFF
--- a/vispy/glsl/build_spatial_filters.py
+++ b/vispy/glsl/build_spatial_filters.py
@@ -55,7 +55,7 @@ Available filters:
   - Hermite (radius 1)
   - Kaiser (radius 1)
   - Quadric (radius 1.5)
-  - Bicubic (radius 2)
+  - Cubic (radius 2)
   - CatRom (radius 2)
   - Mitchell (radius 2)
   - Spline16 (radius 2)
@@ -202,9 +202,9 @@ class Quadric(SpatialFilter):
         return 0
 
 
-class Bicubic(SpatialFilter):
+class Cubic(SpatialFilter):
     """
-    Bicubic filter (radius = 2).
+    Cubic filter (radius = 2).
 
     Weight function::
 
@@ -579,7 +579,7 @@ def generate_filter_code(radius):
 def main():
     # Generate kernels texture (16 x 1024)
     filters = [Linear(), Hanning(), Hamming(), Hermite(), Kaiser(), Quadric(),
-               Bicubic(), CatRom(), Mitchell(), Spline16(), Spline36(), Gaussian(),
+               Cubic(), CatRom(), Mitchell(), Spline16(), Spline36(), Gaussian(),
                Bessel(), Sinc(), Lanczos(), Blackman()]
 
     n = 1024

--- a/vispy/glsl/misc/spatial-filters.frag
+++ b/vispy/glsl/misc/spatial-filters.frag
@@ -1326,11 +1326,11 @@ vec4 Quadric3D(sampler3D texture, vec3 shape, vec3 uv) {
     return filter3D_radius2(texture, u_kernel, 0.34375, uv, 1 / shape);
 }
 
-vec4 Bicubic2D(sampler2D texture, vec2 shape, vec2 uv) {
+vec4 Cubic2D(sampler2D texture, vec2 shape, vec2 uv) {
     return filter2D_radius2(texture, u_kernel, 0.40625, uv, 1 / shape);
 }
 
-vec4 Bicubic3D(sampler3D texture, vec3 shape, vec3 uv) {
+vec4 Cubic3D(sampler3D texture, vec3 shape, vec3 uv) {
     return filter3D_radius2(texture, u_kernel, 0.40625, uv, 1 / shape);
 }
 

--- a/vispy/io/datasets.py
+++ b/vispy/io/datasets.py
@@ -82,7 +82,7 @@ def load_spatial_filters(packed=True):
         not require a filter but can still be used
     """
     names = ("Linear", "Hanning", "Hamming", "Hermite",
-             "Kaiser", "Quadric", "Bicubic", "CatRom",
+             "Kaiser", "Quadric", "Cubic", "CatRom",
              "Mitchell", "Spline16", "Spline36", "Gaussian",
              "Bessel", "Sinc", "Lanczos", "Blackman", "Nearest")
 

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -211,11 +211,12 @@ class ImageVisual(Visual):
         in vispy/gloo/glsl/misc/spatial_filters.frag
 
             * 'nearest': Default, uses 'nearest' with Texture interpolation.
-            * 'bilinear': uses 'linear' with Texture interpolation.
-            * 'linear': alias for 'bilinear'
-            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'bicubic',
+            * 'linear': uses 'linear' with Texture interpolation.
+            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'cubic',
                 'catrom', 'mitchell', 'spline16', 'spline36', 'gaussian',
                 'bessel', 'sinc', 'lanczos', 'blackman'
+            * 'bilinear': alias for 'linear'
+            * 'bicubic': alias for cubic
             * 'custom': uses the sampling kernel provided through 'custom_kernel'.
     texture_format: numpy.dtype | str | None
         How to store data on the GPU. OpenGL allows for many different storage
@@ -349,9 +350,9 @@ class ImageVisual(Visual):
         hardware_lookup = Function(self._func_templates['texture_lookup'])
         interpolation_fun['nearest'] = hardware_lookup
         interpolation_fun['linear'] = hardware_lookup
-        # alias bilinear to linear for compatibility with Volume visual
+        # alias bilinear to linear and bicubic to cubic for compatibility with Volume visual
         # without breaking backward compatibility
-        interpolation_names = interpolation_names + ('bilinear',)
+        interpolation_names = interpolation_names + ('bilinear', 'bicubic')
         return interpolation_names, interpolation_fun
 
     def _init_texture(self, data, texture_format, **texture_kwargs):
@@ -522,6 +523,9 @@ class ImageVisual(Visual):
         # alias bilinear to linear
         if interpolation == 'bilinear':
             interpolation = 'linear'
+        # alias bicubic to cubic
+        if interpolation == 'bicubic':
+            interpolation = 'cubic'
         self._data_lookup_fn = self._interpolation_fun[interpolation]
         self.shared_program.frag['get_data'] = self._data_lookup_fn
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -617,7 +617,7 @@ class VolumeVisual(Visual):
 
             * 'nearest': Default, uses 'nearest' with Texture interpolation.
             * 'linear': uses 'linear' with Texture interpolation.
-            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'bicubic',
+            * 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric', 'cubic',
                 'catrom', 'mitchell', 'spline16', 'spline36', 'gaussian',
                 'bessel', 'sinc', 'lanczos', 'blackman'
     texture_format : numpy.dtype | str | None


### PR DESCRIPTION
When we merged #2322, we decided to switch from `bilinear` to `linear` as our base name for the shader interpolation function (for consistency between `Image` and `Volume`, otherwise we should have had `trilinear` in `Volume`). To preserve backwards compatibility, we added an alias for the old interpolation mode `bilinear`.

We missed however that the same could have been done for `bicubic` (if I understand correctly). This PR does just that; I didn't add any fallback for `Volume`, since it was just added in v0.11.0, but I can do that if others think we should preserve backward compatibility even this shortly.
