### PR TITLE
Fix a few comment and docstring typos

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -255,7 +255,7 @@ Windows
 
 In Windows, you should open the the Nvidia-console and add your specific
 python to the list of programs that should use the dedicated graphics card.
-Note that this setting is seperate for different conda environments so make
+Note that this setting is separate for different conda environments so make
 sure you have selected the one you are using VisPy with.
 
 Linux

--- a/examples/gloo/animate_shape.py
+++ b/examples/gloo/animate_shape.py
@@ -23,7 +23,7 @@ im1[:50, :, 0] = 1.0
 im1[:, :50, 1] = 1.0
 im1[50:, 50:, 2] = 1.0
 
-# Create vetices and texture coords, combined in one array for high performance
+# Create vertices and texture coords, combined in one array for high performance
 vertex_data = np.zeros(4, dtype=[('a_position', np.float32, 3),
                                  ('a_texcoord', np.float32, 2)])
 vertex_data['a_position'] = np.array([[-0.8, -0.8, 0.0], [+0.7, -0.7, 0.0],

--- a/vispy/io/image.py
+++ b/vispy/io/image.py
@@ -35,7 +35,7 @@ def _make_png(data, level=6):
         PNG formatted array
     """
     # Eventually we might want to use ext/png.py for this, but this
-    # routine *should* be faster b/c it's speacialized for our use case
+    # routine *should* be faster b/c it's specialized for our use case
 
     def mkchunk(data, name):
         if isinstance(data, np.ndarray):

--- a/vispy/util/wrappers.py
+++ b/vispy/util/wrappers.py
@@ -9,7 +9,7 @@ and vispy.gloo.gl can be used independently, they are not complely
 independent for some configureation. E.g. when using real ES 2.0,
 the app backend should use EGL and not a desktop OpenGL context. Also,
 we probably want it to be easy to configure vispy to use the ipython
-notebook backend, which requires specifc config of both app and gl.
+notebook backend, which requires specific config of both app and gl.
 
 This module does not have to be aware of the available app and gl
 backends, but it should be(come) aware of (in)compatibilities between

--- a/vispy/visuals/collections/array_list.py
+++ b/vispy/visuals/collections/array_list.py
@@ -52,7 +52,7 @@ class ArrayList(object):
             an error is raised.
 
             If `itemsize` is 1-D array, the array will be divided into
-            elements whose succesive sizes will be picked from itemsize.
+            elements whose successive sizes will be picked from itemsize.
             If the sum of itemsize values is different from array size,
             an error is raised.
 
@@ -291,7 +291,7 @@ class ArrayList(object):
             an error is raised.
 
             If `itemsize` is 1-D array, the array will be divided into
-            elements whose succesive sizes will be picked from itemsize.
+            elements whose successive sizes will be picked from itemsize.
             If the sum of itemsize values is different from array size,
             an error is raised.
         """
@@ -394,7 +394,7 @@ class ArrayList(object):
             an error is raised.
 
             If `itemsize` is 1-D array, the array will be divided into
-            elements whose succesive sizes will be picked from itemsize.
+            elements whose successive sizes will be picked from itemsize.
             If the sum of itemsize values is different from array size,
             an error is raised.
         """

--- a/vispy/visuals/collections/base_collection.py
+++ b/vispy/visuals/collections/base_collection.py
@@ -237,7 +237,7 @@ class BaseCollection(object):
             an error is raised.
 
             If `itemsize` is 1-D array, the array will be divided into
-            elements whose succesive sizes will be picked from itemsize.
+            elements whose successive sizes will be picked from itemsize.
             If the sum of itemsize values is different from array size,
             an error is raised.
         """

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -367,7 +367,7 @@ class Visual(BaseVisual):
         *args : tuple
             Arguments.
         **kwargs : dict
-            Keyword argments.
+            Keyword arguments.
         """
         if len(args) == 1:
             self._vshare.gl_state['preset'] = args[0]
@@ -636,7 +636,7 @@ class CompoundVisual(BaseVisual):
         *args : tuple
             Arguments.
         **kwargs : dict
-            Keyword argments.
+            Keyword arguments.
         """
         for v in self._subvisuals:
             v.update_gl_state(*args, **kwargs)


### PR DESCRIPTION
There are small typos in:
- doc/installation.rst
- examples/gloo/animate_shape.py
- vispy/io/image.py
- vispy/util/wrappers.py
- vispy/visuals/collections/array_list.py
- vispy/visuals/collections/base_collection.py
- vispy/visuals/visual.py

Fixes:
- Should read `successive` rather than `succesive`.
- Should read `arguments` rather than `argments`.
- Should read `vertices` rather than `vetices`.
- Should read `specific` rather than `specifc`.
- Should read `specialized` rather than `speacialized`.
- Should read `separate` rather than `seperate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md