### PR TITLE
Improve Markers symbols validation performance

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -616,7 +616,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not all(x in self._symbol_shader_values for x in set([symbol] if isinstance(symbol, str) else symbol)):
+            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values_):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -616,7 +616,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values_)):
+            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values)):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -617,7 +617,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not np.all(np.isin(np.asarray(symbol), self.symbols)):
+            if not all(x in self._symbol_shader_values for x in set(np.asarray(symbol))):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -649,7 +649,7 @@ class MarkersVisual(Visual):
                 if isinstance(symbol, str):
                     symbol = [symbol]
                 try:
-                    data['a_symbol'] = np.array(self._symbol_shader_values[x] for x in symbol)
+                    data['a_symbol'] = np.array([self._symbol_shader_values[x] for x in symbol])
                 except KeyError:
                     raise ValueError(f'symbols must one of {self.symbols}')
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -616,7 +616,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values_):
+            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values_)):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -618,7 +618,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not all(x in self._symbol_shader_values for x in set(x if isinstance(x, Iterable) else [x])):
+            if not all(x in self._symbol_shader_values for x in set(symbol if isinstance(symbol, Iterable) else [symbol])):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -617,7 +617,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not all(x in self._symbol_shader_values for x in set(np.asarray(symbol))):
+            if not all(x in self._symbol_shader_values for x in set(x if isinstance(x, Iterable) else [x])):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -616,7 +616,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values)):
+            if (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values)):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -4,6 +4,7 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 """Marker Visual and shader definitions."""
+from typing import Iterable
 
 import numpy as np
 

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -615,10 +615,6 @@ class MarkersVisual(Visual):
             if np.any(edge_width_rel < 0):
                 raise ValueError('edge_width_rel cannot be negative')
 
-        if symbol is not None:
-            if (set([symbol] if isinstance(symbol, str) else symbol) - set(self._symbol_shader_values)):
-                raise ValueError(f'symbols must one of {self.symbols}')
-
         edge_color = ColorArray(edge_color).rgba
         if len(edge_color) == 1:
             edge_color = edge_color[0]
@@ -647,7 +643,15 @@ class MarkersVisual(Visual):
             data['a_position'][:, :pos.shape[1]] = pos
             data['a_size'] = size
 
-            data['a_symbol'] = np.vectorize(self._symbol_shader_values.get)(symbol)
+            if symbol is None:
+                data["a_symbol"] = np.array(None)
+            else:
+                if isinstance(symbol, str):
+                    symbol = [symbol]
+                try:
+                    data['a_symbol'] = np.array(self._symbol_shader_values[x] for x in symbol)
+                except KeyError:
+                    raise ValueError(f'symbols must one of {self.symbols}')
 
             self._data = data
             self._vbo.set_data(data)

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -4,8 +4,6 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 """Marker Visual and shader definitions."""
-from typing import Iterable
-
 import numpy as np
 
 from ..color import ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -618,7 +618,7 @@ class MarkersVisual(Visual):
                 raise ValueError('edge_width_rel cannot be negative')
 
         if symbol is not None:
-            if not all(x in self._symbol_shader_values for x in set(symbol if isinstance(symbol, Iterable) else [symbol])):
+            if not all(x in self._symbol_shader_values for x in set([symbol] if isinstance(symbol, str) else symbol)):
                 raise ValueError(f'symbols must one of {self.symbols}')
 
         edge_color = ColorArray(edge_color).rgba


### PR DESCRIPTION
In this PR, I changed the validation of marker symbols from quadratic to linear. 

The `self.symbol` is a list created from `self._symbol_shader_values`. So check if something is in O(n)
The `self._symbol_shader_values` is dict so checking if something is in in O(1)

Also python `all` is lazy when `np.all` is required to calculate all values. 

The problem was spotted in https://github.com/napari/napari/issues/6275