### PR TITLE
Fix custom image interpolation kernels to work with negative numbers

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -141,7 +141,6 @@ vec4 texture_lookup(vec2 texcoord) {
     vec2 kernel_pos, tex_pos;
     vec4 color = vec4(0);
     float weight;
-    float weight_sum = 0;
 
     // offset 0.5 to sample center of pixels
     for (float i = 0.5; i < $kernel_shape.x; i++) {
@@ -150,15 +149,14 @@ vec4 texture_lookup(vec2 texcoord) {
             tex_pos = sampling_corner + vec2(i, j) * tex_pixel;
             // TODO: allow other edge effects, like mirror or wrap
             if (tex_pos.x >= 0 && tex_pos.y >= 0 && tex_pos.x <= 1 && tex_pos.y <= 1) {
-                weight = texture2D($kernel, kernel_pos).g;
-                weight_sum += weight;
+                weight = texture2D($kernel, kernel_pos).r;
                 // make sure to clamp or we sample outside
                 color += texture2D($texture, clamp(tex_pos, 0, 1)) * weight;
             }
         }
     }
 
-    return color / weight_sum;
+    return color;
 }
 """
 
@@ -505,7 +503,7 @@ class ImageVisual(Visual):
         if value.ndim != 2:
             raise ValueError(f'kernel must have 2 dimensions; got {value.ndim}')
         self._custom_kernel = value
-        self._custom_kerneltex = Texture2D(value, interpolation='nearest')
+        self._custom_kerneltex = Texture2D(value, interpolation='nearest', internalformat='r32f')
         if self._data_lookup_fn is not None and 'kernel' in self._data_lookup_fn:
             self._data_lookup_fn['kernel'] = self._custom_kerneltex
             self._data_lookup_fn['kernel_shape'] = value.shape[::-1]

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -302,9 +302,8 @@ def test_image_interpolation():
     """Test different interpolations"""
     size = (81, 81)
     data = np.array([[0, 1]], dtype=int)
-    # we need to avoid the edges because the canvas adds a white border of 1 px
-    left = (40, 10)
-    right = (40, 71)
+    left = (40, 0)
+    right = (40, 80)
     center_left = (40, 39)
     center = (40, 40)
     center_right = (40, 41)
@@ -313,7 +312,7 @@ def test_image_interpolation():
     gray = (128, 128, 128, 255)
 
     with TestingCanvas(size=size[::-1], bgcolor="w") as c:
-        view = c.central_widget.add_view()
+        view = c.central_widget.add_view(border_width=0)
         view.camera = PanZoomCamera((0, 0, 2, 1))
         image = Image(data=data, cmap='grays',
                       parent=view.scene)
@@ -337,9 +336,9 @@ def test_image_interpolation():
         image.interpolation = 'custom'
         image.custom_kernel = np.array([[0]])  # no sampling
         render = c.render()
-        assert np.allclose(render[left], white)
-        assert np.allclose(render[right], white)
-        assert np.allclose(render[center], white)
+        assert np.allclose(render[left], black)
+        assert np.allclose(render[right], black)
+        assert np.allclose(render[center], black)
 
         image.custom_kernel = np.array([[1]])  # same as linear
         render = c.render()


### PR DESCRIPTION
When trying to expose in napari the custom interpolation kernels from #2319, I found some issues:

- due to the automatic normalization, the shader was really only suitable to gaussian blurring or other filters where total intensity should be preserved. This is especially bad with kernels with negative values
- after fixing the above, negative values still didn't work. It turns out that we need to specify the internalformat so it actually uses floats and allows negative numbers (If I understood correctly).


These changes fix the above, but do not guarantee normalized kernels anymore, so users have to do it themselves. I updated the example to do this, and made it a bit better at showcasing what this can do.
