### PR TITLE
Correction to Vispy.Visuals.Markers.set_data

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -579,7 +579,7 @@ class MarkersVisual(Visual):
 
         self.freeze()
 
-    def set_data(self, pos=None, size=10., edge_width=1., edge_width_rel=None,
+    def set_data(self, pos=None, size=10., edge_width=None, edge_width_rel=None,
                  edge_color='black', face_color='white',
                  symbol='o'):
         """Set the data used to display this visual.
@@ -602,9 +602,13 @@ class MarkersVisual(Visual):
         symbol : str or array
             The style of symbol used to draw each marker (see Notes).
         """
-        if (edge_width is not None) + (edge_width_rel is not None) != 1:
-            raise ValueError('exactly one of edge_width and edge_width_rel '
-                             'must be non-None')
+        if (edge_width is not None) and (edge_width_rel is not None):
+            #both edge_width and edge_width_rel are supplied
+            raise ValueError('either edge_width or edge_width_rel '
+                             'should be provided, not both')
+        elif (edge_width is None) and (edge_width_rel is None):
+            #neither the two widths is supplied
+            edge_width = 1.0
 
         if edge_width is not None:
             edge_width = np.asarray(edge_width)

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -497,8 +497,10 @@ class MarkersVisual(Visual):
     edge_width : float or array or None
         The width of the symbol outline in screen (or data, if scaling is on) px.
     edge_width_rel : float or array or None
-        The width as a fraction of marker size. Exactly one of
-        `edge_width` and `edge_width_rel` must be supplied.
+        The width as a fraction of marker size.
+        Note on edge_width and edge_width_rel:
+            By default, edge_width = 1.0 if neither edge_width nor edge_width_rel is provided
+            A ValueError will be raised if both edge_width and edge_width_rel are supplied.
     edge_color : Color | ColorArray
         The color used to draw each symbol outline.
     face_color : Color | ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -595,10 +595,8 @@ class MarkersVisual(Visual):
         edge_width : float or array or None
             The width of the symbol outline in screen (or data, if scaling is on) px.
         edge_width_rel : float or array or None
-            The width as a fraction of marker size.
-            Note on edge_width and edge_width_rel:
-                By default, edge_width = 1.0 if neither edge_width nor edge_width_rel is provided
-                A ValueError will be raised if both `edge_width` and `edge_width_rel` are supplied.
+            The width as a fraction of marker size. Can not be specified along with
+            edge_width. A ValueError will be raised if both are provided.
         edge_color : Color | ColorArray
             The color used to draw each symbol outline.
         face_color : Color | ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -499,10 +499,8 @@ class MarkersVisual(Visual):
         Defaults to 1.0 if None or not provided and ``edge_width_rel`` is not
         provided.
     edge_width_rel : float or array or None
-        The width as a fraction of marker size.
-        Note on edge_width and edge_width_rel:
-            By default, edge_width = 1.0 if neither edge_width nor edge_width_rel is provided
-            A ValueError will be raised if both edge_width and edge_width_rel are supplied.
+        The width as a fraction of marker size. Can not be specified along with
+        edge_width. A ValueError will be raised if both are provided.
     edge_color : Color | ColorArray
         The color used to draw each symbol outline.
     face_color : Color | ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -594,6 +594,8 @@ class MarkersVisual(Visual):
             The symbol size in screen (or data, if scaling is on) px.
         edge_width : float or array or None
             The width of the symbol outline in screen (or data, if scaling is on) px.
+            Defaults to 1.0 if None or not provided and ``edge_width_rel`` is not
+        provided.
         edge_width_rel : float or array or None
             The width as a fraction of marker size. Can not be specified along with
             edge_width. A ValueError will be raised if both are provided.

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -593,8 +593,10 @@ class MarkersVisual(Visual):
         edge_width : float or array or None
             The width of the symbol outline in screen (or data, if scaling is on) px.
         edge_width_rel : float or array or None
-            The width as a fraction of marker size. Exactly one of
-            `edge_width` and `edge_width_rel` must be supplied.
+            The width as a fraction of marker size.
+            Note on edge_width and edge_width_rel:
+                By default, edge_width = 1.0 if neither edge_width nor edge_width_rel is provided
+                A ValueError will be raised if both `edge_width` and `edge_width_rel` are supplied.
         edge_color : Color | ColorArray
             The color used to draw each symbol outline.
         face_color : Color | ColorArray

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -602,12 +602,10 @@ class MarkersVisual(Visual):
         symbol : str or array
             The style of symbol used to draw each marker (see Notes).
         """
-        if (edge_width is not None) and (edge_width_rel is not None):
-            #both edge_width and edge_width_rel are supplied
-            raise ValueError('either edge_width or edge_width_rel '
-                             'should be provided, not both')
-        elif (edge_width is None) and (edge_width_rel is None):
-            #neither the two widths is supplied
+        if edge_width is not None and edge_width_rel is not None:
+            raise ValueError("either edge_width or edge_width_rel "
+                             "should be provided, not both")
+        elif edge_width is None and edge_width_rel is None:
             edge_width = 1.0
 
         if edge_width is not None:

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -496,6 +496,8 @@ class MarkersVisual(Visual):
         The symbol size in screen (or data, if scaling is on) px.
     edge_width : float or array or None
         The width of the symbol outline in screen (or data, if scaling is on) px.
+        Defaults to 1.0 if None or not provided and ``edge_width_rel`` is not
+        provided.
     edge_width_rel : float or array or None
         The width as a fraction of marker size.
         Note on edge_width and edge_width_rel:


### PR DESCRIPTION
This pull request follows issue 2546 (https://github.com/vispy/vispy/issues/2564). After further examining the original code, I found I misunderstood its purpose when I was writing the post. However, there is a bug in the original code, and I would like to restate it:

The (inferred) purpose of the original code:
In the original code, it is assumed that either edge_width or edge_width_rel is passed to set_data. 
If both are supplied, the method yields a ValueError. 
If neither is supplied, the method simply uses a default edge_width of 1.0. 
If either edge_width or edge_width_rel is supplied, it will be applied.

However, due to the default value of edge_width given in the definition of set_data, the function ends up with a ValueError when only edge_width_rel is supplied, which deviates from the last purpose, and I personally believe this is a bug.

The solution is to set both edge_width and edge_width_rel to None in the definition of set_data, and assign 1.0 to edge_width when both variables are None.

