### PR TITLE
Fix: bug with new Markers.symbol and empty data

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -653,15 +653,18 @@ class MarkersVisual(Visual):
 
     @symbol.setter
     def symbol(self, value):
-        rec_to_kw = {
-            'a_position': 'pos',
-            'a_fg_color': 'edge_color',
-            'a_bg_color': 'face_color',
-            'a_size': 'size',
-            'a_edgewidth': 'edge_width',
-            'a_symbol': 'symbol',
-        }
-        kwargs = {kw: self._data[rec] for rec, kw in rec_to_kw.items()}
+        if self._data is not None:
+            rec_to_kw = {
+                'a_position': 'pos',
+                'a_fg_color': 'edge_color',
+                'a_bg_color': 'face_color',
+                'a_size': 'size',
+                'a_edgewidth': 'edge_width',
+                'a_symbol': 'symbol',
+            }
+            kwargs = {kw: self._data[rec] for rec, kw in rec_to_kw.items()}
+        else:
+            kwargs = {}
         kwargs['symbol'] = value
         self.set_data(**kwargs)
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -646,6 +646,8 @@ class MarkersVisual(Visual):
 
     @property
     def symbol(self):
+        if self._data is None:
+            return None
         value_to_symbol = {v: k for k, v in self._symbol_shader_values.items()}
         return np.vectorize(value_to_symbol.get)(self._data['a_symbol'])
 

--- a/vispy/visuals/tests/test_markers.py
+++ b/vispy/visuals/tests/test_markers.py
@@ -45,4 +45,10 @@ def test_markers_edge_width():
     with pytest.raises(ValueError):
         marker.set_data(pos=data, edge_width_rel=edge_width - 1, edge_width=None)
 
+
+def test_empty_markers_symbol():
+    markers = Markers()
+    markers.symbol = 'o'
+
+
 run_tests_if_main()


### PR DESCRIPTION
Another lesson on why having tests is good. Due to the latest changes to `Markers.symbol`, both setter and getter were failing when called on Markers with empty data, because they both assumed that `self._data` was not `None`.

This PR is a bugfix for both cases, and adds a small test which failed on main. Note that the test also triggered the `getter`, because `frozen` uses `hasattr`, which in turns [uses `getattr` under the hood](https://docs.python.org/2/library/functions.html#hasattr). This is actually how I noticed the error in the first place...

This should probably go in a patch release asap.
