### PR TITLE
Use QNativeEventGesture for touchpad gesture input

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -22,6 +22,7 @@ known to cause unpredictable behavior and segfaults.
 from __future__ import division
 
 from time import sleep, time
+import math
 import os
 import sys
 import atexit
@@ -410,17 +411,10 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             # either not PyQt5 backend or no parent window available
             pass
 
-        # Activate touch and gesture.
-        # NOTE: we only activate touch on OS X because there seems to be
-        # problems on Ubuntu computers with touchscreen.
-        # See https://github.com/vispy/vispy/pull/1143
-        if sys.platform == 'darwin':
-            if PYQT6_API:
-                self.setAttribute(QtCore.Qt.WidgetAttribute.WA_AcceptTouchEvents)
-                self.grabGesture(QtCore.Qt.GestureType.PinchGesture)
-            else:
-                self.setAttribute(QtCore.Qt.WA_AcceptTouchEvents)
-                self.grabGesture(QtCore.Qt.PinchGesture)
+        # QNativeGestureEvent does not keep track of last or total
+        # values like QGestureEvent does
+        self._native_gesture_scale_values = []
+        self._native_gesture_rotation_values = []
 
     def screen_changed(self, new_screen):
         """Window moved from one display to another, resize canvas.
@@ -563,50 +557,81 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
     def keyReleaseEvent(self, ev):
         self._keyEvent(self._vispy_canvas.events.key_release, ev)
 
+    def _handle_native_gesture_event(self, ev):
+        if self._vispy_canvas is None:
+            return
+        t = ev.gestureType()
+        # this is a workaround for what looks like a Qt bug where
+        # QNativeGestureEvent gives the wrong local position.
+        # See: https://bugreports.qt.io/browse/QTBUG-59595
+        try:
+            pos = self.mapFromGlobal(ev.globalPosition())
+        except AttributeError:
+            # globalPos is deprecated in Qt6
+            pos = self.mapFromGlobal(ev.globalPos())
+        pos = pos.x(), pos.y()
+
+        if t == QtCore.Qt.NativeGestureType.BeginNativeGesture:
+            self._vispy_canvas.events.touch(
+                type='gesture_begin',
+                pos=_get_event_xy(ev),
+            )
+        elif t == QtCore.Qt.NativeGestureType.EndNativeGesture:
+            # TODO: need to track corresponding begin/end? not sure how in Qt5
+            self._native_touch_total_rotation = []
+            self._native_touch_total_scale = []
+            self._vispy_canvas.events.touch(
+                type='gesture_end',
+                pos=_get_event_xy(ev),
+            )
+        elif t == QtCore.Qt.NativeGestureType.RotateNativeGesture:
+            angle = ev.value()
+            last_angle = (
+                self._native_gesture_rotation_values[-1]
+                if self._native_gesture_rotation_values
+                else None
+            )
+            self._native_gesture_rotation_values.append(angle)
+            total_rotation_angle = math.fsum(self._native_gesture_rotation_values)
+            self._vispy_canvas.events.touch(
+                type="gesture_rotate",
+                pos=pos,
+                last_pos=None,  # TODO: is this needed?
+                rotation=angle,
+                last_rotation=last_angle,
+                total_rotation_angle=total_rotation_angle,
+            )
+        elif t == QtCore.Qt.NativeGestureType.ZoomNativeGesture:
+            scale = ev.value()
+            last_scale = (
+                self._native_gesture_scale_values[-1]
+                if self._native_gesture_scale_values
+                else None
+            )
+            self._native_gesture_scale_values.append(scale)
+            total_scale_factor = math.fsum(self._native_gesture_scale_values)
+            self._vispy_canvas.events.touch(
+                type="gesture_zoom",
+                pos=pos,
+                last_pos=None,  # TODO: is this needed?
+                last_scale=last_scale,
+                scale=scale,
+                total_scale_factor=total_scale_factor,
+            )
+        # TODO: do we need or will we ever get pan events?
+        # With two fingers they are anyway converted to scroll/wheel events.
+        # On macOS, more fingers are usually swallowed by the OS (by spaces,
+        # mission control, etc.).
+        # elif t == QtCore.Qt.NativeGestureType.PanNativeGesture:
+
     def event(self, ev):
         out = super(QtBaseCanvasBackend, self).event(ev)
-        t = ev.type()
 
-        qt_event_types = QtCore.QEvent.Type if PYQT6_API else QtCore.QEvent
-        # Two-finger pinch.
-        if t == qt_event_types.TouchBegin:
-            self._vispy_canvas.events.touch(type='begin')
-        if t == qt_event_types.TouchEnd:
-            self._vispy_canvas.events.touch(type='end')
-        if t == qt_event_types.Gesture:
-            pinch_gesture = QtCore.Qt.GestureType.PinchGesture if PYQT6_API else QtCore.Qt.PinchGesture
-            gesture = ev.gesture(pinch_gesture)
-            if gesture:
-                (x, y) = _get_qpoint_pos(gesture.centerPoint())
-                scale = gesture.scaleFactor()
-                last_scale = gesture.lastScaleFactor()
-                rotation = gesture.rotationAngle()
-                self._vispy_canvas.events.touch(
-                    type="pinch",
-                    pos=(x, y),
-                    last_pos=None,
-                    scale=scale,
-                    last_scale=last_scale,
-                    rotation=rotation,
-                    total_rotation_angle=gesture.totalRotationAngle(),
-                    total_scale_factor=gesture.totalScaleFactor(),
-                )
-        # General touch event.
-        elif t == qt_event_types.TouchUpdate:
-            if qt_lib == 'pyqt6' or qt_lib == 'pyside6':
-                points = ev.points()
-                # These variables are lists of (x, y) coordinates.
-                pos = [_get_qpoint_pos(p.position()) for p in points]
-                lpos = [_get_qpoint_pos(p.lastPosition()) for p in points]
-            else:
-                points = ev.touchPoints()
-                # These variables are lists of (x, y) coordinates.
-                pos = [_get_qpoint_pos(p.pos()) for p in points]
-                lpos = [_get_qpoint_pos(p.lastPos()) for p in points]
-            self._vispy_canvas.events.touch(type='touch',
-                                            pos=pos,
-                                            last_pos=lpos,
-                                            )
+        # QNativeGestureEvent is Qt 5+
+        if QT5_NEW_API or PYSIDE6_API or PYQT6_API:
+            if isinstance(ev, QtGui.QNativeGestureEvent):
+                self._handle_native_gesture_event(ev)
+
         return out
 
     def _keyEvent(self, func, ev):

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -577,7 +577,6 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
                 pos=_get_event_xy(ev),
             )
         elif t == QtCore.Qt.NativeGestureType.EndNativeGesture:
-            # TODO: need to track corresponding begin/end? not sure how in Qt5
             self._native_touch_total_rotation = []
             self._native_touch_total_scale = []
             self._vispy_canvas.events.touch(
@@ -596,7 +595,6 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             self._vispy_canvas.events.touch(
                 type="gesture_rotate",
                 pos=pos,
-                last_pos=None,  # TODO: is this needed?
                 rotation=angle,
                 last_rotation=last_angle,
                 total_rotation_angle=total_rotation_angle,
@@ -613,24 +611,26 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             self._vispy_canvas.events.touch(
                 type="gesture_zoom",
                 pos=pos,
-                last_pos=None,  # TODO: is this needed?
                 last_scale=last_scale,
                 scale=scale,
                 total_scale_factor=total_scale_factor,
             )
-        # TODO: do we need or will we ever get pan events?
-        # With two fingers they are anyway converted to scroll/wheel events.
+        # QtCore.Qt.NativeGestureType.PanNativeGesture
+        # Qt6 docs seem to imply this is only supported on Wayland but I have
+        # not been able to test it.
+        # Two finger pan events are anyway converted to scroll/wheel events.
         # On macOS, more fingers are usually swallowed by the OS (by spaces,
         # mission control, etc.).
-        # elif t == QtCore.Qt.NativeGestureType.PanNativeGesture:
 
     def event(self, ev):
         out = super(QtBaseCanvasBackend, self).event(ev)
 
         # QNativeGestureEvent is Qt 5+
-        if QT5_NEW_API or PYSIDE6_API or PYQT6_API:
-            if isinstance(ev, QtGui.QNativeGestureEvent):
-                self._handle_native_gesture_event(ev)
+        if (
+            (QT5_NEW_API or PYSIDE6_API or PYQT6_API)
+            and isinstance(ev, QtGui.QNativeGestureEvent)
+        ):
+            self._handle_native_gesture_event(ev)
 
         return out
 

--- a/vispy/scene/cameras/base_camera.py
+++ b/vispy/scene/cameras/base_camera.py
@@ -133,6 +133,8 @@ class BaseCamera(Node):
         viewbox.events.mouse_release.connect(self.viewbox_mouse_event)
         viewbox.events.mouse_move.connect(self.viewbox_mouse_event)
         viewbox.events.mouse_wheel.connect(self.viewbox_mouse_event)
+        viewbox.events.gesture_zoom.connect(self.viewbox_mouse_event)
+        viewbox.events.gesture_rotate.connect(self.viewbox_mouse_event)
         viewbox.events.resize.connect(self.viewbox_resize_event)
         # todo: also add key events! (and also on viewbox (they're missing)
 
@@ -144,6 +146,8 @@ class BaseCamera(Node):
         viewbox.events.mouse_release.disconnect(self.viewbox_mouse_event)
         viewbox.events.mouse_move.disconnect(self.viewbox_mouse_event)
         viewbox.events.mouse_wheel.disconnect(self.viewbox_mouse_event)
+        viewbox.events.gesture_zoom.disconnect(self.viewbox_mouse_event)
+        viewbox.events.gesture_rotate.disconnect(self.viewbox_mouse_event)
         viewbox.events.resize.disconnect(self.viewbox_resize_event)
 
     @property

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -207,7 +207,10 @@ class PanZoomCamera(BaseCamera):
             center = self._scene_transform.imap(event.pos)
             self.zoom((1 + self.zoom_factor)**(-event.delta[1] * 30), center)
             event.handled = True
-
+        elif event.type == 'gesture_zoom':
+            center = self._scene_transform.imap(event.pos)
+            self.zoom(1 - event.mouse_event.scale, center)
+            event.handled = True
         elif event.type == 'mouse_move':
             if event.press_event is None:
                 return

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -209,7 +209,7 @@ class PanZoomCamera(BaseCamera):
             event.handled = True
         elif event.type == 'gesture_zoom':
             center = self._scene_transform.imap(event.pos)
-            self.zoom(1 - event.mouse_event.scale, center)
+            self.zoom(1 - event.scale, center)
             event.handled = True
         elif event.type == 'mouse_move':
             if event.press_event is None:

--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -63,7 +63,7 @@ class PerspectiveCamera(BaseCamera):
                 self._distance *= s
             self.view_changed()
         elif event.type == 'gesture_zoom':
-            s = 1 - event.mouse_event.scale
+            s = 1 - event.scale
             self._scale_factor *= s
             if self._distance is not None:
                 self._distance *= s

--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -62,6 +62,12 @@ class PerspectiveCamera(BaseCamera):
             if self._distance is not None:
                 self._distance *= s
             self.view_changed()
+        elif event.type == 'gesture_zoom':
+            s = 1 - event.mouse_event.scale
+            self._scale_factor *= s
+            if self._distance is not None:
+                self._distance *= s
+            self.view_changed()
 
     @property
     def scale_factor(self):

--- a/vispy/scene/cameras/tests/test_cameras.py
+++ b/vispy/scene/cameras/tests/test_cameras.py
@@ -5,8 +5,15 @@
 # -----------------------------------------------------------------------------
 import numpy as np
 import pytest
-from vispy.scene.cameras import TurntableCamera
-from vispy.testing import run_tests_if_main
+
+from vispy import io
+from vispy import scene
+from vispy.scene import TurntableCamera
+from vispy.testing import (
+    requires_application,
+    TestingCanvas,
+    run_tests_if_main,
+)
 
 
 @pytest.mark.parametrize(
@@ -22,6 +29,35 @@ def test_turntable_camera_transform(elevation, azimuth, roll, expected):
     camera = TurntableCamera(elevation=elevation, azimuth=azimuth, roll=roll)
     matrix = camera._get_rotation_tr()
     np.testing.assert_allclose(matrix, expected, atol=1e-5)
+
+
+@requires_application()
+@pytest.mark.parametrize("camera_type", ("panzoom", "perspective"))
+def test_touch_gesture_zoom(camera_type):
+    with TestingCanvas(size=(120, 200)) as canvas:
+        grid = canvas.central_widget.add_grid()
+        imdata = io.load_crate().astype('float32') / 255
+        v = grid.add_view(row=0, col=0)
+        v.camera = 'panzoom'
+        image = scene.visuals.Image(imdata)
+        image.transform = scene.STTransform(
+            translate=(0, 0),
+            scale=(1.0, 1.0),
+        )
+        v.add(image)
+
+        assert v.camera.rect.pos == (0, 0)
+        assert v.camera.rect.size == (1, 1)
+
+        center = v.camera._scene_transform.map((0, 0))[:2]
+        canvas.events.touch(
+            type="gesture_zoom",
+            scale=-1.0,
+            pos=center,
+        )
+
+        assert v.camera.rect.pos == (0, 0)
+        assert v.camera.rect.size == (2, 2)
 
 
 run_tests_if_main()

--- a/vispy/scene/cameras/tests/test_cameras.py
+++ b/vispy/scene/cameras/tests/test_cameras.py
@@ -5,15 +5,8 @@
 # -----------------------------------------------------------------------------
 import numpy as np
 import pytest
-
-from vispy import io
-from vispy import scene
-from vispy.scene import TurntableCamera
-from vispy.testing import (
-    requires_application,
-    TestingCanvas,
-    run_tests_if_main,
-)
+from vispy.scene.cameras import TurntableCamera
+from vispy.testing import run_tests_if_main
 
 
 @pytest.mark.parametrize(
@@ -29,35 +22,6 @@ def test_turntable_camera_transform(elevation, azimuth, roll, expected):
     camera = TurntableCamera(elevation=elevation, azimuth=azimuth, roll=roll)
     matrix = camera._get_rotation_tr()
     np.testing.assert_allclose(matrix, expected, atol=1e-5)
-
-
-@requires_application()
-@pytest.mark.parametrize("camera_type", ("panzoom", "perspective"))
-def test_touch_gesture_zoom(camera_type):
-    with TestingCanvas(size=(120, 200)) as canvas:
-        grid = canvas.central_widget.add_grid()
-        imdata = io.load_crate().astype('float32') / 255
-        v = grid.add_view(row=0, col=0)
-        v.camera = 'panzoom'
-        image = scene.visuals.Image(imdata)
-        image.transform = scene.STTransform(
-            translate=(0, 0),
-            scale=(1.0, 1.0),
-        )
-        v.add(image)
-
-        assert v.camera.rect.pos == (0, 0)
-        assert v.camera.rect.size == (1, 1)
-
-        center = v.camera._scene_transform.map((0, 0))[:2]
-        canvas.events.touch(
-            type="gesture_zoom",
-            scale=-1.0,
-            pos=center,
-        )
-
-        assert v.camera.rect.pos == (0, 0)
-        assert v.camera.rect.size == (2, 2)
 
 
 run_tests_if_main()

--- a/vispy/scene/cameras/tests/test_perspective.py
+++ b/vispy/scene/cameras/tests/test_perspective.py
@@ -82,4 +82,41 @@ def test_panzoom_center():
         assert v.camera.center == (-12.8, -12.8, 0)
 
 
+@requires_application()
+def test_panzoom_gesture_zoom():
+    with TestingCanvas(size=(120, 200)) as canvas:
+        view = canvas.central_widget.add_view()
+        imdata = io.load_crate().astype('float32') / 255
+        scene.visuals.Image(imdata, parent=view.scene)
+        view.camera = scene.PanZoomCamera(aspect=1)
+
+        assert view.camera.rect.size == (1, 1)
+
+        canvas.events.touch(
+            type="gesture_zoom",
+            pos=(60, 100),
+            scale=-1.0,
+        )
+
+        assert view.camera.rect.size == (2, 2)
+
+
+@requires_application()
+def test_turntable_gesture_zoom():
+    with TestingCanvas(size=(120, 200)) as canvas:
+        view = canvas.central_widget.add_view()
+        imdata = io.load_crate().astype('float32') / 255
+        scene.visuals.Image(imdata, parent=view.scene)
+        view.camera = scene.TurntableCamera()
+
+        initial_scale_factor = view.camera.scale_factor
+        canvas.events.touch(
+            type="gesture_zoom",
+            pos=(60, 100),
+            scale=-1.0,
+        )
+
+        assert view.camera.scale_factor == 2 * initial_scale_factor
+
+
 run_tests_if_main()

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -140,6 +140,7 @@ class SceneCanvas(app.Canvas, Frozen):
         self.events.mouse_move.connect(self._process_mouse_event)
         self.events.mouse_release.connect(self._process_mouse_event)
         self.events.mouse_wheel.connect(self._process_mouse_event)
+        self.events.touch.connect(self._process_mouse_event)
 
         self.scene = SubScene()
         self.freeze()
@@ -344,7 +345,12 @@ class SceneCanvas(app.Canvas, Frozen):
 
     def _process_mouse_event(self, event):
         prof = Profiler()  # noqa
-        deliver_types = ['mouse_press', 'mouse_wheel']
+        deliver_types = [
+            'mouse_press',
+            'mouse_wheel',
+            'gesture_zoom',
+            'gesture_rotate',
+        ]
         if self._send_hover_events:
             deliver_types += ['mouse_move']
 
@@ -524,6 +530,7 @@ class SceneCanvas(app.Canvas, Frozen):
         self.events.mouse_move.disconnect(self._process_mouse_event)
         self.events.mouse_release.disconnect(self._process_mouse_event)
         self.events.mouse_wheel.disconnect(self._process_mouse_event)
+        self.events.touch.disconnect(self._process_mouse_event)
 
     # -------------------------------------------------- transform handling ---
     def push_viewport(self, viewport):

--- a/vispy/scene/events.py
+++ b/vispy/scene/events.py
@@ -71,6 +71,15 @@ class SceneMouseEvent(Event):
         """The increment by which the mouse wheel has moved."""
         return self.mouse_event.delta
 
+    @property
+    def scale(self):
+        """The scale of a gesture_zoom event"""
+        try:
+            return self.mouse_event.scale
+        except AttributeError:
+            errmsg = f"SceneMouseEvent type '{self.type}' has no scale"
+            raise TypeError(errmsg)
+
     def copy(self):
         ev = self.__class__(self.mouse_event, self.visual)
         return ev

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -63,7 +63,8 @@ class Node(object):
         # Add some events to the emitter groups:
         events = ['canvas_change', 'parent_change', 'children_change', 
                   'transform_change', 'mouse_press', 'mouse_move',
-                  'mouse_release', 'mouse_wheel', 'key_press', 'key_release']
+                  'mouse_release', 'mouse_wheel', 'key_press', 'key_release',
+                  'gesture_zoom', 'gesture_rotate']
         # Create event emitter if needed (in subclasses that inherit from
         # Visual, we already have an emitter to share)
         if not hasattr(self, 'events'):


### PR DESCRIPTION
This refactors the touch input to use `QNtaiveEventGesture` instead of `WA_AcceptTouchEvents` and `PinchGesture` for touchpad gesture input, as proposed in #2455. This is basically proof-of-concept and there are a number of TODOs within the code for discussion, hence the draft status. I have tested on macOS with PyQt5 and PyQt6, but would like to test other backends to make sure there are no regressions. The previous implementation was limited to macOS, but it would be interesting to try this version on other platforms. I believe Qt (6?) now has _some_ support for these gestures in Windows and Linux (Wayland).

Right now this also basically re-implements #1980 and then some, but this is mostly for testing (another reason for draft status here). For the main refactor you can just look at `vispy/app/backends/_qt.py`, but the other code lets you test pinch-to-zoom in `examples/scene/turntable_box.py` and in napari. These changes to the canvas and cameras are likely out of scope for this PR.