### PR TITLE
`Markers`: allow setting `symbol` on individual basis

### DIFF
--- a/examples/basics/visuals/rescalingmarkers.py
+++ b/examples/basics/visuals/rescalingmarkers.py
@@ -37,8 +37,8 @@ class Canvas(scene.SceneCanvas):
         )
         self.unfreeze()
         self.index = 0
-        self.markers = visuals.Markers()
-        self.markers.set_data(pos, face_color=(0, 1, 0), scaling=False)
+        self.markers = visuals.Markers(scaling=False)
+        self.markers.set_data(pos, face_color=(0, 1, 0))
         self.markers.symbol = self.markers.symbols[self.index]
         self.text = visuals.Text(self.markers.symbols[self.index],
                                  pos=(80, 15), font_size=14,

--- a/examples/scene/point_cloud.py
+++ b/examples/scene/point_cloud.py
@@ -27,16 +27,17 @@ pos = np.random.normal(size=(100000, 3), scale=0.2)
 # one could stop here for the data generation, the rest is just to make the
 # data look more interesting. Copied over from magnify.py
 centers = np.random.normal(size=(50, 3))
-indexes = np.random.normal(size=100000, loc=centers.shape[0]/2.,
-                           scale=centers.shape[0]/3.)
-indexes = np.clip(indexes, 0, centers.shape[0]-1).astype(int)
+indexes = np.random.normal(size=100000, loc=centers.shape[0] / 2,
+                           scale=centers.shape[0] / 3)
+indexes = np.clip(indexes, 0, centers.shape[0] - 1).astype(int)
+symbols = np.random.choice(['o', '^'], len(pos))
 scales = 10**(np.linspace(-2, 0.5, centers.shape[0]))[indexes][:, np.newaxis]
 pos *= scales
 pos += centers[indexes]
 
 # create scatter object and fill in the data
 scatter = visuals.Markers()
-scatter.set_data(pos, edge_color=None, face_color=(1, 1, 1, .5), size=5)
+scatter.set_data(pos, edge_width=0, face_color=(1, 1, 1, .5), size=5, symbol=symbols)
 
 view.add(scatter)
 

--- a/vispy/visuals/graphs/graph.py
+++ b/vispy/visuals/graphs/graph.py
@@ -63,7 +63,7 @@ class GraphVisual(CompoundVisual):
     _arrow_kw_trans = dict(line_color='color', line_width='width')
     _node_kw_trans = dict(node_symbol='symbol', node_size='size',
                           border_color='edge_color', border_width='edge_width')
-    _node_properties_args = ('symbol',)
+    _node_properties_args = ()
 
     def __init__(self, adjacency_mat=None, directed=False, layout=None,
                  animate=False, line_color=None, line_width=None,

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -496,8 +496,8 @@ class MarkersVisual(Visual):
         The color used to draw each symbol outline.
     face_color : Color | ColorArray
         The color used to draw each symbol interior.
-    symbol : str
-        The style of symbol to draw (see Notes).
+    symbol : str or array
+        The style of symbol used to draw each marker (see Notes).
     scaling : bool
         If set to True, marker scales when rezooming.
     alpha : float
@@ -559,7 +559,7 @@ class MarkersVisual(Visual):
 
     def set_data(self, pos=None, size=10., edge_width=1., edge_width_rel=None,
                  edge_color='black', face_color='white',
-                 symbol='o', scaling=None):
+                 symbol='o'):
         """Set the data used to display this visual.
 
         Parameters
@@ -577,6 +577,8 @@ class MarkersVisual(Visual):
             The color used to draw each symbol outline.
         face_color : Color | ColorArray
             The color used to draw each symbol interior.
+        symbol : str or array
+            The style of symbol used to draw each marker (see Notes).
         """
         if (edge_width is not None) + (edge_width_rel is not None) != 1:
             raise ValueError('exactly one of edge_width and edge_width_rel '
@@ -594,14 +596,6 @@ class MarkersVisual(Visual):
         if symbol is not None:
             if not np.all(np.isin(np.asarray(symbol), self.symbols)):
                 raise ValueError(f'symbols must one of {self.symbols}')
-
-        if scaling is not None:
-            warnings.warn(
-                "The scaling parameter is deprecated. Use MarkersVisual.scaling instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.scaling = scaling
 
         edge_color = ColorArray(edge_color).rgba
         if len(edge_color) == 1:

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -644,6 +644,25 @@ class MarkersVisual(Visual):
         return list(self._symbol_shader_values)
 
     @property
+    def symbol(self):
+        value_to_symbol = {v: k for k, v in self._symbol_shader_values.items()}
+        return np.vectorize(value_to_symbol.get)(self._data['a_symbol'])
+
+    @symbol.setter
+    def symbol(self, value):
+        rec_to_kw = {
+            'a_position': 'pos',
+            'a_fg_color': 'edge_color',
+            'a_bg_color': 'face_color',
+            'a_size': 'size',
+            'a_edgewidth': 'edge_width',
+            'a_symbol': 'symbol',
+        }
+        kwargs = {kw: self._data[rec] for rec, kw in rec_to_kw.items()}
+        kwargs['symbol'] = value
+        self.set_data(**kwargs)
+
+    @property
     def scaling(self):
         """
         If set to True, marker scales when rezooming.

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -5,8 +5,6 @@
 # -----------------------------------------------------------------------------
 """Marker Visual and shader definitions."""
 
-import warnings
-
 import numpy as np
 
 from ..color import ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -202,227 +202,247 @@ void main()
 }
 """
 
+disc = """
+float r = length((pointcoord.xy - vec2(0.5,0.5))*size);
+r -= $v_size/2.;
+return r;
+"""
+
+
+arrow = """
+const float sqrt2 = sqrt(2.);
+float half_size = $v_size/2.;
+float ady = abs(pointcoord.y -.5)*size;
+float dx = (pointcoord.x -.5)*size;
+float r1 = abs(dx) + ady - half_size;
+float r2 = dx + 0.25*$v_size + ady - half_size;
+float r = max(r1,-r2);
+return r/sqrt2;//account for slanted edge and correct for width
+"""
+
+
+ring = """
+float r1 = length((pointcoord.xy - vec2(0.5,0.5))*size) - $v_size/2.;
+float r2 = length((pointcoord.xy - vec2(0.5,0.5))*size) - $v_size/4.;
+float r = max(r1,-r2);
+return r;
+"""
+
+clobber = """
+const float sqrt3 = sqrt(3.);
+const float PI = 3.14159265358979323846264;
+const float t1 = -PI/2;
+float circle_radius = 0.32 * $v_size;
+float center_shift = 0.36/sqrt3 * $v_size;
+//total size (horizontal) = 2*circle_radius + sqrt3*center_shirt = $v_size
+vec2  c1 = vec2(cos(t1),sin(t1))*center_shift;
+const float t2 = t1+2*PI/3;
+vec2  c2 = vec2(cos(t2),sin(t2))*center_shift;
+const float t3 = t2+2*PI/3;
+vec2  c3 = vec2(cos(t3),sin(t3))*center_shift;
+//xy is shift to center marker vertically
+vec2 xy = (pointcoord.xy-vec2(0.5,0.5))*size + vec2(0.,-0.25*center_shift);
+float r1 = length(xy - c1) - circle_radius;
+float r2 = length(xy - c2) - circle_radius;
+float r3 = length(xy - c3) - circle_radius;
+float r = min(min(r1,r2),r3);
+return r;
+"""
+
+
+square = """
+float r = max(abs(pointcoord.x -.5)*size, abs(pointcoord.y -.5)*size);
+r -= $v_size/2.;
+return r;
+"""
+
+x = """
+vec2 rotcoord = vec2((pointcoord.x + pointcoord.y - 1.) / sqrt(2.),
+ (pointcoord.y - pointcoord.x) / sqrt(2.));
+//vbar
+float r1 = abs(rotcoord.x)*size - $v_size/6.;
+float r2 = abs(rotcoord.y)*size - $v_size/2.;
+float vbar = max(r1,r2);
+//hbar
+float r3 = abs(rotcoord.y)*size - $v_size/6.;
+float r4 = abs(rotcoord.x)*size - $v_size/2.;
+float hbar = max(r3,r4);
+return min(vbar, hbar);
+"""
+
+
+diamond = """
+float r = abs(pointcoord.x -.5)*size + abs(pointcoord.y -.5)*size;
+r -= $v_size/2.;
+return r / sqrt(2.);//account for slanted edge and correct for width
+"""
+
+
+vbar = """
+float r1 = abs(pointcoord.x - 0.5)*size - $v_size/6.;
+float r3 = abs(pointcoord.y - 0.5)*size - $v_size/2.;
+float r = max(r1,r3);
+return r;
+"""
+
+hbar = """
+float r2 = abs(pointcoord.y - 0.5)*size - $v_size/6.;
+float r3 = abs(pointcoord.x - 0.5)*size - $v_size/2.;
+float r = max(r2,r3);
+return r;
+"""
+
+cross = """
+//vbar
+float r1 = abs(pointcoord.x - 0.5)*size - $v_size/6.;
+float r2 = abs(pointcoord.y - 0.5)*size - $v_size/2.;
+float vbar = max(r1,r2);
+//hbar
+float r3 = abs(pointcoord.y - 0.5)*size - $v_size/6.;
+float r4 = abs(pointcoord.x - 0.5)*size - $v_size/2.;
+float hbar = max(r3,r4);
+return min(vbar, hbar);
+"""
+
+
+tailed_arrow = """
+const float sqrt2 = sqrt(2.);
+float half_size = $v_size/2.;
+float ady = abs(pointcoord.y -.5)*size;
+float dx = (pointcoord.x -.5)*size;
+float r1 = abs(dx) + ady - half_size;
+float r2 = dx + 0.25*$v_size + ady - half_size;
+float arrow = max(r1,-r2);
+//hbar
+float upper_bottom_edges = ady - $v_size/8./sqrt2;
+float left_edge = -dx - half_size;
+float right_edge = dx + ady - half_size;
+float hbar = max(upper_bottom_edges, left_edge);
+float scale = 1.; //rescaling for slanted edge
+if (right_edge >= hbar)
+{
+hbar = right_edge;
+scale = sqrt2;
+}
+if (arrow <= hbar)
+{
+return arrow / sqrt2;//account for slanted edge and correct for width
+}
+else
+{
+return hbar / scale;
+}
+"""
+
+
+triangle_up = """
+float height = $v_size*sqrt(3.)/2.;
+float bottom = ((pointcoord.y - 0.5)*size - height/2.);
+float rotated_y = sqrt(3.)/2. * (pointcoord.x - 0.5) * size
+  - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
+float right_edge = (rotated_y - height/2.);
+float cc_rotated_y = -sqrt(3.)/2. * (pointcoord.x - 0.5)*size
+  - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
+float left_edge = (cc_rotated_y - height/2.);
+float slanted_edges = max(right_edge, left_edge);
+return max(slanted_edges, bottom);
+"""
+
+triangle_down = """
+float height = -$v_size*sqrt(3.)/2.;
+float bottom = -((pointcoord.y - 0.5)*size - height/2.);
+float rotated_y = sqrt(3.)/2. * (pointcoord.x - 0.5) * size
+- 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
+float right_edge = -(rotated_y - height/2.);
+float cc_rotated_y = -sqrt(3.)/2. * (pointcoord.x - 0.5)*size
+- 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
+float left_edge = -(cc_rotated_y - height/2.);
+float slanted_edges = max(right_edge, left_edge);
+return max(slanted_edges, bottom);
+"""
+
+
+star = """
+float star = -10000.;
+const float PI2_5 = 3.141592653589*2./5.;
+const float PI2_20 = 3.141592653589/10.;  //PI*2/20
+// downwards shift to that the marker center is halfway vertically
+// between the top of the upward spike (y = -v_size/2.)
+// and the bottom of one of two downward spikes
+// (y = +v_size/2.*cos(2.*pi/10.) approx +v_size/2.*0.8)
+// center is at -v_size/2.*0.1
+float shift_y = -0.05*$v_size;
+// first spike upwards,
+// rotate spike by 72 deg four times to complete the star
+for (int i = 0; i <= 4; i++)
+{
+//if not the first spike, rotate it upwards
+float x = (pointcoord.x - 0.5)*size;
+float y = (pointcoord.y - 0.5)*size;
+float spike_rot_angle = float(i) * PI2_5;
+float cosangle = cos(spike_rot_angle);
+float sinangle = sin(spike_rot_angle);
+float spike_x = x;
+float spike_y = y + shift_y;
+if (i > 0)
+{
+spike_x = cosangle * x - sinangle * (y + shift_y);
+spike_y = sinangle * x + cosangle * (y + shift_y);
+}
+// in the frame where the spike is upwards:
+// rotate 18 deg the zone x < 0 around the top of the star
+// (point whose coords are -s/2, 0 where s is the size of the marker)
+// compute y coordonates as well because
+// we do a second rotation to put the spike at its final position
+float rot_center_y = -$v_size/2.;
+float rot18x = cos(PI2_20) * spike_x
+- sin(PI2_20) * (spike_y - rot_center_y);
+//rotate -18 deg the zone x > 0 arount the top of the star
+float rot_18x = cos(PI2_20) * spike_x
++ sin(PI2_20) * (spike_y - rot_center_y);
+float bottom = spike_y - $v_size/10.;
+// max(left edge, right edge)
+float spike = max(bottom, max(rot18x, -rot_18x));
+if (i == 0)
+{// first spike, skip the rotation
+star = spike;
+}
+else // i > 0
+{
+star = min(star, spike);
+}
+}
+return star;
+"""
+
+cross_lines = """
+//vbar
+float r1 = abs(pointcoord.x - 0.5)*size;
+float r2 = abs(pointcoord.y - 0.5)*size - $v_size/2;
+float vbar = max(r1,r2);
+//hbar
+float r3 = abs(pointcoord.y - 0.5)*size;
+float r4 = abs(pointcoord.x - 0.5)*size - $v_size/2;
+float hbar = max(r3,r4);
+return min(vbar, hbar);
+"""
 
 symbol_shaders = {
-    'disc': """
-        float r = length((pointcoord.xy - vec2(0.5,0.5))*size);
-        r -= $v_size/2.;
-        return r;
-    """,
-
-    'arrow': """
-        const float sqrt2 = sqrt(2.);
-        float half_size = $v_size/2.;
-        float ady = abs(pointcoord.y -.5)*size;
-        float dx = (pointcoord.x -.5)*size;
-        float r1 = abs(dx) + ady - half_size;
-        float r2 = dx + 0.25*$v_size + ady - half_size;
-        float r = max(r1,-r2);
-        return r/sqrt2;//account for slanted edge and correct for width
-    """,
-
-    'ring': """
-        float r1 = length((pointcoord.xy - vec2(0.5,0.5))*size) - $v_size/2.;
-        float r2 = length((pointcoord.xy - vec2(0.5,0.5))*size) - $v_size/4.;
-        float r = max(r1,-r2);
-        return r;
-    """,
-
-    'clobber': """
-        const float sqrt3 = sqrt(3.);
-        const float PI = 3.14159265358979323846264;
-        const float t1 = -PI/2;
-        float circle_radius = 0.32 * $v_size;
-        float center_shift = 0.36/sqrt3 * $v_size;
-        //total size (horizontal) = 2*circle_radius + sqrt3*center_shirt = $v_size
-        vec2  c1 = vec2(cos(t1),sin(t1))*center_shift;
-        const float t2 = t1+2*PI/3;
-        vec2  c2 = vec2(cos(t2),sin(t2))*center_shift;
-        const float t3 = t2+2*PI/3;
-        vec2  c3 = vec2(cos(t3),sin(t3))*center_shift;
-        //xy is shift to center marker vertically
-        vec2 xy = (pointcoord.xy-vec2(0.5,0.5))*size + vec2(0.,-0.25*center_shift);
-        float r1 = length(xy - c1) - circle_radius;
-        float r2 = length(xy - c2) - circle_radius;
-        float r3 = length(xy - c3) - circle_radius;
-        float r = min(min(r1,r2),r3);
-        return r;
-    """,
-
-
-    'square': """
-        float r = max(abs(pointcoord.x -.5)*size, abs(pointcoord.y -.5)*size);
-        r -= $v_size/2.;
-        return r;
-    """,
-
-    'x': """
-        vec2 rotcoord = vec2((pointcoord.x + pointcoord.y - 1.) / sqrt(2.),
-                             (pointcoord.y - pointcoord.x) / sqrt(2.));
-        //vbar
-        float r1 = abs(rotcoord.x)*size - $v_size/6.;
-        float r2 = abs(rotcoord.y)*size - $v_size/2.;
-        float vbar = max(r1,r2);
-        //hbar
-        float r3 = abs(rotcoord.y)*size - $v_size/6.;
-        float r4 = abs(rotcoord.x)*size - $v_size/2.;
-        float hbar = max(r3,r4);
-        return min(vbar, hbar);
-    """,
-
-
-    'diamond': """
-        float r = abs(pointcoord.x -.5)*size + abs(pointcoord.y -.5)*size;
-        r -= $v_size/2.;
-        return r / sqrt(2.);//account for slanted edge and correct for width
-    """,
-
-
-    'vbar': """
-        float r1 = abs(pointcoord.x - 0.5)*size - $v_size/6.;
-        float r3 = abs(pointcoord.y - 0.5)*size - $v_size/2.;
-        float r = max(r1,r3);
-        return r;
-    """,
-
-    'hbar': """
-        float r2 = abs(pointcoord.y - 0.5)*size - $v_size/6.;
-        float r3 = abs(pointcoord.x - 0.5)*size - $v_size/2.;
-        float r = max(r2,r3);
-        return r;
-    """,
-
-    'cross': """
-        //vbar
-        float r1 = abs(pointcoord.x - 0.5)*size - $v_size/6.;
-        float r2 = abs(pointcoord.y - 0.5)*size - $v_size/2.;
-        float vbar = max(r1,r2);
-        //hbar
-        float r3 = abs(pointcoord.y - 0.5)*size - $v_size/6.;
-        float r4 = abs(pointcoord.x - 0.5)*size - $v_size/2.;
-        float hbar = max(r3,r4);
-        return min(vbar, hbar);
-    """,
-
-    'tailed_arrow': """
-        const float sqrt2 = sqrt(2.);
-        float half_size = $v_size/2.;
-        float ady = abs(pointcoord.y -.5)*size;
-        float dx = (pointcoord.x -.5)*size;
-        float r1 = abs(dx) + ady - half_size;
-        float r2 = dx + 0.25*$v_size + ady - half_size;
-        float arrow = max(r1,-r2);
-        //hbar
-        float upper_bottom_edges = ady - $v_size/8./sqrt2;
-        float left_edge = -dx - half_size;
-        float right_edge = dx + ady - half_size;
-        float hbar = max(upper_bottom_edges, left_edge);
-        float scale = 1.; //rescaling for slanted edge
-        if (right_edge >= hbar)
-        {
-            hbar = right_edge;
-            scale = sqrt2;
-        }
-        if (arrow <= hbar)
-        {
-            return arrow / sqrt2;//account for slanted edge and correct for width
-        }
-        else
-        {
-            return hbar / scale;
-        }
-    """,
-
-    'triangle_up': """
-        float height = $v_size*sqrt(3.)/2.;
-        float bottom = ((pointcoord.y - 0.5)*size - height/2.);
-        float rotated_y = sqrt(3.)/2. * (pointcoord.x - 0.5) * size
-                  - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
-        float right_edge = (rotated_y - height/2.);
-        float cc_rotated_y = -sqrt(3.)/2. * (pointcoord.x - 0.5)*size
-                  - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
-        float left_edge = (cc_rotated_y - height/2.);
-        float slanted_edges = max(right_edge, left_edge);
-        return max(slanted_edges, bottom);
-    """,
-
-    'triangle_down': """
-        float height = -$v_size*sqrt(3.)/2.;
-        float bottom = -((pointcoord.y - 0.5)*size - height/2.);
-        float rotated_y = sqrt(3.)/2. * (pointcoord.x - 0.5) * size
-                    - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
-        float right_edge = -(rotated_y - height/2.);
-        float cc_rotated_y = -sqrt(3.)/2. * (pointcoord.x - 0.5)*size
-                    - 0.5 * ((pointcoord.y - 0.5)*size - height/6.) + height/6.;
-        float left_edge = -(cc_rotated_y - height/2.);
-        float slanted_edges = max(right_edge, left_edge);
-        return max(slanted_edges, bottom);
-    """,
-
-    'star': """
-        float star = -10000.;
-        const float PI2_5 = 3.141592653589*2./5.;
-        const float PI2_20 = 3.141592653589/10.;  //PI*2/20
-        // downwards shift to that the marker center is halfway vertically
-        // between the top of the upward spike (y = -v_size/2.)
-        // and the bottom of one of two downward spikes
-        // (y = +v_size/2.*cos(2.*pi/10.) approx +v_size/2.*0.8)
-        // center is at -v_size/2.*0.1
-        float shift_y = -0.05*$v_size;
-        // first spike upwards,
-        // rotate spike by 72 deg four times to complete the star
-        for (int i = 0; i <= 4; i++)
-        {
-            //if not the first spike, rotate it upwards
-            float x = (pointcoord.x - 0.5)*size;
-            float y = (pointcoord.y - 0.5)*size;
-            float spike_rot_angle = float(i) * PI2_5;
-            float cosangle = cos(spike_rot_angle);
-            float sinangle = sin(spike_rot_angle);
-            float spike_x = x;
-            float spike_y = y + shift_y;
-            if (i > 0)
-            {
-                spike_x = cosangle * x - sinangle * (y + shift_y);
-                spike_y = sinangle * x + cosangle * (y + shift_y);
-            }
-            // in the frame where the spike is upwards:
-            // rotate 18 deg the zone x < 0 around the top of the star
-            // (point whose coords are -s/2, 0 where s is the size of the marker)
-            // compute y coordonates as well because
-            // we do a second rotation to put the spike at its final position
-            float rot_center_y = -$v_size/2.;
-            float rot18x = cos(PI2_20) * spike_x
-                                - sin(PI2_20) * (spike_y - rot_center_y);
-            //rotate -18 deg the zone x > 0 arount the top of the star
-            float rot_18x = cos(PI2_20) * spike_x
-                                + sin(PI2_20) * (spike_y - rot_center_y);
-            float bottom = spike_y - $v_size/10.;
-            //                     max(left edge, right edge)
-            float spike = max(bottom, max(rot18x, -rot_18x));
-            if (i == 0)
-            {// first spike, skip the rotation
-                star = spike;
-            }
-            else // i > 0
-            {
-                star = min(star, spike);
-            }
-        }
-        return star;
-    """,
-
-    'cross_lines': """
-        //vbar
-        float r1 = abs(pointcoord.x - 0.5)*size;
-        float r2 = abs(pointcoord.y - 0.5)*size - $v_size/2;
-        float vbar = max(r1,r2);
-        //hbar
-        float r3 = abs(pointcoord.y - 0.5)*size;
-        float r4 = abs(pointcoord.x - 0.5)*size - $v_size/2;
-        float hbar = max(r3,r4);
-        return min(vbar, hbar);
-    """,
+    'disc': disc,
+    'arrow': arrow,
+    'ring': ring,
+    'clobber': clobber,
+    'square': square,
+    'x': x,
+    'diamond': diamond,
+    'vbar': vbar,
+    'hbar': hbar,
+    'cross': cross,
+    'tailed_arrow': tailed_arrow,
+    'triangle_up': triangle_up,
+    'triangle_down': triangle_down,
+    'star': star,
+    'cross_lines': cross_lines,
 }
 
 # combine all the symbol shaders in a big if-else statement


### PR DESCRIPTION
This PR allows to provide `symbol` on a per-point basis in a `Markers` visual.

Currently, the single `symbol` attribute forces users to create multiple visuals if they want multiple symbols; instead, we can accept an array of symbols and handle everything in the shader. I changed the example `point_cloud.py` to take advantage of this, and everything seems to be working great!

![image](https://user-images.githubusercontent.com/23482191/180774959-9fe75ffa-c6db-4536-afd9-715388935aff.png)


Since we cannot pass enums/strings/integers to the shader, we're forced to convert to float and do some gymnastic to get everything to work, which makes things a bit less readable. One downside of this is that `Marker._data['a_symbol']` will contain a bunch of uninterpretable floats, but since this is a private attribute it shouldn't be a big deal.
