### PR TITLE
Improve PySide6 Support: swapBehavior for DoubleBuffer, BUTTONMAP as pyqt6, xfail test_context

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -278,11 +278,11 @@ def _set_config(c):
     glformat.setGreenBufferSize(c['green_size'])
     glformat.setBlueBufferSize(c['blue_size'])
     glformat.setAlphaBufferSize(c['alpha_size'])
-    if QT5_NEW_API or PYSIDE6_API:
+    if QT5_NEW_API:
         # Qt5 >= 5.4.0 - below options automatically enabled if nonzero.
         glformat.setSwapBehavior(glformat.DoubleBuffer if c['double_buffer']
                                  else glformat.SingleBuffer)
-    elif PYQT6_API:
+    elif PYQT6_API or PYSIDE6_API:
         glformat.setSwapBehavior(glformat.SwapBehavior.DoubleBuffer if c['double_buffer']
                                  else glformat.SwapBehavior.SingleBuffer)
     else:

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -191,7 +191,7 @@ KEYMAP = {
     qt_keys.Key_Return: keys.ENTER,
     qt_keys.Key_Tab: keys.TAB,
 }
-if PYQT6_API:
+if PYQT6_API or PYSIDE6_API:
     BUTTONMAP = {
         QtCore.Qt.MouseButton.NoButton: 0,
         QtCore.Qt.MouseButton.LeftButton: 1,

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -17,8 +17,8 @@ def test_context_properties():
         return  # cannot set more than once on Pyglet
     if a.backend_name.lower() == 'osmesa':
         return  # cannot set config on OSMesa
-    if 'pyqt5' in a.backend_name.lower() or 'pyqt6' in a.backend_name.lower() or 'pyside6' in a.backend_name.lower():
-        pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide6 at this time.")
+    if 'pyqt5' in a.backend_name.lower() or 'pyqt6' in a.backend_name.lower() or 'pyside2' in a.backend_name.lower() or 'pyside6' in a.backend_name.lower():
+        pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide2, or PySide6 at this time.")
 
     # stereo, double buffer won't work on every sys
     configs = [dict(samples=4), dict(stencil_size=8),
@@ -71,8 +71,8 @@ def test_context_sharing():
         check()
 
         # pyqt5 does not currently support context sharing, pyside6 seg faults on app tests
-        if 'pyqt5' in c1.app.backend_name.lower() or 'pyqt6' in c1.app.backend_name.lower() or 'pyside6' in c1.app.backend_name.lower():
-            pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide6 at this time.")
+        if 'pyqt5' in c1.app.backend_name.lower() or 'pyqt6' in c1.app.backend_name.lower() or 'pyside2' in c1.app.backend_name.lower() or 'pyside6' in c1.app.backend_name.lower():
+            pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide2, or PySide6 at this time.")
 
         # Tkinter does not currently support context sharing
         if 'tk' in c1.app.backend_name.lower():

--- a/vispy/app/tests/test_context.py
+++ b/vispy/app/tests/test_context.py
@@ -17,6 +17,8 @@ def test_context_properties():
         return  # cannot set more than once on Pyglet
     if a.backend_name.lower() == 'osmesa':
         return  # cannot set config on OSMesa
+    if 'pyqt5' in a.backend_name.lower() or 'pyqt6' in a.backend_name.lower() or 'pyside6' in a.backend_name.lower():
+        pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide6 at this time.")
 
     # stereo, double buffer won't work on every sys
     configs = [dict(samples=4), dict(stencil_size=8),
@@ -68,9 +70,9 @@ def test_context_sharing():
         # Check while c1 is active
         check()
 
-        # pyqt5 does not currently support context sharing
-        if 'pyqt5' in c1.app.backend_name.lower() or 'pyqt6' in c1.app.backend_name.lower():
-            pytest.xfail("Context sharing is not supported in PyQt5 at this time.")
+        # pyqt5 does not currently support context sharing, pyside6 seg faults on app tests
+        if 'pyqt5' in c1.app.backend_name.lower() or 'pyqt6' in c1.app.backend_name.lower() or 'pyside6' in c1.app.backend_name.lower():
+            pytest.xfail("Context sharing is not supported in PyQt5, PyQt6, PySide6 at this time.")
 
         # Tkinter does not currently support context sharing
         if 'tk' in c1.app.backend_name.lower():


### PR DESCRIPTION
Fixes #2407 by using `SwapBehavior` to set DoubleBuffer
PYSIDE6_API is included in the existing PYQT6_API logic:
https://github.com/vispy/vispy/blob/8bf4f9e538dee5cb986779006b84f62eed81ed7c/vispy/app/backends/_qt.py#L281-L287

This should work for PySide6 going back to at least 6.2 (LTS)
I found the Qt 6.2 (LTS) docs. The swap behavior was already present.
https://doc.qt.io/qt-6.2/qsurfaceformat.html#SwapBehavior-enum
https://doc.qt.io/qtforpython-6.2/PySide6/QtGui/QSurfaceFormat.html#PySide6.QtGui.PySide6.QtGui.QSurfaceFormat.SwapBehavior

Edit: Also uses the same BUTTONMAP as PyQT6
Plus, xfails the shared context tests: test_context.py
Fixes https://github.com/vispy/vispy/issues/2410