### PR TITLE
clipping planes performance: do not create a new function willy nilly

### DIFF
--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -42,6 +42,8 @@ class PlanesClipper(Filter):
     """
 
     def __init__(self, clipping_planes: Optional[np.ndarray] = None, coord_system: str = 'scene'):
+        self._clipping_planes = np.empty((0, 2, 3), dtype=np.float32)
+
         tr = ['visual', 'scene', 'document', 'canvas', 'framebuffer', 'render']
         if coord_system not in tr:
             raise ValueError(f'Invalid coordinate system {coord_system}. Must be one of {tr}.')
@@ -103,7 +105,7 @@ class PlanesClipper(Filter):
     @clipping_planes.setter
     def clipping_planes(self, value: Optional[np.ndarray]):
         if value is None:
-            value = np.empty([0, 2, 3])
+            value = np.empty((0, 2, 3), dtype=np.float32)
 
         # only recreate function if amount of clipping planes changes
         if len(value) != len(self._clipping_planes):

--- a/vispy/visuals/filters/clipping_planes.py
+++ b/vispy/visuals/filters/clipping_planes.py
@@ -104,10 +104,15 @@ class PlanesClipper(Filter):
     def clipping_planes(self, value: Optional[np.ndarray]):
         if value is None:
             value = np.empty([0, 2, 3])
-        self._clipping_planes = value
 
-        clip_func = Function(self._build_clipping_planes_glsl(len(value)))
-        self.fshader['clip_with_planes'] = clip_func
+        # only recreate function if amount of clipping planes changes
+        if len(value) != len(self._clipping_planes):
+            clip_func = Function(self._build_clipping_planes_glsl(len(value)))
+            self.fshader['clip_with_planes'] = clip_func
+        else:
+            clip_func = self.fshader['clip_with_planes']
+
+        self._clipping_planes = value
 
         for idx, plane in enumerate(value):
             clip_func[f'clipping_plane_pos{idx}'] = tuple(plane[0])


### PR DESCRIPTION
Over at napari we noticed that with some specific GPUs (Intel Iris so far), we gat very bad performance when recompiling programs, due to these lines:

https://github.com/vispy/vispy/blob/16d8c5bd8694df9c18086e6fad31ffbaa08abaf4/vispy/visuals/filters/clipping_planes.py#L103-L114

In `0.10`, the `Function` was cached, which turned out to be problematic when working with multiple instances of the filter (due to [this issue](https://rednafi.github.io/reflections/dont-wrap-instance-methods-with-functoolslru_cache-decorator-in-python.html).

However, now a new `Function` gets create every time, even when unnecessary. Granted, in napari we are mistakenly calling this setter *way* too often, which we are fixing, but this should probably be checked in vispy as well.