### PR TITLE
Reset VertexAttribDivisor even if None

### DIFF
--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -1283,8 +1283,7 @@ class GlirProgram(GlirObject):
                 gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo_handle)
                 gl.glEnableVertexAttribArray(attr_handle)
                 func(attr_handle, *args)
-                if divisor is not None:
-                    gl.glVertexAttribDivisor(attr_handle, divisor)
+                gl.glVertexAttribDivisor(attr_handle, divisor or 0)
             else:
                 gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
                 gl.glDisableVertexAttribArray(attr_handle)


### PR DESCRIPTION
Fixes #2581 - see additional discussion in that issue.

My hypothesis here is that the `attr_handle` is reused between the text and instanced mesh visuals, but the divisor is not properly (re)set. The single mesh does not interfere because it does not use more than handle 0, which is okay because the divisor is the same for this attribute (`a_position`).

Here is some debug output from `GlirProgram._pre_draw` showing the attribute name, handle, and divisor value. You can see the overlapping values from the Text and InstancedMesh visuals.

```
drawing <Text at 0x1340d6dd0>
a_color 4 None
a_position 1 None
a_texcoord 0 None
a_rotation 2 None
a_pos 3 None

drawing <Mesh at 0x1340e5310>
a_position 0 None

drawing <InstancedMesh at 0x1340e5410>
a_position 0 None
u_base_color 1 1
transform_x 5 1
transform_y 4 1
transform_z 2 1
shift 3 1
```

cc @brisvag @rzmearns