### PR TITLE
Switch to newer macOS ci

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macOS-latest]
         arch: [auto]
         include:
           - os: ubuntu-20.04


### PR DESCRIPTION
CI is often skipping/failing the macOS wheel workflow; turns out, we're using a deprecated runner. This updates to the recommended one: https://github.com/actions/virtual-environments/issues/5583.

