### PR TITLE
Fix geometry shader example

### DIFF
--- a/examples/gloo/geometry_shader.py
+++ b/examples/gloo/geometry_shader.py
@@ -27,7 +27,7 @@ position = np.random.normal(loc=0, scale=0.3, size=(1000, 2)).astype('float32')
 VERT_SHADER = """
 #version 330
 
-in vec2 a_position;
+attribute vec2 a_position;
 
 void main (void) {
     gl_Position = vec4(a_position, 0, 1);


### PR DESCRIPTION
It seems that this example had a mistake which crashed it with a `must have at least one attribute` error. This change fixes it.
