### PR TITLE
Add governance and steering committee information to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,20 @@ expectations of members, the penalties for violating these expectations, and
 how violations can be reported to the members of the community in charge of
 enforcing this Code of Conduct.
 
+Governance
+----------
+
+The VisPy project maintainers make decisions about the project based on a
+simple consensus model. This is described in more detail on
+`our website <https://vispy.org/governance/GOVERNANCE.html>`_ as well as the
+`list of maintainers <https://vispy.org/governance/MAINTAINERS.html>`_.
+
+In addition to decisions about the VisPy project, there is also a steering
+committee for the overall VisPy organization. More information about this
+committee can also be found on `our website <https://vispy.org/org/STEERING-COMMITTEE.html>`_,
+along with the organization's `charter <https://vispy.org/org/CHARTER.html>`_ and
+other related documents (linked in the charter).
+
 Genesis
 -------
 

--- a/ci/requirements/linux_full_newqtdeps_pip.txt
+++ b/ci/requirements/linux_full_newqtdeps_pip.txt
@@ -1,2 +1,2 @@
 pyopengltk
-pyqt6
+pyqt6 <6.4.0

--- a/ci/requirements/linux_full_newqtdeps_pip.txt
+++ b/ci/requirements/linux_full_newqtdeps_pip.txt
@@ -1,2 +1,3 @@
 pyopengltk
 pyqt6 <6.4.0
+pyqt6-qt6 <6.4.0


### PR DESCRIPTION
As discussed in our last monthly meeting, the governance documents are a little difficult for newcomers to find. This PR adds this information to the README. In the last meeting @rougier, @larsoner, and others brought up that github may have a specific document names that it looks for in the root of the repository and links to. From what I can tell there is nothing like this for GOVERNANCE documents (code of conduct and contributing documents are different). Because of this I have decided not to include any softlinks or "stub" files with specific names in the root of the repository.

Side note: @brisvag I've included in this a patch to force the PyQt6 version in the CI test environment so hopefully our Qt6 tests pass again and don't seg fault.