### PR TITLE
WIP: Texture as data source

### DIFF
--- a/vispy/gloo/tests/test_texture.py
+++ b/vispy/gloo/tests/test_texture.py
@@ -5,6 +5,9 @@
 # -----------------------------------------------------------------------------
 import unittest
 import numpy as np
+import pytest
+
+import numpy as np
 
 from vispy.gloo import Texture1D, Texture2D, Texture3D, TextureAtlas
 from vispy.testing import requires_pyopengl, run_tests_if_main, assert_raises
@@ -713,5 +716,19 @@ def test_texture_2D_internalformats():
 def test_texture_3D_internalformats():
     _test_texture_internalformats(Texture3D, (10, 10, 10))
 
+
+@requires_pyopengl()
+@pytest.mark.parametrize('input_dtype', [np.uint8, np.uint16, np.float32, np.float64])
+@pytest.mark.parametrize('output_dtype', [np.uint8, np.uint16, np.float32, np.float64])
+def test_texture_set_data_different_dtype(input_dtype, output_dtype):
+    data2D = np.random.rand(20, 20).astype(input_dtype)
+    tex2D = Texture2D(data2D)
+    tex2D[:10] = np.array(1, dtype=output_dtype)
+    tex2D.set_data(data2D.astype(output_dtype))
+
+    data3D = np.random.rand(20, 20, 20).astype(input_dtype)
+    tex3D = Texture3D(data3D)
+    tex2D[:10] = np.array(1, dtype=output_dtype)
+    tex3D.set_data(data3D.astype(output_dtype))
 
 run_tests_if_main()

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -114,9 +114,9 @@ class BaseTexture(GLObject):
 
         # Init shape and format
         self._resizable = True  # at least while we're in init
-        self._shape = tuple([0 for i in range(self._ndim+1)])
         self._format = format
         self._internalformat = internalformat
+        self._data = None
 
         # Set texture parameters (before setting data)
         self.interpolation = interpolation or 'nearest'
@@ -130,7 +130,7 @@ class BaseTexture(GLObject):
                 raise ValueError('Texture needs data or shape, not both.')
             data = np.array(data, copy=False)
             # So we can test the combination
-            self._resize(data.shape, format, internalformat)
+            self._check_shape_and_format(data.shape, format, internalformat)
             self._set_data(data)
         elif shape is not None:
             self._resize(shape, format, internalformat)
@@ -149,24 +149,23 @@ class BaseTexture(GLObject):
             assert isinstance(data_or_shape, tuple)
             data = None
             shape = data_or_shape
-        # Check and correct
-        if shape:
-            if len(shape) < self._ndim:
-                raise ValueError("Too few dimensions for texture")
-            elif len(shape) > self._ndim + 1:
-                raise ValueError("Too many dimensions for texture")
-            elif len(shape) == self._ndim:
-                shape = shape + (1,)
-            else:  # if len(shape) == self._ndim + 1:
-                if shape[-1] > 4:
-                    raise ValueError("Too many channels for texture")
+
+        if len(shape) < self._ndim:
+            raise ValueError("Too few dimensions for texture")
+        elif len(shape) > self._ndim + 1:
+            raise ValueError("Too many dimensions for texture")
+        elif len(shape) == self._ndim:
+            shape = shape + (1,)
+        else:  # if len(shape) == self._ndim + 1:
+            if shape[-1] > 4:
+                raise ValueError("Too many channels for texture")
         # Return
         return data.reshape(shape) if data is not None else shape
 
     @property
     def shape(self):
         """Data shape (last dimension indicates number of color channels)"""
-        return self._shape
+        return self._data.shape
 
     @property
     def format(self):
@@ -288,8 +287,7 @@ class BaseTexture(GLObject):
             raise ValueError('Internalformat does not match with given shape.')
         return internalformat
 
-    def _resize(self, shape, format=None, internalformat=None):
-        """Internal method for resize."""
+    def _check_shape_and_format(self, shape, format, internalformat):
         shape = self._normalize_shape(shape)
 
         # Check
@@ -298,12 +296,17 @@ class BaseTexture(GLObject):
 
         format = self._check_format_change(format, shape[-1])
         internalformat = self._check_internalformat_change(internalformat, shape[-1])
+        return shape, format, internalformat
 
+    def _resize(self, shape, format=None, internalformat=None):
+        """Internal method for resize."""
         # Store and send GLIR command
-        self._shape = shape
+        shape, format, internalformat = self._check_shape_and_format(shape, format, internalformat)
+        if self._data is not None:
+            self._data = np.resize(self._data.resize, shape)
         self._format = format
         self._internalformat = internalformat
-        self._glir.command('SIZE', self._id, self._shape, self._format,
+        self._glir.command('SIZE', self._id, shape, self._format,
                            self._internalformat)
 
     def set_data(self, data, offset=None, copy=False):
@@ -325,7 +328,7 @@ class BaseTexture(GLObject):
         This operation implicitly resizes the texture to the shape of
         the data if given offset is None.
         """
-        return self._set_data(data, offset, copy)
+        self._set_data(data, offset, copy)
 
     def _set_data(self, data, offset=None, copy=False):
         """Internal method for set_data."""
@@ -334,82 +337,72 @@ class BaseTexture(GLObject):
         data = self._normalize_shape(data)
 
         # Maybe resize to purge DATA commands?
-        if offset is None:
+        if offset is None or all([i == 0 for i in offset]):
             self._resize(data.shape)
-        elif all([i == 0 for i in offset]) and data.shape == self._shape:
-            self._resize(data.shape)
+        else:
+            # Check if data fits
+            for i in range(len(data.shape)-1):
+                if offset[i] + data.shape[i] > self._data.shape[i]:
+                    raise ValueError("Data is too large")
 
         # Convert offset to something usable
         offset = offset or tuple([0 for i in range(self._ndim)])
         assert len(offset) == self._ndim
 
-        # Check if data fits
-        for i in range(len(data.shape)-1):
-            if offset[i] + data.shape[i] > self._shape[i]:
-                raise ValueError("Data is too large")
-
+        # convert offset to slices
+        if all(i == 0 for i in offset):
+            # probably better cause it does not mess with memory
+            self._data = data
+        else:
+            offset_slices = tuple(slice(i, None) for i in offset)
+            self._data[offset_slices] = data
         # Send GLIR command
         self._glir.command('DATA', self._id, offset, data)
 
+    def _update_data(self, offset=None):
+        if offset is None:
+            offset = tuple(0 for i in range(self._ndim))
+        offset_slices = tuple(slice(i, None) for i in offset)
+        print(type(offset))
+        self._glir.command('DATA', self._id, offset, self._data[offset_slices])
+
+    def __getitem__(self, key):
+        return self._data[key]
+
     def __setitem__(self, key, data):
         """x.__getitem__(y) <==> x[y]"""
+        self._data[key] = data
+
         # Make sure key is a tuple
         if isinstance(key, (int, slice)) or key == Ellipsis:
             key = (key,)
-
-        # Default is to access the whole texture
-        shape = self._shape
-        slices = [slice(0, shape[i]) for i in range(len(shape))]
 
         # Check last key/Ellipsis to decide on the order
         keys = key[::+1]
         dims = range(0, len(key))
         if key[0] == Ellipsis:
             keys = key[::-1]
-            dims = range(len(self._shape) - 1,
-                         len(self._shape) - 1 - len(keys), -1)
+            dims = range(len(self._data.shape) - 1,
+                         len(self._data.shape) - 1 - len(keys), -1)
 
         # Find exact range for each key
+        offset = [0 for _ in range(self._ndim)]
         for k, dim in zip(keys, dims):
-            size = self._shape[dim]
             if isinstance(k, int):
-                if k < 0:
-                    k += size
-                if k < 0 or k > size:
-                    raise IndexError("Texture assignment index out of range")
-                start, stop = k, k + 1
-                slices[dim] = slice(start, stop, 1)
+                offset[dim] = k
             elif isinstance(k, slice):
-                start, stop, step = k.indices(size)
-                if step != 1:
-                    raise IndexError("Cannot access non-contiguous data")
-                if stop < start:
-                    start, stop = stop, start
-                slices[dim] = slice(start, stop, step)
+                offset[dim] = k.start or 0
             elif k == Ellipsis:
                 pass
             else:
                 raise TypeError("Texture indices must be integers")
 
-        offset = tuple([s.start for s in slices])[:self._ndim]
-        shape = tuple([s.stop - s.start for s in slices])
-        size = np.prod(shape) if len(shape) > 0 else 1
-
-        # Make sure data is an array
-        if not isinstance(data, np.ndarray):
-            data = np.array(data, copy=False)
-        # Make sure data is big enough
-        if data.shape != shape:
-            data = np.resize(data, shape)
-        # Ensure dtype is the same as the current (eventual downcasting will happen later)
-        data = np.array(data, dtype=getattr(self, '_data_dtype', None), copy=False)
-
-        # Set data (deferred)
-        self._set_data(data=data, offset=offset, copy=False)
+        offset = tuple(offset)
+        self._update_data(offset)
 
     def __repr__(self):
         return "<%s shape=%r format=%r at 0x%x>" % (
-            self.__class__.__name__, self._shape, self._format, id(self))
+            self.__class__.__name__, self._data.shape, self._format, id(self))
 
 
 # --------------------------------------------------------- Texture1D class ---
@@ -456,7 +449,7 @@ class Texture1D(BaseTexture):
     @property
     def width(self):
         """Texture width"""
-        return self._shape[0]
+        return self._data.shape[0]
 
     @property
     def glsl_type(self):
@@ -517,12 +510,12 @@ class Texture2D(BaseTexture):
     @property
     def height(self):
         """Texture height"""
-        return self._shape[0]
+        return self._data.shape[0]
 
     @property
     def width(self):
         """Texture width"""
-        return self._shape[1]
+        return self._data.shape[1]
 
     @property
     def glsl_type(self):
@@ -584,17 +577,17 @@ class Texture3D(BaseTexture):
     @property
     def width(self):
         """Texture width"""
-        return self._shape[2]
+        return self._data.shape[2]
 
     @property
     def height(self):
         """Texture height"""
-        return self._shape[1]
+        return self._data.shape[1]
 
     @property
     def depth(self):
         """Texture depth"""
-        return self._shape[0]
+        return self._data.shape[0]
 
     @property
     def glsl_type(self):
@@ -652,24 +645,24 @@ class TextureCube(BaseTexture):
                  internalformat=None, resizeable=None):
         BaseTexture.__init__(self, data, format, resizable, interpolation,
                              wrapping, shape, internalformat, resizeable)
-        if self._shape[0] != 6:
+        if self._data.shape[0] != 6:
             raise ValueError("Texture cube require arrays first dimension to be 6 :"
-                             " {} was given.".format(self._shape[0]))
+                             " {} was given.".format(self._data.shape[0]))
 
     @property
     def height(self):
         """Texture height"""
-        return self._shape[1]
+        return self._data.shape[1]
 
     @property
     def width(self):
         """Texture width"""
-        return self._shape[2]
+        return self._data.shape[2]
 
     @property
     def depth(self):
         """Texture depth"""
-        return self._shape[0]
+        return self._data.shape[0]
 
     @property
     def glsl_type(self):
@@ -1004,13 +997,13 @@ class TextureAtlas(Texture2D):
         node = self._atlas_nodes[index]
         x, y = node[0], node[1]
         width_left = width
-        if x+width > self._shape[1]:
+        if x+width > self._data.shape[1]:
             return -1
         i = index
         while width_left > 0:
             node = self._atlas_nodes[i]
             y = max(y, node[1])
-            if y+height > self._shape[0]:
+            if y+height > self._data.shape[0]:
                 return -1
             width_left -= node[2]
             i += 1

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -330,8 +330,6 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
         self._data_limits = data_limits
         return super().scale_and_set_data(data, offset=offset, copy=False)
 
-    def _update_data(self, offset=None):
-        data, clim, data_limits = self._scale_data_and_clim(self._data, copy)
 
 class GPUScaledTextureMixin(_ScaledTextureMixin):
     """Texture class for smarter scaling and internalformat decisions.

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 
 from vispy.gloo import Texture2D, Texture3D
-from vispy.gloo.texture import downcast_to_32
 
 
 def get_default_clim_from_dtype(dtype):

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -210,7 +210,8 @@ class _ScaledTextureMixin:
 
     def scale_and_set_data(self, data, offset=None, copy=False):
         """Upload new data to the GPU."""
-        return self._set_data(data, offset=offset, copy=copy)
+        # we need to call super here or we get infinite recursion
+        return super().set_data(data, offset=offset, copy=copy)
 
 
 class CPUScaledTextureMixin(_ScaledTextureMixin):

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -8,7 +8,7 @@ from __future__ import division
 import numpy as np
 
 from ..gloo import Texture2D, VertexBuffer
-from ..gloo.texture import should_cast_to_f32
+from ..gloo.texture import downcast_to_32
 from ..color import get_colormap
 from .shaders import Function, FunctionChain
 from .transforms import NullTransform
@@ -373,7 +373,7 @@ class ImageVisual(Visual):
             )
         return tex
 
-    def set_data(self, image):
+    def set_data(self, image, copy=False):
         """Set the image data.
 
         Parameters
@@ -388,8 +388,7 @@ class ImageVisual(Visual):
             raise TypeError(
                 "Complex data types not supported. Please use 'ComplexImage' instead"
             )
-        if should_cast_to_f32(data.dtype):
-            data = data.astype(np.float32)
+        data = downcast_to_32(data, copy=copy)
         # can the texture handle this data?
         self._texture.check_data_format(data)
         if self._data is None or self._data.shape[:2] != data.shape[:2]:

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -308,6 +308,7 @@ def test_image_interpolation():
     center_right = (41, 40)
     white = (255, 255, 255, 255)
     black = (255, 255, 255, 255)
+    # TODO: somethign went wrong here, with black being white :/
     gray = (130, 130, 130, 255)
 
     with TestingCanvas(size=size[::-1], bgcolor="w") as c:
@@ -342,5 +343,36 @@ def test_image_interpolation():
         assert np.allclose(render[right], black)
         assert np.allclose(render[center_left], gray)
 
+
+def test_image_set_data_different_dtype():
+    size = (80, 80)
+    data = np.array([[0, 255]], dtype=np.int8)
+    right = (40, 20)
+    left = (40, 60)
+    white = (255, 255, 255, 255)
+    black = (0, 0, 0, 255)
+
+
+    # TODO: ALL WRONG!
+    with TestingCanvas(size=size[::-1], bgcolor="w") as c:
+        view = c.central_widget.add_view()
+        view.camera = PanZoomCamera((0, 0, 2, 1))
+        image = Image(data=data, cmap='grays',
+                      parent=view.scene)
+
+        render = c.render()
+        assert np.allclose(render[left], black)
+        assert np.allclose(render[right], white)
+
+        image.set_data(data.astype(np.float32))
+        render = c.render()
+        assert np.allclose(render[left], black)
+        assert np.allclose(render[right], white)
+
+        # something very different and out of bounds
+        new_data = np.array([[100000, 0]], dtype=np.float32)
+        image.set_data(new_data)
+        assert np.allclose(render[left], black)
+        assert np.allclose(render[right], white)
 
 run_tests_if_main()

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -253,6 +253,7 @@ def test_set_data_does_not_change_input():
     # using set_data() with `copy=False` should be expected to alter the data.
     vol2 = np.array(vol, dtype='float32', copy=True)
     assert np.allclose(vol, vol2)
+    print(1, vol.data)
     V.set_data(vol2, clim=(0, 200), copy=False)
     assert not np.allclose(vol, vol2)
 

--- a/vispy/visuals/tests/test_volume.py
+++ b/vispy/visuals/tests/test_volume.py
@@ -253,7 +253,6 @@ def test_set_data_does_not_change_input():
     # using set_data() with `copy=False` should be expected to alter the data.
     vol2 = np.array(vol, dtype='float32', copy=True)
     assert np.allclose(vol, vol2)
-    print(1, vol.data)
     V.set_data(vol2, clim=(0, 200), copy=False)
     assert not np.allclose(vol, vol2)
 

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -816,8 +816,8 @@ class VolumeVisual(Visual):
 
         Parameters
         ----------
-        vol : ndarray or Texture
-            The 3D volume,
+        vol : ndarray
+            The 3D volume.
         clim : tuple
             Colormap limits to use (min, max). None will use the min and max
             values. Defaults to ``None``.
@@ -856,9 +856,6 @@ class VolumeVisual(Visual):
             self._vol_shape = shape
             self._need_vertex_update = True
         self._vol_shape = shape
-
-    def __setitem__(self, key, value):
-        self._texture.__setitem__(key, value)
 
     @property
     def rendering_methods(self):


### PR DESCRIPTION
*Note that this PR includes #2350 to correctly cast dtypes.*

This PR is an attempt at implementing a form of "data source" in vispy. This stems from previous discussions both on napari channels and on the vispy gitter.


This particular implementation does *not* introduce a new object; instead, it expands the `gloo.Texture` object to be able to keep track of the data it represents on the CPU side as well. This is a WIP implementation which currently works well with the `ImageVisual`, but not all tests pass and probably breaks all sorts of other things. To see how it works, try the following:

```py
from vispy import scene
from vispy.io import load_data_file, read_png

canvas = scene.SceneCanvas(keys='interactive')
canvas.size = 800, 600
canvas.show()

view = canvas.central_widget.add_view()
img_data = read_png(load_data_file('mona_lisa/mona_lisa_sm.png'))

image = scene.visuals.Image(img_data, parent=view.scene)

view.camera = scene.PanZoomCamera(aspect=1)
view.camera.flip = (0, 1, 0)
view.camera.set_range()
```

Then, you can alter the texture data like this:

```py
image._texture[:, 250:300] = [127, 0, 0]
image.update()
```

Or access it from the texture + chnage it from the `Image` level:

```py
image.set_data(image._texture._data * 2)
image.update()
```

The ultimate goal is to then be able to easily do things like sharing textures between images:

```py
import numpy as np

rand_data = np.random.randint(0, 127, (100, 100), dtype=np.int8)
image2 = scene.visuals.Image(rand_data, parent=view.scene)
image2.transform = scene.STTransform(translate=(-100, 0))
image.set_texture(image2._texture)
```

without ending up with broken states. The above code *works* here, but I haven't tested it properly yet, and I'm sure it needs some checks and protections (and maybe disallowing changing texture class).

@djhoese does this resemble what you had in mind? I found it was a lot easier to work on the `Texture` object, rather than creating a wrapper around it.

Might be interested and/or have good insight: @almarklein, @rossant

cc @melonora