### PR TITLE
Bugfix: Use color.lower() for _color_dict keys

### DIFF
--- a/vispy/color/color_array.py
+++ b/vispy/color/color_array.py
@@ -21,7 +21,7 @@ def _string_to_rgb(color):
     if not color.startswith('#'):
         if color.lower() not in _color_dict:
             raise ValueError('Color "%s" unknown' % color)
-        color = _color_dict[color]
+        color = _color_dict[color.lower()]
         assert color[0] == '#'
     # hex color
     color = color[1:]


### PR DESCRIPTION
The `_string_to_rgb` helper function uses `color.lower()` to raise a ValueError, because the names are all lower case in `_color_dict`. However, in the next line, it still uses `color` as the key to the dict, which means that if the string is upper case, the first logic passes, but then a KeyError happens. This was first reported here in napari: 
https://github.com/napari/napari/issues/5599#issuecomment-1455280966

So this PR simply makes sure to use `color.lower()` as the key to the `_color_dict` dictionary.

All tests pass for me locally with this and the napari issue is fixed.