### PR TITLE
Do not use old style enum for PySide6

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -284,8 +284,8 @@ def _set_config(c):
         glformat.setSwapBehavior(glformat.DoubleBuffer if c['double_buffer']
                                  else glformat.SingleBuffer)
     elif PYQT6_API or PYSIDE6_API:
-        glformat.setSwapBehavior(glformat.SwapBehavior.DoubleBuffer if c['double_buffer']
-                                 else glformat.SwapBehavior.SingleBuffer)
+        glformat.setSwapBehavior(QGLFormat.DoubleBuffer if c['double_buffer']
+                                 else QGLFormat.SingleBuffer)
     else:
         # Qt4 and Qt5 < 5.4.0 - buffers must be explicitly requested.
         glformat.setAccum(False)


### PR DESCRIPTION
It seems to be getting removed

See: https://wiki.qt.io/Qt_for_Python_Development_Notes

> old Enums are being removed, and the startup time will improve a bit (still in progress)