### PR TITLE
Fix marker size with anisotropic scaling

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -47,9 +47,18 @@ void main (void) {
 
     if (u_scaling == true) {
         // calculate point size from visual to framebuffer coords to determine size
-        vec4 x = $framebuffer_to_visual(fb_pos + vec4(big_float, 0, 0, 0));
-        x = (x - pos);
-        vec4 size_vec = $visual_to_framebuffer(pos + normalize(x) * a_size);
+        // move horizontally in framebuffer space
+        // then go to scene coordinates (not visual, so scaling is accounted for)
+        vec4 x = $framebuffer_to_scene(fb_pos + vec4(big_float, 0, 0, 0));
+        // subtract position, so we get the scene-coordinate vector describing
+        // an "horizontal direction parallel to the screen"
+        vec4 scene_pos = $framebuffer_to_scene(fb_pos);
+        x = (x - scene_pos);
+        // multiply that direction by the size (in scene space) and add it to the position
+        // this gives us the position of the edge of the point, which we convert in screen space
+        vec4 size_vec = $scene_to_framebuffer(scene_pos + normalize(x) * a_size);
+        // divide by `w` for perspective, and subtract pos
+        // this gives us the actual screen-space size of the point
         $v_size = size_vec.x / size_vec.w - fb_pos.x / fb_pos.w;
         v_edgewidth = ($v_size / a_size) * a_edgewidth;
     }
@@ -867,6 +876,8 @@ class MarkersVisual(Visual):
         view.view_program.vert['visual_to_framebuffer'] = view.get_transform('visual', 'framebuffer')
         view.view_program.vert['framebuffer_to_visual'] = view.get_transform('framebuffer', 'visual')
         view.view_program.vert['framebuffer_to_render'] = view.get_transform('framebuffer', 'render')
+        view.view_program.vert['framebuffer_to_scene'] = view.get_transform('framebuffer', 'scene')
+        view.view_program.vert['scene_to_framebuffer'] = view.get_transform('scene', 'framebuffer')
 
     def _prepare_draw(self, view):
         if self._data is None or self._symbol is None:


### PR DESCRIPTION
Fix for #2357. The solution was to use `scene` coordinates rather than `visual` coordinates for the calculation, so we do everything in a space where the scaling already happened.

~While this fixes the size of the markers, edge width is probably affected too since it uses pure `a_size`... I need to investigate that.~ EDIT: this works just fine!

To test this out, try the following here versus `main`:

```py
from vispy import scene
import numpy as np

# basic canvas and camera
canvas = scene.SceneCanvas(show=True)
view = canvas.central_widget.add_view()
view.camera = scene.cameras.ArcballCamera(fov=0)

# create points and apply scaling transform
points = scene.visuals.Markers(
    pos=np.array([[0, 0, 0], [0.2, 0.1, 0.3]]),
    size=0.1,
    edge_width=0.01,
    edge_color='red',
    scaling=True,
    parent=view.scene,
)
points.transform = scene.transforms.STTransform(scale=(5, 2, 1))
```
