### PR TITLE
Implements limiting size for gridlines

### DIFF
--- a/vispy/visuals/gridlines.py
+++ b/vispy/visuals/gridlines.py
@@ -4,6 +4,8 @@
 
 from __future__ import division
 
+import numpy as np
+
 from .image import ImageVisual
 from ..color import Color
 from .shaders import Function
@@ -11,7 +13,7 @@ from .shaders import Function
 
 _GRID_COLOR = """
 uniform vec4 u_gridlines_bounds;
-uniform float u_boarder_width;
+uniform float u_border_width;
 
 vec4 grid_color(vec2 pos) {
     vec4 px_pos = $map_to_doc(vec4(pos, 0, 1));
@@ -67,9 +69,9 @@ vec4 grid_color(vec2 pos) {
     if (any(lessThan(local_pos.xy, u_gridlines_bounds.xz)) ||
         any(greaterThan(local_pos.xy, u_gridlines_bounds.yw))) {
 
-        // inside the defined bouarder width
-        if (all(greaterThan(local_pos.xy, u_gridlines_bounds.xz - u_boarder_width)) &&
-            all(lessThan(local_pos.xy, u_gridlines_bounds.yw + u_boarder_width))) {
+        // inside the defined border width
+        if (all(greaterThan(local_pos.xy, u_gridlines_bounds.xz - u_border_width)) &&
+            all(lessThan(local_pos.xy, u_gridlines_bounds.yw + u_border_width))) {
             alpha = 1;
         } else {
             discard;
@@ -94,8 +96,9 @@ class GridLinesVisual(ImageVisual):
         channel modified.
     """
 
-    def __init__(self, scale=(1, 1), color='w', bounds=(-1e3, 1e3, -1e3, 1e3),
-                 boarder_width=2):
+    def __init__(self, scale=(1, 1), color='w',
+                 bounds=(-np.inf, np.inf, -np.inf, np.inf),
+                 border_width=2):
         # todo: PlaneVisual should support subdivide/impostor methods from
         # image and gridlines should inherit from plane instead.
         self._grid_color_fn = Function(_GRID_COLOR)
@@ -108,7 +111,7 @@ class GridLinesVisual(ImageVisual):
         self.shared_program.frag['color_transform'] = cfun
         self.unfreeze()
         self.bounds = bounds
-        self.boarder_width = boarder_width
+        self.border_width = border_width
         self.freeze()
 
     @property
@@ -122,13 +125,13 @@ class GridLinesVisual(ImageVisual):
         self.update()
 
     @property
-    def boarder_width(self):
-        return self._boarder_width
+    def border_width(self):
+        return self._border_width
 
-    @boarder_width.setter
-    def boarder_width(self, value):
-        self.shared_program['u_boarder_width'] = value
-        self._boarder_width = value
+    @border_width.setter
+    def border_width(self, value):
+        self.shared_program['u_border_width'] = value
+        self._border_width = value
         self.update()
 
     @property

--- a/vispy/visuals/gridlines.py
+++ b/vispy/visuals/gridlines.py
@@ -92,7 +92,7 @@ class GridLinesVisual(ImageVisual):
     """
 
     def __init__(self, scale=(1, 1), color='w',
-                 bounds=None,
+                 grid_bounds=None,
                  border_width=2):
         # todo: PlaneVisual should support subdivide/impostor methods from
         # image and gridlines should inherit from plane instead.
@@ -105,28 +105,28 @@ class GridLinesVisual(ImageVisual):
         cfun = Function('vec4 null(vec4 x) { return x; }')
         self.shared_program.frag['color_transform'] = cfun
         self.unfreeze()
-        self.bounds = bounds
+        self._grid_bounds = grid_bounds
         self.border_width = border_width
         self.freeze()
 
     @property
-    def bounds(self):
+    def grid_bounds(self):
         return self._bounds
 
-    @bounds.setter
-    def bounds(self, value):
+    @grid_bounds.setter
+    def grid_bounds(self, value):
         if value is None:
             value = (None,) * 4
-        bounds = []
+        grid_bounds = []
         for i, v in enumerate(value):
             if v is None:
                 if i % 2:
                     v = -np.inf
                 else:
                     v = np.inf
-            bounds.append(v)
+            grid_bounds.append(v)
         self.shared_program['u_gridlines_bounds'] = value
-        self._bounds = bounds
+        self._grid_bounds = grid_bounds
         self.update()
 
     @property


### PR DESCRIPTION
This closes #2311 

Test:
```python
from vispy import scene, app

canvas = scene.SceneCanvas(keys="interactive", show=True)

view = canvas.central_widget.add_view()
view.camera = "turntable"

grid_lines = scene.visuals.GridLines(parent=view.scene)

app.run()
```
![Screenshot from 2023-06-24 21-58-03](https://github.com/vispy/vispy/assets/22362177/7c72e2a4-5d14-4667-a8e1-c1fa043f6b39)

Custom limits and boarder width

```python
grid_lines.bounds = -500, 0, 10, 200
grid_lines.boarder_width = 10
```

![Screenshot from 2023-06-24 21-59-38](https://github.com/vispy/vispy/assets/22362177/340d8c02-0e2f-40cd-aa0f-e8a56a1a153d)

Equivalent of infinite grid

```python
grid_lines.bounds = -np.inf, np.inf, -np.inf, np.inf
```

![Screenshot from 2023-06-24 22-06-40](https://github.com/vispy/vispy/assets/22362177/cfff8bad-a954-416e-8578-0dd38580dba0)
