### PR TITLE
Fix TypeError with pinch-to-zoom

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -565,7 +565,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         # QNativeGestureEvent gives the wrong local position.
         # See: https://bugreports.qt.io/browse/QTBUG-59595
         try:
-            pos = self.mapFromGlobal(ev.globalPosition())
+            pos = self.mapFromGlobal(ev.globalPosition().toPoint())
         except AttributeError:
             # globalPos is deprecated in Qt6
             pos = self.mapFromGlobal(ev.globalPos())


### PR DESCRIPTION
Sorry - some additional manual testing today revealed this bug. It seems to only be a problem with specific backend versions - the function is overloaded in Qt6 to accept either type.

Here's the error I get:
```
File ~/src/vispy/vispy/app/backends/_qt.py:568, in QtBaseCanvasBackend._handle_native_gesture_event(self=<vispy.app.backends._qt.CanvasBackendDesktop object>, ev=<PyQt5.QtGui.QNativeGestureEvent object>)
    564 # this is a workaround for what looks like a Qt bug where
    565 # QNativeGestureEvent gives the wrong local position.
    566 # See: https://bugreports.qt.io/browse/QTBUG-59595
    567 try:
--> 568     pos = self.mapFromGlobal(ev.globalPosition())
        self = <vispy.app.backends._qt.CanvasBackendDesktop object at 0x293ec3760>
        ev = <PyQt5.QtGui.QNativeGestureEvent object at 0x293f22a70>
        ev.globalPosition = <bound method <lambda> of <PyQt5.QtGui.QNativeGestureEvent object at 0x293f22a70>>
    569 except AttributeError:
    570     # globalPos is deprecated in Qt6
    571     pos = self.mapFromGlobal(ev.globalPos())

TypeError: mapFromGlobal(self, a0: QPoint): argument 1 has unexpected type 'QPointF'
```

This is the system information:
```
❯ python -c 'import vispy; print(vispy.sys_info())'
Platform: macOS-13.3.1-arm64-arm-64bit
Python:   3.10.10 | packaged by conda-forge | (main, Mar 24 2023, 20:12:31) [Clang 14.0.6 ]
NumPy:    1.24.2
Backend:  PyQt5
pyqt5:    ('PyQt5', '5.15.7', '5.15.6')
```