### PR TITLE
Loosen bound on relative step size

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -1166,8 +1166,8 @@ class VolumeVisual(Visual):
     @relative_step_size.setter
     def relative_step_size(self, value):
         value = float(value)
-        if value < 0.1:
-            raise ValueError('relative_step_size cannot be smaller than 0.1')
+        if value <= 0:
+            raise ValueError('relative_step_size cannot be 0 or negative.')
         self._relative_step_size = value
         self.shared_program['u_relative_step_size'] = value
 


### PR DESCRIPTION
Having a really tiny step size is important when rendering very tiny volumes,
which otherwise show nasty sawtooth artifacts (napari/napari#3550). The value
of 0.1 seems pretty arbitrary, so here I just check that it's not 0 or
negative. We could set some much tinier epsilon but I don't see a principled
way of doing that...
