### PR TITLE
Fix shader compilation error for MeshVisual when mesh.clim = 'auto'

### DIFF
--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -283,8 +283,8 @@ class MeshVisual(Visual):
         clim_func = 'float cmap(float val) { return (val - $cmin) / ($cmax - $cmin); }'
         if colors.ndim == 2 and colors.shape[1] == 1:
             fun = Function(clim_func)
-            fun['cmin'] = self.clim[0]
-            fun['cmax'] = self.clim[1]
+            fun['cmin'] = self._clim_values[0]
+            fun['cmax'] = self._clim_values[1]
             fun = FunctionChain(None, [fun, Function(self.cmap.glsl_map)])
         else:
             fun = Function(null_color_transform)

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -33,6 +33,23 @@ def test_mesh_color():
 
 @requires_pyopengl()
 @requires_application()
+def test_mesh_with_values():
+    size = (45, 40)
+    with TestingCanvas(size=size) as c:
+        v = c.central_widget.add_view(border_width=0)
+        vertices = np.array([(0, 0, 0), (0, 0, 1), (1, 0, 0)], dtype=float)
+        faces = np.array([(0, 1, 2)])
+        mesh = scene.visuals.Mesh(
+            vertices=vertices,
+            faces=faces,
+            vertex_values=np.ones(len(vertices)),
+        )
+        v.add(mesh)
+        c.render()
+
+
+@requires_pyopengl()
+@requires_application()
 @pytest.mark.parametrize('shading', [None, 'flat', 'smooth'])
 def test_mesh_shading_change_from_none(shading):
     # Regression test for #2041: exception raised when changing the shading

--- a/vispy/visuals/tests/test_mesh.py
+++ b/vispy/visuals/tests/test_mesh.py
@@ -33,7 +33,7 @@ def test_mesh_color():
 
 @requires_pyopengl()
 @requires_application()
-def test_mesh_with_values():
+def test_mesh_with_vertex_values():
     size = (45, 40)
     with TestingCanvas(size=size) as c:
         v = c.central_widget.add_view(border_width=0)


### PR DESCRIPTION
Rendering a mesh with `vertex_values` produces a shader compilation error when `mesh.clim == "auto"` (the default):
```
RuntimeError: Shader compilation error in GL_VERTEX_SHADER:
    on line 336: Use of undeclared identifier 'a'
      float cmap(float val) { return (val - a) / (u - a); }
    on line 336: Use of undeclared identifier 'u'
      float cmap(float val) { return (val - a) / (u - a); }
    on line 336: Use of undeclared identifier 'a'
      float cmap(float val) { return (val - a) / (u - a); }
```
These "undeclared identifiers"  `a` and `u` are meant to be numbers that come from `mesh.clim`, but this attribute may be a tuple or the string `"auto"`, so here it was taking the first two characters from that string instead of the values.