### PR TITLE
Demo for Drafting: On-GPU Data Access (CUDA, CuPy, PyTorch, DLPack)

### DIFF
--- a/vispy/gloo/dlpack/LICENSE
+++ b/vispy/gloo/dlpack/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 by Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vispy/gloo/dlpack/README
+++ b/vispy/gloo/dlpack/README
@@ -1,0 +1,1 @@
+dlpack code from example at https://github.com/dmlc/dlpack/tree/main/apps/numpy_dlpack/dlpack

--- a/vispy/gloo/dlpack/cuda_.py
+++ b/vispy/gloo/dlpack/cuda_.py
@@ -1,0 +1,127 @@
+from cuda import cudart
+
+#from . import dlpack, util
+import dlpack, util
+
+
+def cuda_check(ret):
+    err = ret[0]
+    if err != cudart.cudaError_t.cudaSuccess:
+        _, errname = cudart.cudaGetErrorName(err)
+        errcode = str(int(err))
+        _, errdescr = cudart.cudaGetErrorString(err)
+        raise RuntimeError(errdescr.decode() + ' (' + errname.decode() + ' ' + errcode + ')')
+    return ret[1:] if len(ret) != 2 else ret[1]
+
+class CudaBuffer:
+    class _Mapping:
+        def __init__(self, buffer, stream):
+            self.buffer = buffer
+            self.stream = stream
+            self.resource = cuda_check(cudart.cudaGraphicsGLRegisterBuffer(buffer.glir_object.handle, buffer.flags))
+            cuda_check(cudart.cudaGraphicsMapResources(1, self.resource, self.stream))
+            self.ptr, self.size = cuda_check(cudart.cudaGraphicsResourceGetMappedPointer(self.resource))
+        def capsule(self):
+            buffer = self.buffer
+            return util.create_dlpack_capsule(self, self.ptr, buffer.device, buffer.dtype, buffer.shape, None, buffer.byte_offset)
+        def __del__(self):
+            cuda_check(cudart.cudaGraphicsUnmapResources(1, self.resource, self.stream))
+            cuda_check(cudart.cudaGraphicsUnregisterResource(self.resource))
+            
+    def __init__(self, glir_object, shape, dtype, byte_offset = 0, read = False, write = True):
+        self.device = dlpack.DLDevice(dlpack.DLDeviceType.kDLCUDA, 0) # warning: harcoded to device id 0
+        self.glir_object = glir_object
+        self.shape = shape
+        self.dtype = dlpack.DLDataType.TYPE_MAP[str(dtype)]
+        self.byte_offset = byte_offset
+        assert read or write
+        if not read:
+            self.flags = cudart.cudaGraphicsRegisterFlags.cudaGraphicsRegisterFlagsReadOnly
+        elif not write:
+            self.flags = cudart.cudaGraphicsRegisterFlags.cudaGraphicsRegisterFlagsWriteDiscard
+        else:
+            self.flags = cudart.cudaGraphicsRegisterFlags.cudaGraphicsRegisterFlagsNone
+            
+    def __dlpack__(self, stream=None):
+        return self._Mapping(self, stream).capsule()
+
+    def __dlpack_device__(self):
+        return self.device.device_type, self.device.device_id
+
+if __name__ == '__main__':
+    import vispy.app
+    import numpy as np, vispy.gloo.glir
+    
+    vertex = """
+        uniform float theta;
+        attribute vec4 color;
+        attribute vec2 position;
+        varying vec4 v_color;
+        void main()
+        {
+            float ct = cos(theta);
+            float st = sin(theta);
+            float x = 0.75* (position.x*ct - position.y*st);
+            float y = 0.75* (position.x*st + position.y*ct);
+            gl_Position = vec4(x, y, 0.0, 1.0);
+            v_color = color;
+        } """
+    
+    fragment = """
+        varying vec4 v_color;
+        void main()
+        {
+            gl_FragColor = v_color;
+        } """
+
+    class Canvas(vispy.app.Canvas):
+        def __init__(self):
+            super().__init__(size=(512, 512), title='Rotating quad',
+                             keys='interactive')
+            # Build program & data
+            self.program = vispy.gloo.Program(vertex, fragment, count=4)
+            self.program['color'] = [(1, 0, 0, 1), (0, 1, 0, 1),
+                                     (0, 0, 1, 1), (1, 1, 0, 1)]
+
+            position =  np.array([(-1, -1), (-1, +1),
+                                  (+1, -1), (+1, +1)], dtype=np.float32)
+            print('Sending position to vispy as a numpy array:')
+            print('position =', position)
+            self.program['position'] = position
+            self.context.glir.associate(self.program.glir)
+            self.context.glir.flush(self.context.shared.parser)
+            position_vb = self.context.shared.parser.get_object(self.program['position'].base.id)
+            print('Pulling position out:')
+            position_dlpack = CudaBuffer(position_vb, position.shape, position.dtype)
+            import torch
+            print('position torch tensor = ', torch.from_dlpack(position_dlpack))
+            import cupy
+            print('position cupy array = ', cupy.from_dlpack(position_dlpack))
+
+            self.program['theta'] = 0.0
+
+    
+            vispy.gloo.set_viewport(0, 0, *self.physical_size)
+            vispy.gloo.set_clear_color('white')
+    
+            self.timer = vispy.app.Timer('auto', self.on_timer)
+            self.clock = 0
+            self.timer.start()
+    
+            self.show()
+    
+        def on_draw(self, event):
+            vispy.gloo.clear()
+            self.program.draw('triangle_strip')
+    
+        def on_resize(self, event):
+            vispy.gloo.set_viewport(0, 0, *event.physical_size)
+    
+        def on_timer(self, event):
+            self.clock += 0.001 * 1000.0 / 60.
+            self.program['theta'] = self.clock
+            self.update()
+        
+    c = Canvas()
+    c.show()
+    vispy.app.run()

--- a/vispy/gloo/dlpack/dlpack.py
+++ b/vispy/gloo/dlpack/dlpack.py
@@ -1,0 +1,137 @@
+import ctypes
+
+_c_str_dltensor = b"dltensor"
+
+
+class DLDeviceType(ctypes.c_int):
+    """The enum that encodes the type of the device where
+    DLTensor memory is allocated.
+    """
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLCUDAManaged = 13
+    kDLOneAPI = 14
+
+    def __str__(self):
+        return {
+            self.kDLCPU : "CPU",
+            self.kDLCUDA: "CUDA",
+            self.kDLCUDAHost: "CUDAHost",
+            self.kDLOpenCL: "OpenCL",
+            self.kDLVulkan: "Vulkan",
+            self.kDLMetal: "Metal",
+            self.kDLVPI: "VPI",
+            self.kDLROCM: "ROCM",
+            self.kDLROCMHost: "ROMCHost",
+            self.kDLCUDAManaged: "CUDAManaged",
+            self.kDLOneAPI: "oneAPI",
+            }[self.value]
+
+
+class DLDevice(ctypes.Structure):
+    """Represents the device where DLTensor memory is allocated.
+    The device is represented by the pair of fields:
+       device_type: DLDeviceType
+       device_id: c_int
+    """
+    _fields_ = [
+        ("device_type", DLDeviceType),
+        ("device_id", ctypes.c_int),
+    ]
+
+
+class DLDataTypeCode(ctypes.c_uint8):
+    """An integer that encodes the category of DLTensor elements' data type."""
+    kDLInt = 0
+    kDLUInt = 1
+    kDLFloat = 2
+    kDLOpaquePointer = 3
+    kDLBfloat = 4
+    kDLComplex = 5
+
+    def __str__(self):
+        return {
+            self.kDLInt: "int",
+            self.kDLUInt: "uint",
+            self.kDLFloat: "float",
+            self.kDLBfloat: "bfloat",
+            self.kDLComplex: "complex",
+            self.kDLOpaquePointer: "void_p"
+        }[self.value]
+
+
+class DLDataType(ctypes.Structure):
+    """Descriptor of data type for elements of DLTensor.
+    The data type is described by a triple, `DLDataType.type_code`,
+    `DLDataType.bits`, and `DLDataType.lanes`.
+
+    The element is understood as packed `lanes` repetitions of
+    elements from `type_code` data-category of width `bits`.
+    """
+    _fields_ = [
+        ("type_code", DLDataTypeCode),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+    TYPE_MAP = {
+        "bool": (DLDataTypeCode.kDLUInt, 1, 1),
+        "int8": (DLDataTypeCode.kDLInt, 8, 1),
+        "int16": (DLDataTypeCode.kDLInt, 16, 1),
+        "int32": (DLDataTypeCode.kDLInt, 32, 1),
+        "int64": (DLDataTypeCode.kDLInt, 64, 1),
+        "uint8": (DLDataTypeCode.kDLUInt, 8, 1),
+        "uint16": (DLDataTypeCode.kDLUInt, 16, 1),
+        "uint32": (DLDataTypeCode.kDLUInt, 32, 1),
+        "uint64": (DLDataTypeCode.kDLUInt, 64, 1),
+        "float16": (DLDataTypeCode.kDLFloat, 16, 1),
+        "float32": (DLDataTypeCode.kDLFloat, 32, 1),
+        "float64": (DLDataTypeCode.kDLFloat, 64, 1),
+        "complex64": (DLDataTypeCode.kDLComplex, 64, 1),
+        "complex128": (DLDataTypeCode.kDLComplex, 128, 1)
+    }
+
+
+class DLTensor(ctypes.Structure):
+    """Structure describing strided layout of DLTensor.
+    Fields are:
+       data:  void pointer
+       device: DLDevice
+       ndim: number of indices needed to reference an
+             element of the tensor
+       dtype: data type descriptor
+       shape: tuple with lengths of the corresponding
+              tensor dimensions
+       strides: tuple of numbers of array elements to
+                step in each dimension when traversing
+                the tensor
+       byte_offset: data + byte_offset gives the address of
+                tensor element with index (0,) * ndim
+    """
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class DLManagedTensor(ctypes.Structure):
+    """Structure storing the pointer to the tensor descriptor,
+    deleter callable for the tensor descriptor, and pointer to
+    some additional data. These are stored in fields `dl_tensor`,
+    `deleter`, and `manager_ctx`."""
+    _fields_ = [
+        ("dl_tensor", DLTensor),
+        ("manager_ctx", ctypes.c_void_p),
+        ("deleter", ctypes.CFUNCTYPE(None, ctypes.c_void_p)),
+    ]

--- a/vispy/gloo/dlpack/util.py
+++ b/vispy/gloo/dlpack/util.py
@@ -1,0 +1,58 @@
+import dlpack
+
+import ctypes
+
+DLManagedTensor_size = ctypes.c_size_t(ctypes.sizeof(dlpack.DLManagedTensor))
+
+ctypes.pythonapi.PyMem_RawMalloc.restype = ctypes.c_void_p
+ctypes.pythonapi.PyMem_RawFree.argtypes = [ctypes.c_void_p]
+
+ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+ctypes.pythonapi.PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+
+def _manager_ctx(obj) -> ctypes.c_void_p:
+    py_obj = ctypes.py_object(obj)
+    py_obj_ptr = ctypes.pointer(py_obj)
+    ctypes.pythonapi.Py_IncRef(py_obj)
+    ctypes.pythonapi.Py_IncRef(ctypes.py_object(py_obj_ptr))
+    return ctypes.cast(py_obj_ptr, ctypes.c_void_p)
+
+@ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+def _manager_ctx_deleter(handle: ctypes.c_void_p) -> None:
+    dl_managed = dlpack.DLManagedTensor.from_address(handle)
+    py_obj_ptr = ctypes.cast(
+        dl_managed.manager_ctx, ctypes.POINTER(ctypes.py_object)
+    )
+    py_obj = py_obj_ptr.contents
+    ctypes.pythonapi.Py_DecRef(py_obj)
+    ctypes.pythonapi.Py_DecRef(ctypes.py_object(py_obj_ptr))
+    ctypes.pythonapi.PyMem_RawFree(handle)
+
+@ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+def _pycapsule_deleter(handle: ctypes.c_void_p) -> None:
+    pycapsule: ctypes.py_object = ctypes.cast(handle, ctypes.py_object)
+    if ctypes.pythonapi.PyCapsule_IsValid(pycapsule, dlpack._c_str_dltensor):
+        dl_managed = ctypes.pythonapi.PyCapsule_GetPointer(
+            pycapsule, _c_str_dltensor
+        )
+        _manager_ctx_deleter(dl_managed)
+        ctypes.pythonapi.PyCapsule_SetDestructor(pycapsule, None)
+
+def create_dlpack_capsule(obj, ptr, device, dtype, shape, strides = None, byte_offset = 0):
+    ndim = len(shape)
+    dl_managed = dlpack.DLManagedTensor.from_address(ctypes.pythonapi.PyMem_RawMalloc(DLManagedTensor_size))
+    dl_managed.dl_tensor.data = ptr
+    dl_managed.dl_tensor.device = device
+    dl_managed.dl_tensor.dtype = dtype
+    dl_managed.dl_tensor.ndim = ndim
+    dl_managed.dl_tensor.shape = (ctypes.c_int64 * ndim)(*shape)
+    dl_managed.dl_tensor.strides = strides
+    dl_managed.dl_tensor.byte_offset = 0
+    dl_managed.manager_ctx = _manager_ctx(obj)
+    dl_managed.deleter = _manager_ctx_deleter
+    pycapsule = ctypes.pythonapi.PyCapsule_New(
+        ctypes.byref(dl_managed),
+        dlpack._c_str_dltensor,
+        _pycapsule_deleter,
+    )
+    return pycapsule


### PR DESCRIPTION
This is just a scratch work showcasins concepts for gpu data access coming together. It's a quick half-working thing.

Demo (watch the text output: attaches a vertex buffer to a program, then exports it to pytorch in-place):
```
pip3 install torch
cd vispy/gloo/dlpack
python3 cuda_.py
```

I copied from the dlpack repository to write a basic dlpack wrapper for vispy's GL buffers. I spent some hours on this, and am sharing it now that it actually runs at all. I'm not sure whether I will return to this or not, but I expect others would find it helpful.

It looks like something on the GL end is getting corrupt, maybe from my quick calls to access the buffer leaving something out, or from an unaddressed mistake managing the data, not sure, haven't looked at it.

Strangely, CuPy appears to be ignoring its from_dlpack implementation and maybe handing off to numpy, which doesn't support CUDA? So CuPy fails right now. Not sure why that is. It has a cuda-oriented from_dlpack implementation in its codebase, though.

But it was pretty exciting for me to see the same data output in the torch tensor as I passed in to vispy's program, once I got this far.