### PR TITLE
switch to newer python for ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,22 +169,22 @@ jobs:
       matrix:
         include:
           - test_number: 1
-            python_version: "3.7"
+            python_version: "3.8"
             deps: "min"
             test: "standard"
             new_qt: false
           - test_number: 2
-            python_version: "3.7"
+            python_version: "3.8"
             deps: "full"
             test: "standard"
             new_qt: false
           - test_number: 3
-            python_version: "3.7"
+            python_version: "3.8"
             deps: "osmesa"
             test: "osmesa"
             new_qt: false
           - test_number: 4
-            python_version: "3.9"
+            python_version: "3.10"
             deps: "full"
             test: "standard"
             new_qt: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
         sleep 5
         # export python_version
-        echo ::set-output name=python_version::39
+        echo ::set-output name=python_version::310
     - uses: mamba-org/provision-with-micromamba@v7
       with:
         environment-file: ./ci/requirements/py${{ steps.vars.outputs.python_version }}.yml

--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -2,7 +2,6 @@ cmake
 cython
 coveralls
 decorator
-freetype<2.10.0
 freetype-py
 glfw!=3.3.1
 imageio

--- a/ci/requirements/linux_full_newqtdeps_conda.txt
+++ b/ci/requirements/linux_full_newqtdeps_conda.txt
@@ -2,7 +2,6 @@ cmake
 cython
 coveralls
 decorator
-freetype<2.10.0
 freetype-py
 imageio
 # Do NOT include jupyter as it depends on qtconsole which pulls in PyQt5

--- a/ci/requirements/py310.yml
+++ b/ci/requirements/py310.yml
@@ -2,5 +2,5 @@ name: vispy-tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -2,5 +2,5 @@ name: vispy-tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - pip


### PR DESCRIPTION
As discussed in the monthly meeting, we're switching to newer python for CI. I'm not sure how the workflows work, so this is likely to be completely wrong as a first attempt :P
