### PR TITLE
fix: wx timer from float to int

### DIFF
--- a/vispy/app/backends/_wx.py
+++ b/vispy/app/backends/_wx.py
@@ -466,7 +466,7 @@ class TimerBackend(BaseTimerBackend):
         parent.Bind(wx.EVT_TIMER, self._vispy_timeout, self._timer)
 
     def _vispy_start(self, interval):
-        self._timer.Start(interval * 1000., False)
+        self._timer.Start(int(interval * 1000.), False)
 
     def _vispy_stop(self):
         self._timer.Stop()


### PR DESCRIPTION
As mentioned in #2395 the wx backend had a bug with the wx timer receiving a float as argument, instead of an integer