### PR TITLE
Allow 180 fov and clarify docstring

### DIFF
--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -224,8 +224,8 @@ class BaseCamera(Node):
     @fov.setter
     def fov(self, fov):
         fov = float(fov)
-        if fov < 0 or fov >= 180:
-            raise ValueError("fov must be between 0 and 180.")
+        if fov < 0 or fov > 180:
+            raise ValueError("fov must be 0 <= fov <= 180.")
         self._fov = fov
         self.view_changed()
 

--- a/vispy/scene/cameras/turntable.py
+++ b/vispy/scene/cameras/turntable.py
@@ -24,7 +24,8 @@ class TurntableCamera(Base3DRotationCamera):
     Parameters
     ----------
     fov : float
-        Field of view. Zero (default) means orthographic projection.
+        Field of view. 0.0 means orthographic projection,
+        default is 45.0 (some perspective)
     elevation : float
         Elevation angle in degrees. The elevation angle represents a
         rotation of the camera around the current scene x-axis. The


### PR DESCRIPTION
This is the same as #2393. I was unable to recover the commits with cherry-pick, because there were multiple copies of the same commits with slightly different contents and with the wrong authors. Hopefully this was all the changes we wanted from that?

cc @djhoese
