### PR TITLE
Fix deprecated save-output usage in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
         sleep 5
         # export python_version
-        echo ::set-output name=python_version::39
+        echo "python_version=39" >> $GITHUB_OUTPUT
     - uses: mamba-org/provision-with-micromamba@v7
       with:
         environment-file: ./ci/requirements/py${{ steps.vars.outputs.python_version }}.yml


### PR DESCRIPTION
According to this (and the warnings in CI) we're using some deprecated functionality:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR replaces it with the new method.