### PR TITLE
Add push/pop gl_state for visuals (used in picking)

### DIFF
--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -33,7 +33,9 @@ def convert_dtype_and_clip(data, dtype, copy=False):
     else:
         # to reduce copying, we clip into a pre-generated array of the right dtype
         new_data = np.empty_like(data, dtype=dtype)
-        np.clip(data, new_min, new_max, out=new_data)
+        # allow "unsafe" casting here as we're explicitly clipping to the
+        # range of the new dtype - this was a default before numpy 1.25
+        np.clip(data, new_min, new_max, out=new_data, casting="unsafe")
         return new_data
 
 

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -493,7 +493,7 @@ class SceneCanvas(app.Canvas, Frozen):
             than triggering transform updates across the scene with every
             click.
         """
-        with self._scene.picking_context():
+        with self._scene.set_picking():
             img = self.render(bgcolor=(0, 0, 0, 0), crop=crop)
         img = img.astype('int32') * [2**0, 2**8, 2**16, 2**24]
         id_ = img.sum(axis=2).astype('int32')

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -493,11 +493,8 @@ class SceneCanvas(app.Canvas, Frozen):
             than triggering transform updates across the scene with every
             click.
         """
-        try:
-            self._scene.picking = True
+        with self._scene.picking_context():
             img = self.render(bgcolor=(0, 0, 0, 0), crop=crop)
-        finally:
-            self._scene.picking = False
         img = img.astype('int32') * [2**0, 2**8, 2**16, 2**24]
         id_ = img.sum(axis=2).astype('int32')
         return id_

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -629,9 +629,12 @@ class Node(object):
         self._picking = p
 
     @contextmanager
-    def picking_context(self, *, picking=True):
-        """Context manager to temporarily set picking for this node and its
-        children.
+    def set_picking(self, *, picking=True):
+        """Context manager to temporarily set picking for this node and its children.
+
+        Note that this function will not alter the picking mode unless/until
+        the context manager is entered (using the `with` statement). Use
+        :py:attr:`~picking` for setting the picking mode directly.
         """
         old_picking = self.picking
         try:

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -5,6 +5,8 @@
 from __future__ import division
 
 import weakref
+from contextlib import contextmanager
+
 
 from ..util.event import Event, EmitterGroup
 from ..visuals.transforms import (NullTransform, BaseTransform, 
@@ -587,7 +589,7 @@ class Node(object):
             A list of Transform instances.
         """
         a, b = self.node_path(node)
-        return ([n.transform for n in a[:-1]] + 
+        return ([n.transform for n in a[:-1]] +
                 [n.transform.inverse for n in b])[::-1]
 
     def node_transform(self, node):
@@ -626,3 +628,13 @@ class Node(object):
         for c in self.children:
             c.picking = p
         self._picking = p
+
+    @contextmanager
+    def picking_context(self):
+        """Context manager to temporarily enable picking for this node and its
+        children.
+        """
+        picking = self.picking
+        self.picking = True
+        yield
+        self.picking = picking

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -7,7 +7,6 @@ from __future__ import division
 import weakref
 from contextlib import contextmanager
 
-
 from ..util.event import Event, EmitterGroup
 from ..visuals.transforms import (NullTransform, BaseTransform, 
                                   ChainTransform, create_transform,
@@ -589,7 +588,7 @@ class Node(object):
             A list of Transform instances.
         """
         a, b = self.node_path(node)
-        return ([n.transform for n in a[:-1]] +
+        return ([n.transform for n in a[:-1]] + 
                 [n.transform.inverse for n in b])[::-1]
 
     def node_transform(self, node):
@@ -630,11 +629,13 @@ class Node(object):
         self._picking = p
 
     @contextmanager
-    def picking_context(self):
-        """Context manager to temporarily enable picking for this node and its
+    def picking_context(self, *, picking=True):
+        """Context manager to temporarily set picking for this node and its
         children.
         """
-        picking = self.picking
-        self.picking = True
-        yield
-        self.picking = picking
+        old_picking = self.picking
+        try:
+            self.picking = picking
+            yield self.picking
+        finally:
+            self.picking = old_picking

--- a/vispy/scene/node.py
+++ b/vispy/scene/node.py
@@ -634,7 +634,7 @@ class Node(object):
 
         Note that this function will not alter the picking mode unless/until
         the context manager is entered (using the `with` statement). Use
-        :py:attr:`~picking` for setting the picking mode directly.
+        :py:attr:`~.picking` for setting the picking mode directly.
         """
         old_picking = self.picking
         try:

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -117,18 +117,3 @@ def test_blend_presets(preset):
 
         rgba_result = c.render()
         assert not np.allclose(rgba_result[..., :3], 0)
-
-
-def test_picking_context():
-    canvas = scene.SceneCanvas()
-    view = canvas.central_widget.add_view()
-    mesh = scene.visuals.Mesh()
-    view.add(mesh)
-
-    assert not view.picking
-    assert not mesh.picking
-    with canvas._scene.picking_context():
-        assert view.picking
-        assert mesh.picking
-    assert not view.picking
-    assert not mesh.picking

--- a/vispy/scene/tests/test_canvas.py
+++ b/vispy/scene/tests/test_canvas.py
@@ -117,3 +117,18 @@ def test_blend_presets(preset):
 
         rgba_result = c.render()
         assert not np.allclose(rgba_result[..., :3], 0)
+
+
+def test_picking_context():
+    canvas = scene.SceneCanvas()
+    view = canvas.central_widget.add_view()
+    mesh = scene.visuals.Mesh()
+    view.add(mesh)
+
+    assert not view.picking
+    assert not mesh.picking
+    with canvas._scene.picking_context():
+        assert view.picking
+        assert mesh.picking
+    assert not view.picking
+    assert not mesh.picking

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -138,7 +138,7 @@ def test_picking_context(enable_picking):
 
     assert mesh.picking != enable_picking
 
-    with mesh.picking_context(picking=enable_picking) as p:
+    with mesh.set_picking(picking=enable_picking) as p:
         assert p == enable_picking
         assert mesh.picking == enable_picking
 

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vispy.scene import visuals, Node
 from vispy.scene.visuals import VisualNode
 import vispy.visuals
@@ -28,11 +30,32 @@ def test_visual_node_generation():
             assert issubclass(vis_node, obj)
 
 
-def test_push_pop_gl_state():
+def test_push_gl_state():
     node = vispy.visuals.MeshVisual()
     og_gl_state = node._vshare.gl_state.copy()
-    node.push_gl_state(blend=not og_gl_state.get("blend"))
+    node.push_gl_state(blend=False, depth_test=False)
     assert node._vshare.gl_state != og_gl_state
+    # preset is always set, unset kwargs should be absent
+    assert node._vshare.gl_state == {
+        "preset": None,
+        "blend": False,
+        "depth_test": False,
+    }
+    node.pop_gl_state()
+    assert node._vshare.gl_state == og_gl_state
+
+
+def test_push_gl_state_update():
+    node = vispy.visuals.MeshVisual()
+    og_gl_state = node._vshare.gl_state.copy()
+    assert "blend" not in og_gl_state
+    assert node._vshare.gl_state["depth_test"]
+
+    node.push_gl_state_update(blend=False, depth_test=False)
+    assert node._vshare.gl_state != og_gl_state
+    assert not node._vshare.gl_state["blend"]
+    assert not node._vshare.gl_state["depth_test"]
+
     node.pop_gl_state()
     assert node._vshare.gl_state == og_gl_state
 
@@ -45,24 +68,78 @@ def test_pop_empty_gl_state():
     assert node._vshare.gl_state == og_gl_state
 
 
-def test_temp_gl_state():
+def test_update_gl_state():
     node = vispy.visuals.MeshVisual()
+
     og_gl_state = node._vshare.gl_state.copy()
-    with node.temp_gl_state(blend=not og_gl_state.get("blend")):
-        assert node._vshare.gl_state != og_gl_state
+    assert og_gl_state
+    og_gl_state["blend"] = False
+
+    node.update_gl_state(blend=True)
+
+    # check that the state was updated
+    assert node._vshare.gl_state.pop("blend") != og_gl_state.pop("blend")
+    # the rest of the state should be unchanged
     assert node._vshare.gl_state == og_gl_state
 
 
-def test_picking_context():
-    canvas = vispy.scene.SceneCanvas()
-    view = canvas.central_widget.add_view()
-    mesh = visuals.Mesh()
-    view.add(mesh)
+def test_update_gl_state_context_manager():
+    node = vispy.visuals.MeshVisual()
 
-    assert not view.picking
-    assert not mesh.picking
-    with canvas._scene.picking_context():
-        assert view.picking
-        assert mesh.picking
-    assert not view.picking
-    assert not mesh.picking
+    node.set_gl_state(blend=False)
+    og_gl_state = node._vshare.gl_state.copy()
+
+    with node.update_gl_state(blend=True) as state:
+        # check that the state was updated
+        assert state == {**og_gl_state, "blend": True}
+        # check that the state returned is the current state
+        assert state == node._vshare.gl_state
+
+    # the update should be reverted once out of the context
+    assert node._vshare.gl_state == og_gl_state
+
+
+def test_set_gl_state():
+    node = vispy.visuals.MeshVisual()
+
+    node.set_gl_state(blend=False, depth_test=False)
+    # preset is always set, unset kwargs should be absent
+    assert node._vshare.gl_state == {
+        "preset": None,
+        "blend": False,
+        "depth_test": False,
+    }
+
+    node.set_gl_state(blend=False)
+    # preset is always set, unset kwargs should be absent
+    assert node._vshare.gl_state == {"preset": None, "blend": False}
+
+
+def test_set_gl_state_context_manager():
+    node = vispy.visuals.MeshVisual()
+
+    node.set_gl_state(blend=False)
+    og_gl_state = node._vshare.gl_state.copy()
+
+    with node.set_gl_state(blend=True) as state:
+        # preset is always set, unset kwargs should be absent
+        assert node._vshare.gl_state == {"preset": None, "blend": True}
+        # check that the state returned is the current state
+        assert state == node._vshare.gl_state
+
+    # the update should be reverted once out of the context
+    assert node._vshare.gl_state == og_gl_state
+
+
+@pytest.mark.parametrize("enable_picking", [True, False])
+def test_picking_context(enable_picking):
+    mesh = visuals.Mesh()
+    mesh.picking = not enable_picking
+
+    assert mesh.picking != enable_picking
+
+    with mesh.picking_context(picking=enable_picking) as p:
+        assert p == enable_picking
+        assert mesh.picking == enable_picking
+
+    assert mesh.picking != enable_picking

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -89,11 +89,9 @@ def test_update_gl_state_context_manager():
     node.set_gl_state(blend=False)
     og_gl_state = node._vshare.gl_state.copy()
 
-    with node.update_gl_state(blend=True) as state:
+    with node.update_gl_state(blend=True):
         # check that the state was updated
-        assert state == {**og_gl_state, "blend": True}
-        # check that the state returned is the current state
-        assert state == node._vshare.gl_state
+        assert node._vshare.gl_state == {**og_gl_state, "blend": True}
 
     # the update should be reverted once out of the context
     assert node._vshare.gl_state == og_gl_state
@@ -121,11 +119,9 @@ def test_set_gl_state_context_manager():
     node.set_gl_state(blend=False)
     og_gl_state = node._vshare.gl_state.copy()
 
-    with node.set_gl_state(blend=True) as state:
+    with node.set_gl_state(blend=True):
         # preset is always set, unset kwargs should be absent
         assert node._vshare.gl_state == {"preset": None, "blend": True}
-        # check that the state returned is the current state
-        assert state == node._vshare.gl_state
 
     # the update should be reverted once out of the context
     assert node._vshare.gl_state == og_gl_state

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -43,3 +43,26 @@ def test_pop_empty_gl_state():
     og_gl_state = node._vshare.gl_state.copy()
     node.pop_gl_state()
     assert node._vshare.gl_state == og_gl_state
+
+
+def test_temp_gl_state():
+    node = vispy.visuals.MeshVisual()
+    og_gl_state = node._vshare.gl_state.copy()
+    with node.temp_gl_state(blend=not og_gl_state.get("blend")):
+        assert node._vshare.gl_state != og_gl_state
+    assert node._vshare.gl_state == og_gl_state
+
+
+def test_picking_context():
+    canvas = vispy.scene.SceneCanvas()
+    view = canvas.central_widget.add_view()
+    mesh = visuals.Mesh()
+    view.add(mesh)
+
+    assert not view.picking
+    assert not mesh.picking
+    with canvas._scene.picking_context():
+        assert view.picking
+        assert mesh.picking
+    assert not view.picking
+    assert not mesh.picking

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -26,3 +26,20 @@ def test_visual_node_generation():
             vis_node = getattr(visuals, name[:-6])
             assert issubclass(vis_node, Node)
             assert issubclass(vis_node, obj)
+
+
+def test_push_pop_gl_state():
+    node = vispy.visuals.MeshVisual()
+    og_gl_state = node._vshare.gl_state.copy()
+    node.push_gl_state(blend=not og_gl_state.get("blend"))
+    assert node._vshare.gl_state != og_gl_state
+    node.pop_gl_state()
+    assert node._vshare.gl_state == og_gl_state
+
+
+def test_pop_empty_gl_state():
+    node = vispy.visuals.MeshVisual()
+    assert node._prev_gl_state == []
+    og_gl_state = node._vshare.gl_state.copy()
+    node.pop_gl_state()
+    assert node._vshare.gl_state == og_gl_state

--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -72,7 +72,7 @@ class VisualNode(Node):
         self._picking = p
         self._picking_filter.enabled = p
         if p:
-            self.push_gl_state(blend=False)
+            self.push_gl_state_update(blend=False)
         else:
             self.pop_gl_state()
 

--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -71,7 +71,10 @@ class VisualNode(Node):
             return
         self._picking = p
         self._picking_filter.enabled = p
-        self.update_gl_state(blend=not p)
+        if p:
+            self.push_gl_state(blend=False)
+        else:
+            self.pop_gl_state()
 
     def _update_trsys(self, event):
         """Transform object(s) have changed for this Node; assign these to the

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -441,7 +441,7 @@ class Visual(BaseVisual):
             Keyword arguments.
         """
         self._prev_gl_state.append(self._vshare.gl_state.copy())
-        self.set_gl_state(*args, **kwargs)
+        self.update_gl_state(*args, **kwargs)
 
     def pop_gl_state(self):
         """Restore a previous set of GL state parameters if available.

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -83,9 +83,10 @@ A compound visual will automatically handle forwarding transform system changes
 and filter attachments to its internally-wrapped visuals. To the user, this
 will appear to behave as a single visual.
 """
-
 from __future__ import division
 import weakref
+from contextlib import contextmanager
+
 import numpy as np
 
 from .. import gloo
@@ -265,6 +266,28 @@ class BaseVisual(Frozen):
 
     def _transform_changed(self, event=None):
         self.update()
+
+    def push_gl_state(self, *args, **kwargs):
+        raise NotImplementedError(self)
+
+    def pop_gl_state(self):
+        raise NotImplementedError(self)
+
+    def set_gl_state(self, *args, **kwargs):
+        raise NotImplementedError(self)
+
+    def update_gl_state(self, *args, **kwargs):
+        raise NotImplementedError(self)
+
+    @contextmanager
+    def temp_gl_state(self, *args, **kwargs):
+        """Context manager for temporarily modifying GL state.
+
+        The arguments are forwarded to :func:`vispy.gloo.wrappers.set_state`.
+        """
+        self.push_gl_state(*args, **kwargs)
+        yield
+        self.pop_gl_state()
 
 
 class BaseVisualView(object):

--- a/vispy/visuals/visual.py
+++ b/vispy/visuals/visual.py
@@ -350,7 +350,9 @@ class Visual(BaseVisual):
         The arguments are forwarded to :func:`vispy.gloo.wrappers.set_state`.
 
         This can also be used as a context manager that will revert the
-        gl_state on exit.
+        gl_state on exit. When used as a context manager, this function is
+        designed to be constructed directly in the header of the `with`
+        statement to avoid confusion about what state will be restored on exit.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes #2501 

This is a proposed solution to the bug identified in #2501. Hopefully it's pretty self-explanatory but basically it allows you to update and restore gl state on a visual.

The only use right now is in picking, which is used in processing mouse events via `SceneCanvas.visuals_at`.