### PR TITLE
Add early-termination optimization to attenuated mip

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -406,7 +406,7 @@ _ATTENUATED_MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = u_mip_cutoff; // The maximum encountered value
         float sumval = 0.0; // The sum of the encountered values
-        float scaled = 0.0; // The scaled value
+        float scale = 0.0; // The cumulative attenuation
         int maxi = -1;  // Where the maximum value was encountered
         vec3 max_loc_tex = vec3(0.0);  // Location where the maximum value was encountered
         """,
@@ -415,9 +415,12 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         // * attenuation value does not depend on data values
         // * negative values do not amplify instead of attenuate
         sumval = sumval + clamp((val - clim.x) / (clim.y - clim.x), 0.0, 1.0);
-        scaled = val * exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
-        if( scaled > maxval ) {
-            maxval = scaled;
+        scale = exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
+        if( maxval > scale * clim.y ) {
+            // stop if no chance of finding a higher maxval
+            iter = nsteps;
+        } else if( val * scale > maxval ) {
+            maxval = val * scale;
             maxi = iter;
             max_loc_tex = loc;
         }

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -367,7 +367,6 @@ _MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = u_mip_cutoff; // The maximum encountered value
         int maxi = -1;  // Where the maximum value was encountered
-        bool refine = true; // Whether to refine the frag with smaller steps
         """,
     in_loop="""
         if ( val > maxval ) {
@@ -376,13 +375,12 @@ _MIP_SNIPPETS = dict(
             if ( maxval >= clim.y ) {
                 // stop if no chance of finding a higher maxval
                 iter = nsteps;
-                refine = false;
             }
         }
         """,
     after_loop="""
         // Refine search for max value, but only if anything was found
-        if ( maxi > -1 && refine) {
+        if ( maxi > -1 ) {
             // Calculate starting location of ray for sampling
             vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);
             loc = start_loc_refine;
@@ -400,10 +398,6 @@ _MIP_SNIPPETS = dict(
                 loc += small_step;
             }
             frag_depth_point = max_loc_tex * u_shape;
-            gl_FragColor = applyColormap(maxval);
-        } else if ( maxi > -1 ) {
-            // skip refinement if already minimum wrt contrast
-            frag_depth_point = (start_loc + step * float(maxi)) * u_shape;
             gl_FragColor = applyColormap(maxval);
         } else {
             discard;
@@ -449,7 +443,6 @@ _MINIP_SNIPPETS = dict(
     before_loop="""
         float minval = u_minip_cutoff; // The minimum encountered value
         int mini = -1;  // Where the minimum value was encountered
-        bool refine = true;
         """,
     in_loop="""
         if ( val < minval ) {
@@ -458,13 +451,12 @@ _MINIP_SNIPPETS = dict(
             if ( minval <= clim.x ) {
                 // stop if no chance of finding a lower minval
                 iter = nsteps;
-                refine = false;
             }
         }
         """,
     after_loop="""
         // Refine search for min value, but only if anything was found
-        if ( mini > -1 && refine ) {
+        if ( mini > -1 ) {
             // Calculate starting location of ray for sampling
             vec3 start_loc_refine = start_loc + step * (float(mini) - 0.5);
             loc = start_loc_refine;
@@ -482,11 +474,6 @@ _MINIP_SNIPPETS = dict(
                 loc += small_step;
             }
             frag_depth_point = min_loc_tex * u_shape;
-            gl_FragColor = applyColormap(minval);
-        }
-        else if ( mini > -1 ) {
-            // skip refinement if already minimum wrt contrast
-            frag_depth_point = (start_loc + step * float(mini)) * u_shape;
             gl_FragColor = applyColormap(minval);
         } else {
             discard;

--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -366,7 +366,8 @@ _RAYCASTING_SETUP_PLANE = """
 _MIP_SNIPPETS = dict(
     before_loop="""
         float maxval = u_mip_cutoff; // The maximum encountered value
-        int maxi = -2;  // Where the maximum value was encountered
+        int maxi = -1;  // Where the maximum value was encountered
+        bool refine = true; // Whether to refine the frag with smaller steps
         """,
     in_loop="""
         if ( val > maxval ) {
@@ -375,13 +376,13 @@ _MIP_SNIPPETS = dict(
             if ( maxval >= clim.y ) {
                 // stop if no chance of finding a higher maxval
                 iter = nsteps;
-                maxi = -1;
+                refine = false;
             }
         }
         """,
     after_loop="""
         // Refine search for max value, but only if anything was found
-        if ( maxi > -1 ) {
+        if ( maxi > -1 && refine) {
             // Calculate starting location of ray for sampling
             vec3 start_loc_refine = start_loc + step * (float(maxi) - 0.5);
             loc = start_loc_refine;
@@ -400,9 +401,9 @@ _MIP_SNIPPETS = dict(
             }
             frag_depth_point = max_loc_tex * u_shape;
             gl_FragColor = applyColormap(maxval);
-        } else if ( maxi == -1 ) {
+        } else if ( maxi > -1 ) {
             // skip refinement if already minimum wrt contrast
-            frag_depth_point = start_loc + step * float(maxi);
+            frag_depth_point = (start_loc + step * float(maxi)) * u_shape;
             gl_FragColor = applyColormap(maxval);
         } else {
             discard;
@@ -447,7 +448,8 @@ _ATTENUATED_MIP_SNIPPETS = dict(
 _MINIP_SNIPPETS = dict(
     before_loop="""
         float minval = u_minip_cutoff; // The minimum encountered value
-        int mini = -2;  // Where the minimum value was encountered
+        int mini = -1;  // Where the minimum value was encountered
+        bool refine = true;
         """,
     in_loop="""
         if ( val < minval ) {
@@ -456,13 +458,13 @@ _MINIP_SNIPPETS = dict(
             if ( minval <= clim.x ) {
                 // stop if no chance of finding a lower minval
                 iter = nsteps;
-                mini = -1;
+                refine = false;
             }
         }
         """,
     after_loop="""
         // Refine search for min value, but only if anything was found
-        if ( mini > -1 ) {
+        if ( mini > -1 && refine ) {
             // Calculate starting location of ray for sampling
             vec3 start_loc_refine = start_loc + step * (float(mini) - 0.5);
             loc = start_loc_refine;
@@ -482,9 +484,9 @@ _MINIP_SNIPPETS = dict(
             frag_depth_point = min_loc_tex * u_shape;
             gl_FragColor = applyColormap(minval);
         }
-        else if ( mini == -1 ) {
+        else if ( mini > -1 ) {
             // skip refinement if already minimum wrt contrast
-            frag_depth_point = start_loc + step * float(mini);
+            frag_depth_point = (start_loc + step * float(mini)) * u_shape;
             gl_FragColor = applyColormap(minval);
         } else {
             discard;


### PR DESCRIPTION
This idea originated from a [thread on image.sc about poor framerates for volume rendering](https://forum.image.sc/t/poor-3d-viewer-performance-in-napari/68103) napari. The idea is to exit the main raycasting loop early if there is no chance of finding a higher value based on the provided contrast limits. I believe this will not affect the final appearance at all and is only a performance optimization (and my testing supports this).

I don't have a realistic dataset where this makes a truly meaningful difference, but for now you can try this example (adapted from `examples/scene/volume.py`) with a huge cube of random data with/without this change and the performance difference should be apparent.

```python
import numpy as np

from vispy import app, scene

# Prepare canvas
canvas = scene.SceneCanvas(size=(800, 600), show=True)
canvas.measure_fps()

# Set up a viewbox to display the image with interactive pan/zoom
view = canvas.central_widget.add_view()

# Create the volume visual
volume = scene.visuals.Volume(
    np.random.random((1024, 1024, 1024)).astype(np.float32),
    parent=view.scene,
    attenuation=0.05,
    method="attenuated_mip",
)

view.camera = scene.cameras.TurntableCamera(
    parent=view.scene,
    fov=60,
    name='Turntable',
)


if __name__ == '__main__':
    app.run()
```

N.B. @brisvag 