### PR TITLE
Cache make_pattern on DashAtlas

### DIFF
--- a/vispy/visuals/line/dash_atlas.py
+++ b/vispy/visuals/line/dash_atlas.py
@@ -37,12 +37,15 @@ class DashAtlas(object):
         return self._atlas[key]
 
     def __setitem__(self, key, value):
-        length = self._data.shape[1]
-        data, period = _make_pattern(length, value[0], value[1])
+        data, period = self.make_pattern(value[0], value[1])
         self._data[self._index] = data
         self._atlas[key] = [self._index / float(self._data.shape[0]), period]
         self._index += 1
         self._dirty = True
+
+    def make_pattern(self, pattern, caps=[1, 1]):
+        length = self._data.shape[1]
+        return _make_pattern(length, pattern, caps)
 
 
 @lru_cache

--- a/vispy/visuals/line/dash_atlas.py
+++ b/vispy/visuals/line/dash_atlas.py
@@ -2,6 +2,8 @@
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
+from functools import lru_cache
+
 import numpy as np
 
 
@@ -35,51 +37,51 @@ class DashAtlas(object):
         return self._atlas[key]
 
     def __setitem__(self, key, value):
-        data, period = self.make_pattern(value[0], value[1])
+        length = self._data.shape[1]
+        data, period = _make_pattern(length, value[0], value[1])
         self._data[self._index] = data
         self._atlas[key] = [self._index / float(self._data.shape[0]), period]
         self._index += 1
         self._dirty = True
-        # self.add_pattern(value)
 
-    def make_pattern(self, pattern, caps=[1, 1]):
-        """ """
 
-        # A pattern is defined as on/off sequence of segments
-        # It must be a multiple of 2
-        if len(pattern) > 1 and len(pattern) % 2:
-            pattern = [pattern[0] + pattern[-1]] + pattern[1:-1]
-        P = np.array(pattern)
+@lru_cache
+def _make_pattern(length, pattern, caps):
+    """Make a concrete dash pattern of a given length."""
+    # A pattern is defined as on/off sequence of segments
+    # It must be a multiple of 2
+    if len(pattern) > 1 and len(pattern) % 2:
+        pattern = [pattern[0] + pattern[-1]] + pattern[1:-1]
+    P = np.array(pattern)
 
-        # Period is the sum of all segment length
-        period = np.cumsum(P)[-1]
+    # Period is the sum of all segment length
+    period = np.cumsum(P)[-1]
 
-        # Find all start and end of on-segment only
-        C, c = [], 0
-        for i in range(0, len(P) + 2, 2):
-            a = max(0.0001, P[i % len(P)])
-            b = max(0.0001, P[(i + 1) % len(P)])
-            C.extend([c, c + a])
-            c += a + b
-        C = np.array(C)
+    # Find all start and end of on-segment only
+    C, c = [], 0
+    for i in range(0, len(P) + 2, 2):
+        a = max(0.0001, P[i % len(P)])
+        b = max(0.0001, P[(i + 1) % len(P)])
+        C.extend([c, c + a])
+        c += a + b
+    C = np.array(C)
 
-        # Build pattern
-        length = self._data.shape[1]
-        Z = np.zeros((length, 4), dtype=np.float32)
-        for i in np.arange(0, len(Z)):
-            x = period * (i) / float(len(Z) - 1)
-            index = np.argmin(abs(C - (x)))
-            if index % 2 == 0:
-                if x <= C[index]:
-                    dash_type = +1
-                else:
-                    dash_type = 0
-                dash_start, dash_end = C[index], C[index + 1]
+    # Build pattern
+    Z = np.zeros((length, 4), dtype=np.float32)
+    for i in np.arange(0, len(Z)):
+        x = period * (i) / float(len(Z) - 1)
+        index = np.argmin(abs(C - (x)))
+        if index % 2 == 0:
+            if x <= C[index]:
+                dash_type = +1
             else:
-                if x > C[index]:
-                    dash_type = -1
-                else:
-                    dash_type = 0
-                dash_start, dash_end = C[index - 1], C[index]
-            Z[i] = C[index], dash_type, dash_start, dash_end
-        return Z, period
+                dash_type = 0
+            dash_start, dash_end = C[index], C[index + 1]
+        else:
+            if x > C[index]:
+                dash_type = -1
+            else:
+                dash_type = 0
+            dash_start, dash_end = C[index - 1], C[index]
+        Z[i] = C[index], dash_type, dash_start, dash_end
+    return Z, period

--- a/vispy/visuals/line/dash_atlas.py
+++ b/vispy/visuals/line/dash_atlas.py
@@ -48,7 +48,7 @@ class DashAtlas(object):
         return _make_pattern(length, pattern, caps)
 
 
-@lru_cache
+@lru_cache(maxsize=32)
 def _make_pattern(length, pattern, caps):
     """Make a concrete dash pattern of a given length."""
     # A pattern is defined as on/off sequence of segments

--- a/vispy/visuals/line/dash_atlas.py
+++ b/vispy/visuals/line/dash_atlas.py
@@ -43,7 +43,7 @@ class DashAtlas(object):
         self._index += 1
         self._dirty = True
 
-    def make_pattern(self, pattern, caps=[1, 1]):
+    def make_pattern(self, pattern, caps=(1, 1)):
         length = self._data.shape[1]
         return _make_pattern(length, pattern, caps)
 


### PR DESCRIPTION
This one is perhaps a bit silly, but this is a somewhat expensive operation (~70 ms on my machine) and it runs every time a `DashAtlas` is created, which is every time an `_AggLineVisual` is created. I don't think this is generally meaningful, but caching this saves a significant amount of time in the napari test suite.

I moved the function out of the class as caching a method can have undesired effects on garbage collection. The diff is a bit confusing but the code is otherwise unchanged.

It's also worth noting that `caps` appears to be unused. I am happy to remove it but don't want to break the API if anyone uses this directly (the whole method could be remove otherwise).

It's possible there is room for this code to be optimized (vectorized) in general, but I did not look into that.