### PR TITLE
Switch MarkersVisual scaling option to string "fixed", "scene", or "visual"

### DIFF
--- a/examples/basics/visuals/markers.py
+++ b/examples/basics/visuals/markers.py
@@ -4,7 +4,13 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
-""" Display markers at different sizes and line thicknessess.
+"""Display markers at different sizes and line thicknesses.
+
+Keyboard options:
+* spacebar: Cycle through possible marker symbols.
+* "s": Switch between "fixed" marker scaling (initial setting) and "scene"
+  scaling.
+
 """
 
 import numpy as np
@@ -60,10 +66,11 @@ class Canvas(app.Canvas):
             self.markers.symbol = self.markers.symbols[self.index]
             self.update()
         elif event.text == 's':
-            self.markers.scaling = not self.markers.scaling
+            self.markers.scaling = "fixed" if self.markers.scaling != "fixed" else "scene"
             self.update()
 
 
 if __name__ == '__main__':
+    print(__doc__)
     canvas = Canvas()
     app.run()

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -701,13 +701,17 @@ class MarkersVisual(Visual):
 
     @scaling.setter
     def scaling(self, value):
-        scaling_int = {
+        scaling_modes = {
             False: 0,
             True: 1,
             "fixed": 0,
             "scene": 1,
             "visual": 2,
-        }.get(value, value)
+        }
+        if value not in scaling_modes:
+            possible_options = ", ".join(repr(opt) for opt in scaling_modes)
+            raise ValueError(f"Unknown scaling option {value!r}, expected one of: {possible_options}")
+        scaling_int = scaling_modes[value]
         self.shared_program['u_scaling'] = scaling_int
         self._scaling = value
         self._scaling_int = scaling_int


### PR DESCRIPTION
Closes #2453. Related #2359.

As discussed in #2453, this restores the default behavior of the `MarkersVisual` before #2359 was merged. It switches the boolean `scaling` keyword argument to a string option of "fixed" (same as False), "scene" (same as True), or "visual" (same as True from #2453). Although we wish things could be simpler, easier, and clearer, this may be the least amount of work to restoring prior behavior while at least giving users access to the fixes from @brisvag in #2359.

CC @arcanerr @ameraner