### PR TITLE
Fix mesh shading with flipped normals

### DIFF
--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -177,6 +177,7 @@ void shade() {
         vec3 u = dFdx(v_pos_scene.xyz);
         vec3 v = dFdy(v_pos_scene.xyz);
         normal = cross(u, v);
+    } else {
         // Note(asnt): The normal calculated above always points in the
         // direction of the camera. Reintroduce the original orientation of the
         // face.


### PR DESCRIPTION
While working with complex surfaces, I noticed that the shading in some cases is wierd. Turns out, the current shader is giving opposite shading depending on which side the face normals are facing. It seems that a flipping check was impplemented, but an `else` was forgotten. Check out the code below:

```python
from vispy import scene
from vispy.geometry import create_sphere

c = scene.SceneCanvas(show=True)
v = c.central_widget.add_view()
v.camera = 'arcball'

s = create_sphere(method='ico', subdivisions=5)
vert = s.get_vertices()
faces = s.get_faces()

# four spheres. from top left to bottom right:
# - flipped normals, flat shading
# - correct normals, flat shading
# - flipped normals, smooth shading
# - correct normals, smoooth s 
top_left = scene.visuals.Mesh(vertices=vert + (-1, 0, +1), faces=faces[:, ::-1], shading='flat', parent=v.scene)
top_right = scene.visuals.Mesh(vertices=vert + (+1, 0, +1), faces=faces, shading='flat', parent=v.scene)
bot_left = scene.visuals.Mesh(vertices=vert + (-1, 0, -1), faces=faces[:, ::-1], shading='smooth', parent=v.scene)
bot_right = scene.visuals.Mesh(vertices=vert + (+1, 0, -1), faces=faces, shading='smooth', parent=v.scene)
```

On `main`, this is the result:

https://github.com/vispy/vispy/assets/23482191/69f50002-0fa0-403a-b172-aa2e7df7d990

On this PR:


https://github.com/vispy/vispy/assets/23482191/d33e1ddb-b445-4679-94e3-5df55f1fcca5

