### PR TITLE
Update to Cython 3.0

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # "setuptools>=42",
     # "setuptools_scm[toml]>=3.4",
     "setuptools_scm_git_archive",
-    "Cython>=0.29.2",
+    "Cython>=3.0.0",
     "oldest-supported-numpy"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,8 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools>=30.3.0",
-    "setuptools_scm",
-    # Use these when setuptools>=42 is more widely available
-    # "setuptools>=42",
-    # "setuptools_scm[toml]>=3.4",
-    "setuptools_scm_git_archive",
+    "setuptools>=42",
+    "setuptools_scm[toml]>=7.1",
     "Cython>=3.0.0",
     "oldest-supported-numpy"
 ]

--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,11 @@ Announcing:
 
 import os
 from os import path as op
-from distutils import log
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_packages
 
 import numpy as np
 from Cython.Build import cythonize
-
-log.set_verbosity(log.DEBUG)
-log.info('setup.py entered')
-log.info('$PATH=%s' % os.environ['PATH'])
+from Cython.Distutils import Extension
 
 name = 'vispy'
 description = 'Interactive visualization in Python'
@@ -56,8 +52,11 @@ def set_builtin(name, value):
 
 
 extensions = [Extension('vispy.visuals.text._sdf_cpu',
-                        [op.join('vispy', 'visuals', 'text', '_sdf_cpu.pyx')],
-                        include_dirs=[np.get_include()]),
+                        sources=[op.join('vispy', 'visuals', 'text', '_sdf_cpu.pyx')],
+                        include_dirs=[np.get_include()],
+                        cython_directives={"language_level": "3"},
+                        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+                        ),
               ]
 
 readme = open('README.rst', 'r').read()
@@ -70,7 +69,7 @@ setup(
     },
     author='Vispy contributors',
     author_email='vispy@googlegroups.com',
-    license='(new) BSD',
+    license='BSD-3-Clause',
     url='http://vispy.org',
     download_url='https://pypi.python.org/pypi/vispy',
     keywords=[
@@ -92,9 +91,8 @@ setup(
     long_description_content_type='text/x-rst',
     platforms='any',
     provides=['vispy'],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=['numpy', 'freetype-py', 'hsluv', 'kiwisolver', 'packaging'],
-    setup_requires=['numpy', 'cython', 'setuptools_scm', 'setuptools_scm_git_archive', 'packaging'],
     extras_require={
         'ipython-static': ['ipython'],
         'pyglet': ['pyglet>=1.2'],
@@ -147,9 +145,10 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Framework :: IPython'
     ],
 )

--- a/vispy/visuals/text/_sdf_cpu.pyx
+++ b/vispy/visuals/text/_sdf_cpu.pyx
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-
+# cython: language_level=3, boundscheck=False, cdivision=True, wraparound=False, initializedcheck=False, nonecheck=False
 # A Cython implementation of the "eight-points signed sequential Euclidean
 # distance transform algorithm" (8SSEDT)
 
@@ -18,13 +17,14 @@ ctypedef np.complex64_t DTYPE_ct
 cdef DTYPE_ct MAX_VAL = (1e6 + 1e6j)
 
 
-@cython.boundscheck(False)  # designed to stay within bounds
-@cython.wraparound(False)  # we don't use negative indexing
 def _calc_distance_field(np.ndarray[DTYPE_t, ndim=2] pixels,
                          int w, int h, DTYPE_t sp_f):
     # initialize grids
-    cdef np.ndarray[DTYPE_ct, ndim=2] g0 = np.zeros((h, w), dtype_c)
-    cdef np.ndarray[DTYPE_ct, ndim=2] g1 = np.zeros((h, w), dtype_c)
+    cdef np.ndarray[DTYPE_ct, ndim=2] g0_arr = np.zeros((h, w), dtype_c)
+    cdef np.ndarray[DTYPE_ct, ndim=2] g1_arr = np.zeros((h, w), dtype_c)
+    cdef DTYPE_ct[:, ::1] g0 = g0_arr
+    cdef DTYPE_ct[:, ::1] g1 = g1_arr
+    cdef DTYPE_t[:, :] pixels_view = pixels
     cdef Py_ssize_t y, x
     for y in range(h):
         g0[y, 0] = MAX_VAL
@@ -32,9 +32,9 @@ def _calc_distance_field(np.ndarray[DTYPE_t, ndim=2] pixels,
         g1[y, 0] = MAX_VAL
         g1[y, w-1] = MAX_VAL
         for x in range(1, w-1):
-            if pixels[y, x] > 0:
+            if pixels_view[y, x] > 0:
                 g0[y, x] = MAX_VAL
-            if pixels[y, x] < 1:
+            if pixels_view[y, x] < 1:
                 g1[y, x] = MAX_VAL
     for x in range(w):
         g0[0, x] = MAX_VAL
@@ -50,37 +50,35 @@ def _calc_distance_field(np.ndarray[DTYPE_t, ndim=2] pixels,
     cdef DTYPE_t r_sp_f_2 = 1. / (sp_f * 2.)
     for y in range(1, h-1):
         for x in range(1, w-1):
-            pixels[y, x] = sqrt(dist(g0[y, x])) - sqrt(dist(g1[y, x]))
-            if pixels[y, x] < 0:
-                pixels[y, x] = (pixels[y, x] + sp_f) * r_sp_f_2
+            pixels_view[y, x] = sqrt(dist(g0[y, x])) - sqrt(dist(g1[y, x]))
+            if pixels_view[y, x] < 0:
+                pixels_view[y, x] = (pixels_view[y, x] + sp_f) * r_sp_f_2
             else:
-                pixels[y, x] = 0.5 + pixels[y, x] * r_sp_f_2
-            pixels[y, x] = max(min(pixels[y, x], 1), 0)
+                pixels_view[y, x] = 0.5 + pixels_view[y, x] * r_sp_f_2
+            pixels_view[y, x] = max(min(pixels_view[y, x], 1), 0)
 
 
-@cython.boundscheck(False)  # designed to stay within bounds
-@cython.wraparound(False)  # we don't use negative indexing
-cdef Py_ssize_t compare(DTYPE_ct *cell, DTYPE_ct xy, DTYPE_t *current):
+cdef inline Py_ssize_t compare(DTYPE_ct *cell, DTYPE_ct xy, DTYPE_t *current) noexcept nogil:
     cdef DTYPE_t val = dist(xy)
     if val < current[0]:
         cell[0] = xy
         current[0] = val
 
 
-@cython.boundscheck(False)  # designed to stay within bounds
-@cython.wraparound(False)  # we don't use negative indexing
-cdef DTYPE_t dist(DTYPE_ct val):
+cdef DTYPE_t dist(DTYPE_ct val) noexcept nogil:
     return val.real*val.real + val.imag*val.imag
 
 
-@cython.boundscheck(False)  # designed to stay within bounds
-@cython.wraparound(False)  # we don't use negative indexing
-cdef void _propagate(np.ndarray[DTYPE_ct, ndim=2] grid):
+cdef void _propagate(DTYPE_ct[:, :] grid) noexcept nogil:
     cdef Py_ssize_t height = grid.shape[0]
     cdef Py_ssize_t width = grid.shape[1]
     cdef Py_ssize_t y, x
     cdef DTYPE_t current
-    cdef DTYPE_ct a0=-1, a1=-1j, a2=-1-1j, a3=1-1j
+    cdef DTYPE_ct a0, a1, a2, a3
+    a0 = -1
+    a1 = -1j
+    a2 = -1 - 1j
+    a3 = 1 - 1j
     cdef DTYPE_ct b0=1
     cdef DTYPE_ct c0=1, c1=1j, c2=-1+1j, c3=1+1j
     cdef DTYPE_ct d0=-1


### PR DESCRIPTION
Closes #2522 

As talked about in the monthly meeting today, Cython 3.0 is out and we should switch to it for building or at least prepare to use it. This PR makes the full switch and only allows Cython 3+ for building. I checked the HTML output of `cython -a` for the one cython module we have (the CPU text rendering) and was able to remove a couple of low-performance spots by declaring functions as `noexcept nogil`. The `nogil` doesn't actually mean the GIL is released but since this code is happening in the GUI thread inside the TextVisual I'm not sure there is a good reason to do it any other way. There are other optimizations that could be done in the future (most likely), but I'm not sure it is worth it at this point.

I've also switch the license to an SPDX license identifier. I'll see if I can quickly update the setuptools_scm to not use the external git_archive package which is deprecated now.