### PR TITLE
Update tube.py to support Python 3.10 and higher.

### DIFF
--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -65,7 +65,7 @@ class TubeVisual(MeshVisual):
         segments = len(points) - 1
 
         # if single radius, convert to list of radii
-        if not isinstance(radius, collections.Iterable):
+        if not isinstance(radius, collections.abc.Iterable):
             radius = [radius] * len(points)
         elif len(radius) != len(points):
             raise ValueError('Length of radii list must match points.')


### PR DESCRIPTION
Fix reference to Iterable abstract base class (abc).  It has been moved to collections.abc and removed from collections in Python 3.10.