### PR TITLE
Update _glfw.py

### DIFF
--- a/vispy/app/backends/_glfw.py
+++ b/vispy/app/backends/_glfw.py
@@ -250,7 +250,7 @@ class CanvasBackend(BaseCanvasBackend):
                     raise ValueError('fullscreen must be <= %s'
                                      % len(monitor))
                 monitor = monitor[p.fullscreen]
-            use_size = glfw.get_video_mode(monitor)[:2]
+            use_size = glfw.get_video_mode(monitor)[0][:2]
             if use_size != tuple(p.size):
                 logger.debug('Requested size %s, will be ignored to '
                              'use fullscreen mode %s' % (p.size, use_size))


### PR DESCRIPTION
#2495 
A fix that take care of the 3 namedtuple returned by function glfw.get_video_mode(monitor) in glfw backend, and use only the first tuple (size) as the use_size variable.
