### PR TITLE
do not mess up cupy arrays

### DIFF
--- a/examples/scene/image_cupy.py
+++ b/examples/scene/image_cupy.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# vispy: gallery 30
+# -----------------------------------------------------------------------------
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+"""
+Display an Image
+================
+
+Simple use of SceneCanvas to display an Image.
+
+"""
+
+import sys
+
+import cupy as cp
+
+from vispy import scene
+from vispy import app
+from vispy.io import load_data_file, read_png
+
+canvas = scene.SceneCanvas(keys='interactive')
+canvas.size = 800, 600
+canvas.show()
+
+# Set up a viewbox to display the image with interactive pan/zoom
+view = canvas.central_widget.add_view()
+
+# Create the image
+img_data = cp.array(read_png(load_data_file('mona_lisa/mona_lisa_sm.png')))
+interpolation = 'nearest'
+
+image = scene.visuals.Image(img_data, interpolation=interpolation,
+                            parent=view.scene, method='subdivide')
+
+canvas.title = 'Spatial Filtering using %s Filter' % interpolation
+
+# Set 2D camera (the camera will scale to the contents in the scene)
+view.camera = scene.PanZoomCamera(aspect=1)
+# flip y-axis to have correct aligment
+view.camera.flip = (0, 1, 0)
+view.camera.set_range()
+view.camera.zoom(0.1, (250, 200))
+
+# get interpolation functions from Image
+names = image.interpolation_functions
+names = sorted(names)
+act = 17
+
+
+# Implement key presses
+@canvas.events.key_press.connect
+def on_key_press(event):
+    global act
+    if event.key in ['Left', 'Right']:
+        if event.key == 'Right':
+            step = 1
+        else:
+            step = -1
+        act = (act + step) % len(names)
+        interpolation = names[act]
+        image.interpolation = interpolation
+        canvas.title = 'Spatial Filtering using %s Filter' % interpolation
+        canvas.update()
+
+
+if __name__ == '__main__' and sys.flags.interactive == 0:
+    app.run()

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -29,7 +29,15 @@ def convert_dtype_and_clip(data, dtype, copy=False):
     new_min, new_max = get_dtype_limits(dtype)
     if new_max >= old_max and new_min <= old_min:
         # no need to clip
-        return np.array(data, dtype=dtype, copy=copy)
+        try:
+            return np.array(data, dtype=dtype, copy=copy)
+        except TypeError as e:
+            # might be a cupy array, which raises error with implicit conversion
+            try:
+                import cupy as cp
+            except ImportError:
+                raise e
+            data = cp.array(data, dtype=dtype, copy=copy)
     else:
         # to reduce copying, we clip into a pre-generated array of the right dtype
         new_data = np.empty_like(data, dtype=dtype)

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -37,7 +37,7 @@ def convert_dtype_and_clip(data, dtype, copy=False):
                 import cupy as cp
             except ImportError:
                 raise e
-            data = cp.array(data, dtype=dtype, copy=copy)
+            return cp.array(data, dtype=dtype, copy=copy)
     else:
         # to reduce copying, we clip into a pre-generated array of the right dtype
         new_data = np.empty_like(data, dtype=dtype)
@@ -175,7 +175,7 @@ class BaseTexture(GLObject):
 
     def _normalize_shape(self, data_or_shape):
         # Get data and shape from input
-        if isinstance(data_or_shape, np.ndarray):
+        if hasattr(data_or_shape, 'shape'):
             data = data_or_shape
             shape = data.shape
         else:
@@ -811,7 +811,7 @@ class TextureEmulated3D(Texture2D):
         self._update_variables()
 
     def _set_emulated_shape(self, data_or_shape):
-        if isinstance(data_or_shape, np.ndarray):
+        if hasattr(data_or_shape, 'shape'):
             self._emulated_shape = data_or_shape.shape
         else:
             assert isinstance(data_or_shape, tuple)

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -382,7 +382,15 @@ class ImageVisual(Visual):
         texture_format : str or None
 
         """
-        data = np.array(image, copy=copy)
+        try:
+            data = np.array(image, copy=copy)
+        except TypeError as e:
+            # might be a cupy array, which raises error with implicit conversion
+            try:
+                import cupy as cp
+            except ImportError:
+                raise e
+            data = cp.array(image, copy=copy)
         if np.iscomplexobj(data):
             raise TypeError(
                 "Complex data types not supported. Please use 'ComplexImage' instead"


### PR DESCRIPTION
This PR is a very rough example of the kind of changes needed to allow cupy arrays to be preserved all the way to the GL level. (see #1985, #1986, cupy/cupy#5711, napari/napari#2243).

The changes on the `Texture` and `Image` level are overall quite simple, but things get problematic at lower levels where numpy interals are used in ways that I don't quite understand yet.

If one runs the new example (which is a copy of the existing image example but converting the data to a cupy array), the following exception is thrown:

```py
  [...]
  File "/home/lorenzo/git/vispy/vispy/gloo/glir.py", line 822, in parse
    self._parse(command)
  File "/home/lorenzo/git/vispy/vispy/gloo/glir.py", line 792, in _parse
    ob.set_data(*args)
  File "/home/lorenzo/git/vispy/vispy/gloo/glir.py", line 1551, in set_data
    gl.glTexSubImage2D(self._target, 0, x, y, format, gtype, data)
  File "/home/lorenzo/git/vispy/vispy/gloo/gl/_gl2.py", line 1130, in glTexSubImage2D
    pixels = pixels_.ctypes.data
AttributeError: 'ndarray' object has no attribute 'ctypes'
```

The code where this error happens is apparently autogenerated, but examply how I'm not sure. Hopefully the `git blame`d @almarklein can point us in the right direction here :)

cc @haesleinhuepf @jakirkham