### PR TITLE
[Maint, CI] Build arm64 macOS wheels via CIBW_ARCHS_MACOS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,8 @@ jobs:
         CIBW_ENVIRONMENT: "GITHUB_ACTIONS=true"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+        CIBW_ARCHS_MACOS: 'x86_64 arm64'
+        CIBW_TEST_SKIP: '*-macosx_arm64'
     - uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl


### PR DESCRIPTION
At present vispy doesn't have wheels for arm64 macOS.
It builds from source just fine, but not everyone may have development tools.
Wheels make things potentially safer and of course faster.

In this PR I add use of `CIBW_ARCHS_MACOS` to the existing workflow, setting 'x86_64 arm64'. This results in wheels cross compiled for arm64 in addition to the x86 ones. The runners are x86, so the arm64 wheels won't be tested.

I tested this on my fork (see https://github.com/psobolewskiPhD/vispy/actions/runs/4589168480?pr=1 but note I messed up tags, so only the macOS ones have proper version), downloaded and I installed the 3.10 and 3.11 wheels locally on my arm64 mac and everything works same a with build-from-source (`pip install .`). 
```
===== 18 failed, 768 passed, 132 skipped, 5 xfailed, 60 warnings in 43.06s =====
```
And I tried a few examples, e.g.:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/76622105/229363763-bf8c6c43-6166-4500-aa30-6243da421746.png">

Note: The other option, because the wheels are not huge, is to just build one `universal2` wheel, a fat binary. I don't have a strong opinion one way or the other, but I suspect arm64 is still in a minority to maybe a dedicated wheel for that is better?
