### PR TITLE
Remove deprecated code from vispy.color.get_colormap

### DIFF
--- a/examples/demo/scene/picking.py
+++ b/examples/demo/scene/picking.py
@@ -18,7 +18,7 @@ plt.xlabel.text = 'Time (ms)'
 selected = None
 
 # plot data
-cmap = get_colormap('hsl', value=0.5)
+cmap = get_colormap('hsl')
 colors = cmap.map(np.linspace(0.1, 0.9, data.shape[0]))
 t = np.arange(data.shape[1]) * (dt * 1000)
 for i, y in enumerate(data):

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1107,22 +1107,8 @@ def get_colormap(name):
 
     .. versionchanged: 0.7
 
-        Additional args/kwargs are no longer accepted. Colormap classes are
-        no longer created on the fly. To create a ``cubehelix``
-        (``CubeHelixColormap``), ``single_hue`` (``SingleHue``), ``hsl``
-        (``HSL``), ``husl`` (``HSLuv``), ``diverging`` (``Diverging``), or
-        ``RdYeBuCy`` (``RedYellowBlueCyan``) colormap you must import and
-        instantiate it directly from the ``vispy.color.colormap`` module.
-
-    .. versionchanged: 0.13.1
-
-        Remove deprecation for ``cubehelix`` (``CubeHelixColormap``),
-        ``single_hue`` (``SingleHue``), ``hsl`` (``HSL``), ``husl`` (``HSLuv``),
-        ``diverging`` (``Diverging``), and ``RdYeBuCy`` (``RedYellowBlueCyan``)
-        colormaps, which are supported.
-
-        No longer accept args/kwargs at all.  Now passing additional arguments
-        will raise an exception.
+        Additional args/kwargs are no longer accepted. Colormap instances are
+        no longer created on the fly.
 
     """
     if isinstance(name, BaseColormap):

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -1092,17 +1092,13 @@ _colormaps = dict(
 )
 
 
-def get_colormap(name, *args, **kwargs):
-    """Obtain a colormap.
+def get_colormap(name):
+    """Obtain a colormap by name.
 
     Parameters
     ----------
     name : str | Colormap
         Colormap name. Can also be a Colormap for pass-through.
-    *args:
-        Deprecated.
-    **kwargs
-        Deprecated.
 
     Examples
     --------
@@ -1118,11 +1114,17 @@ def get_colormap(name, *args, **kwargs):
         ``RdYeBuCy`` (``RedYellowBlueCyan``) colormap you must import and
         instantiate it directly from the ``vispy.color.colormap`` module.
 
+    .. versionchanged: 0.13.1
+
+        Remove deprecation for ``cubehelix`` (``CubeHelixColormap``),
+        ``single_hue`` (``SingleHue``), ``hsl`` (``HSL``), ``husl`` (``HSLuv``),
+        ``diverging`` (``Diverging``), and ``RdYeBuCy`` (``RedYellowBlueCyan``)
+        colormaps, which are supported.
+
+        No longer accept args/kwargs at all.  Now passing additional arguments
+        will raise an exception.
+
     """
-    if args or kwargs:
-        warnings.warn("Creating a Colormap instance with 'get_colormap' is "
-                      "no longer supported. No additional arguments or "
-                      "keyword arguments should be passed.", DeprecationWarning)
     if isinstance(name, BaseColormap):
         return name
 
@@ -1130,14 +1132,6 @@ def get_colormap(name, *args, **kwargs):
         raise TypeError('colormap must be a Colormap or string name')
     if name in _colormaps:  # vispy cmap
         cmap = _colormaps[name]
-        if name in ("cubehelix", "single_hue", "hsl", "husl", "diverging", "RdYeBuCy"):
-            warnings.warn(
-                f"Colormap '{name}' has been deprecated since vispy 0.7. "
-                f"Please import and create 'vispy.color.colormap.{cmap.__class__.__name__}' "
-                "directly instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     elif has_matplotlib():  # matplotlib cmap
         try:


### PR DESCRIPTION
* No longer allow *args or **kwargs to be passed in.  They have been deprecated since v0.7.
* Remove `DeprecationWarning` for several colormaps, which were all fully supported since 7d1f5966db90836ecbb003c1325d028fec7b2f4b.

Closes #2518.