### PR TITLE
Fix ColorArray failing with numpy 1.24.0

### DIFF
--- a/examples/plotting/colorbar.py
+++ b/examples/plotting/colorbar.py
@@ -13,7 +13,7 @@ import numpy as np
 
 # arg( e^(1/z) )
 def exp_z_inv(x, y):
-    z = np.complex_(x, y)
+    z = complex(x, y)
     f = np.exp(1.0 / z)
     return np.angle(f, deg=True)
 

--- a/examples/plotting/colorbar.py
+++ b/examples/plotting/colorbar.py
@@ -13,7 +13,7 @@ import numpy as np
 
 # arg( e^(1/z) )
 def exp_z_inv(x, y):
-    z = np.complex(x, y)
+    z = np.complex_(x, y)
     f = np.exp(1.0 / z)
     return np.angle(f, deg=True)
 

--- a/vispy/color/color_array.py
+++ b/vispy/color/color_array.py
@@ -163,6 +163,13 @@ class ColorArray(object):
         """Helper to get the class name once it's been created"""
         return cls.__name__
 
+    def __array__(self, dtype=None):
+        """Get a standard numpy array representing RGBA."""
+        rgba = self.rgba
+        if dtype is not None:
+            rgba = rgba.astype(dtype)
+        return rgba
+
     def __len__(self):
         return self._rgba.shape[0]
 

--- a/vispy/visuals/tube.py
+++ b/vispy/visuals/tube.py
@@ -80,7 +80,7 @@ class TubeVisual(MeshVisual):
 
             # Add a vertex for each point on the circle
             v = np.arange(tube_points,
-                          dtype=np.float) / tube_points * 2 * np.pi
+                          dtype=np.float32) / tube_points * 2 * np.pi
             cx = -1. * r * np.cos(v)
             cy = r * np.sin(v)
             grid[i] = (pos + cx[:, np.newaxis]*normal +


### PR DESCRIPTION
This fixes the issue first seen in #2438. The error seen was:

```
  >       assert_array_equal(rgb, ColorArray(np.eye(3)))
  
  vispy/color/tests/test_color.py:93: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  args = (<built-in function eq>, <ColorArray: 3 colors ((1.0, 0.0, 0.0, 1.0) ... (0.0, 0.0, 1.0, 1.0))>, <ColorArray: 3 colors ((1.0, 0.0, 0.0, 1.0) ... (0.0, 0.0, 1.0, 1.0))>)
  kwds = {'err_msg': '', 'header': 'Arrays are not equal', 'strict': False, 'verbose': True}
  
      @wraps(func)
      def inner(*args, **kwds):
          with self._recreate_cm():
  >           return func(*args, **kwds)
  E           ValueError: setting an array element with a sequence. The requested array would exceed the maximum number of dimension of 32.
```

Now when I started debugging this I got into this weird loop where the numpy comparison code ran `np.asanyarray(one_of_the_color_arrays)` which called `__len__` and then a series of `__getitem__` requests. But I couldn't actually nail down where the error was happening because it occurs somewhere in the numpy C code. Regardless, it was clear to me that numpy shouldn't have to work this hard to get an array representation of the ColorArray when all the ColorArray `__getitem__` is doing is getting a row of the `self._rgba` internal array.

This PR adds an `__array__` method to `ColorArray` which returns a copy of the RGBA array of the instance. I wasn't sure if a copy *needed* to be returned but it seemed safest. I also wasn't sure what the behavior was supposed to be when `dtype=None` so I just returned the RGBA array copy as-is.

This fixed the failing test locally so let's see how full CI does...