### PR TITLE
Various optimizations related to camera linking and mesh normals

### DIFF
--- a/vispy/geometry/meshdata.py
+++ b/vispy/geometry/meshdata.py
@@ -386,7 +386,9 @@ class MeshData(object):
         if indexed is None:
             return self._vertex_normals
         elif indexed == 'faces':
-            return self._vertex_normals[self.get_faces()]
+            if self._vertex_normals_indexed_by_faces is None:
+                self._vertex_normals_indexed_by_faces = self._vertex_normals[self.get_faces()]
+            return self._vertex_normals_indexed_by_faces
 
     def get_vertex_colors(self, indexed=None):
         """Get vertex colors

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -164,7 +164,7 @@ class PanZoomCamera(BaseCamera):
     def center(self, center):
         if not (isinstance(center, (tuple, list)) and len(center) in (2, 3)):
             raise ValueError('center must be a 2 or 3 element tuple')
-        rect = Rect(self.rect) or Rect(*DEFAULT_RECT_TUPLE)
+        rect = Rect(self.rect) or Rect(*DEFAULT_RECT_TUPLE)  # make a copy of self.rect
         rect.center = center[:2]
         self.rect = rect
 

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -246,7 +246,7 @@ class PanZoomCamera(BaseCamera):
             event.handled = False
 
     def _update_transform(self):
-        if self._setting_state:  # base camera linking operation
+        if self._resetting:  # base camera linking operation
             return
 
         rect = self.rect

--- a/vispy/scene/cameras/panzoom.py
+++ b/vispy/scene/cameras/panzoom.py
@@ -246,6 +246,9 @@ class PanZoomCamera(BaseCamera):
             event.handled = False
 
     def _update_transform(self):
+        if self._setting_state:  # base camera linking operation
+            return
+
         rect = self.rect
         self._real_rect = Rect(rect)
         vbr = self._viewbox.rect.flipped(x=self.flip[0], y=(not self.flip[1]))

--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -140,6 +140,8 @@ class PerspectiveCamera(BaseCamera):
         # Do we have a viewbox
         if self._viewbox is None:
             return
+        if self._setting_state:  # base camera linking operation
+            return
 
         # Calculate viewing range for x and y
         fx = fy = self._scale_factor

--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -80,7 +80,10 @@ class PerspectiveCamera(BaseCamera):
 
     @scale_factor.setter
     def scale_factor(self, value):
-        self._scale_factor = abs(float(value))
+        value = abs(float(value))
+        if value == self._scale_factor:
+            return
+        self._scale_factor = value
         self.view_changed()
 
     @property

--- a/vispy/scene/cameras/perspective.py
+++ b/vispy/scene/cameras/perspective.py
@@ -140,7 +140,7 @@ class PerspectiveCamera(BaseCamera):
         # Do we have a viewbox
         if self._viewbox is None:
             return
-        if self._setting_state:  # base camera linking operation
+        if self._resetting:  # base camera linking operation
             return
 
         # Calculate viewing range for x and y

--- a/vispy/scene/cameras/turntable.py
+++ b/vispy/scene/cameras/turntable.py
@@ -73,6 +73,9 @@ class TurntableCamera(Base3DRotationCamera):
         super(TurntableCamera, self).__init__(fov=fov, **kwargs)
 
         # Set camera attributes
+        self._azimuth = azimuth
+        self._elevation = elevation
+        self._roll = roll
         self.azimuth = azimuth
         self.elevation = elevation
         self.roll = roll
@@ -90,7 +93,10 @@ class TurntableCamera(Base3DRotationCamera):
     @elevation.setter
     def elevation(self, elev):
         elev = float(elev)
-        self._elevation = min(90, max(-90, elev))
+        elev = min(90, max(-90, elev))
+        if elev == self._elevation:
+            return
+        self._elevation = elev
         self.view_changed()
 
     @property
@@ -108,6 +114,8 @@ class TurntableCamera(Base3DRotationCamera):
             azim += 360
         while azim > 180:
             azim -= 360
+        if azim == self._azimuth:
+            return
         self._azimuth = azim
         self.view_changed()
 
@@ -123,6 +131,8 @@ class TurntableCamera(Base3DRotationCamera):
             roll += 360
         while roll > 180:
             roll -= 360
+        if roll == self._roll:
+            return
         self._roll = roll
         self.view_changed()
 

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -421,6 +421,7 @@ class ShadingFilter(Filter):
         ffunc = Function(self._shaders['fragment'])
 
         self._normals = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
+        self._normals_cache = None
         vfunc['normal'] = self._normals
 
         super().__init__(vcode=vfunc, fcode=ffunc)
@@ -550,7 +551,12 @@ class ShadingFilter(Filter):
         )
 
         normals = self._visual.mesh_data.get_vertex_normals(indexed='faces')
-        self._normals.set_data(normals, convert=True)
+        if normals is not self._normals_cache:
+            # limit how often we upload new normal arrays
+            # gotcha: if normals are changed in place then this won't invalidate this cache
+            print(f"Setting new normals array: {self=} | {id(normals)}")
+            self._normals_cache = normals
+            self._normals.set_data(self._normals_cache, convert=True)
 
     def on_mesh_data_updated(self, event):
         self._update_data()

--- a/vispy/visuals/filters/mesh.py
+++ b/vispy/visuals/filters/mesh.py
@@ -554,7 +554,6 @@ class ShadingFilter(Filter):
         if normals is not self._normals_cache:
             # limit how often we upload new normal arrays
             # gotcha: if normals are changed in place then this won't invalidate this cache
-            print(f"Setting new normals array: {self=} | {id(normals)}")
             self._normals_cache = normals
             self._normals.set_data(self._normals_cache, convert=True)
 


### PR DESCRIPTION
See #2530 

CC @jintaoLee-roger

This is a collection of optimizations uncovered in #2530 debugging by me or @jintaolee-roger. The main ideas are to not update camera properties unless the value has actually changed. This prevents expensive transform-updating methods from being called unnecessarily. This is especially noticeable when a single camera move updates 4+ properties of a linked property and each one tries to report that the view/transform has changed. It does this in two ways:

1. Don't execute a transform update if we're updating properties
2. Don't update a property (and signal a view change) if the property value is the same

This PR also adds some checks in the mesh light filter to see if vertex normals have actually changed before submitting/uploading the normals to the GPU. It also enables the use of a previously unused (yet defined for some reason?) `MeshData._vertex_normal_indexed_by_faces`. This allows the check in the light filter to actually work with a simple identity (`is`) check.


TODO:

* Testing of performance by @jintaolee-roger
* Adding tests for at least the normals caching in the meshdata.