### PR TITLE
Fix integral computation in attenuated mip

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -417,8 +417,8 @@ _ATTENUATED_MIP_SNIPPETS = dict(
         // Scale and clamp accumulation in `sumval` by contrast limits so that:
         // * attenuation value does not depend on data values
         // * negative values do not amplify instead of attenuate
-        sumval = sumval + clamp((val - clim.x) / (clim.y - clim.x), 0.0, 1.0);
-        scale = exp(-u_attenuation * (sumval - 1) / u_relative_step_size);
+        sumval = sumval + u_relative_step_size * clamp((val - clim.x) / (clim.y - clim.x), 0.0, 1.0);
+        scale = exp(-u_attenuation * (sumval - 1));
         if( maxval > scale * clim.y ) {
             // stop if no chance of finding a higher maxval
             iter = nsteps;


### PR DESCRIPTION
The integral computation in the attenuated MIP shader should *multiply* by the step size, rather than divide by it. That's how integrals work. 😅

**Edit:** Adding my longer description from comment below, which should go in the final commit message.

## Longer description

both before and after this change, increasing the attenuation increases the magnitude of the negative exponent and thus decreases the "scale" value, so the displayed value decreases in brightness (and closer values to the camera are favoured).

The reason we have never noticed anything wrong with this formula is that we have never before changed the relative step size, so there was just a division by a constant close to 1. Effectively a no-op.

But the division is in fact a bug, which is now obvious if you play with napari/napari#6930 with attenuation on. In the line changed, we are summing in order to estimate an integral, the total brightness along the ray so far. To estimate an integral, you multiply rather than divide by the step size.

It's understandable that this error would have been made because the integration is moved inside an exponent with a minus in front. But thinking about what `sumval` represents from first principles, together with the definition of attenuation as being proportional to the *integral* of the brightness before a point, makes it clear that this change is correct.