### PR TITLE
Use correct regex when parsing variables

### DIFF
--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -251,13 +251,16 @@ class Program(GLObject):
         self._code_variables = {}
         for kind in ('uniform', 'attribute', 'varying', 'const', 'in', 'out'):
 
+            # pick regex for the correct kind of var
+            reg = REGEX_VAR[kind]
+
             # treat *in* like attribute, *out* like varying
             if kind == 'in':
                 kind = 'attribute'
             elif kind == 'out':
                 kind = 'varying'
 
-            for m in re.finditer(REGEX_VAR[kind], code):
+            for m in re.finditer(reg, code):
                 gtype = m.group('type')
                 size = int(m.group('size')) if m.group('size') else -1
                 this_kind = kind

--- a/vispy/gloo/tests/test_program.py
+++ b/vispy/gloo/tests/test_program.py
@@ -254,6 +254,13 @@ class ProgramTest(unittest.TestCase):
         # And anything else also fails
         self.assertRaises(KeyError, program.__getitem__, 'fooo')
 
+    def test_type_aliases(self):
+        program = Program("in bool A; out float B;", "foo")
+
+        # in aliased to attribute, out to varying
+        assert ('attribute', 'bool', 'A') in program.variables
+        assert ('varying', 'float', 'B') in program.variables
+
     def test_draw(self):
         # Init
         program = Program("attribute float A;", "uniform float foo")


### PR DESCRIPTION
Real fix for the issue found at #2377.

Currently, we were treating `in` and `attribute` *exactly* the same, even when parsing: we were looking for the token `attribute` when parsing in both cases, effectively doing the same thing twice.

What we really should be doing is look for the `in` token, but treat it the same as attribute.

There are still limits with this approach (`in` can actually be a either `attribute` or `varying` depending on if it's used in a vertex or fragment shader), but it's out of scope for this pr.
