### PR TITLE
Scale values when calculating attenuation in attenuated_mip shader

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -411,7 +411,10 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
         """,
     in_loop="""
-        sumval = sumval + val;
+        // Scale accumulation in `sumval` by contrast limits so that:
+        // * attenuation value does not depend on data values
+        // * negative values do not amplify instead of attenuate
+        sumval = sumval + (val - clim.x) / (clim.y - clim.x);
         scaled = val * exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
         if( scaled > maxval ) {
             maxval = scaled;

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -411,10 +411,10 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
         """,
     in_loop="""
-        // Scale accumulation in `sumval` by contrast limits so that:
+        // Scale and clamp accumulation in `sumval` by contrast limits so that:
         // * attenuation value does not depend on data values
         // * negative values do not amplify instead of attenuate
-        sumval = sumval + (val - clim.x) / (clim.y - clim.x);
+        sumval = sumval + clamp((val - clim.x) / (clim.y - clim.x), 0.0, 1.0);
         scaled = val * exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
         if( scaled > maxval ) {
             maxval = scaled;


### PR DESCRIPTION
This is a change I proposed in https://github.com/napari/napari/pull/5215, where it was suggested to fix upstream.

This changes the `attenuated_mip` shader to scale values when calculating the attenuation. I think this is only relevant for certain data types and configurations where the `texture_format` is not normalized. It has two effects:
* The attenuation factor is more consistent across data values, which should require less "tuning" for specific datasets.
* If the image has negative values they pretty much break the current algorithm and amplify instead of attenuate values.

Here is a comparison without (left) and with (right) this change demonstrating the degenerate results when the texture has negative values:
![Screen Shot 2022-10-27 at 12 18 06 PM](https://user-images.githubusercontent.com/1231828/198345669-1c20981c-425d-483d-88c5-a4c0a370476b.png)
