### PR TITLE
return to oldest supported numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    'numpy; python_full_version<"3.12.0rc1"',
-    'numpy>=1.26.0rc1; python_full_version>="3.12.0rc1"',
+    "oldest-supported-numpy",
     "setuptools>=42",
     "setuptools_scm[toml]>=7.1",
     "Cython>=3.0.0"


### PR DESCRIPTION
In #2515, the use of `oldest-supported-numpy` was replaced with the following lines in `pyproject.toml`:

```
	'numpy; python_full_version<"3.12.0rc1"',
	'numpy>=1.26.0rc1; python_full_version>="3.12.0rc1"',
```


Unfortunately, this broke our `min_req` tests in `napari`, because of a few reasons:

- vispy depends on just `numpy` (which means old numpy versions are supported)
- the new build constraints end up using a newer numpy version for compilation
- python3.8 (used in our `min_req` test and officially supported by vispy) no longer works with numpy>=1.25 (python>=3.9 only), which is used for compilation

As far as we (cc @Czaki) can tell, there is no reason to *not* use `oldest-supported-numpy` as dependency, for now; also, the second line in the above snippet is no longer needed, since 1.26 is now out.

PS: after this (or whatever alternative might come up) is merged, we should probably publish a bugfix release.