### PR TITLE
Raise ValueError when setting relative_step_size 0 or negative

### DIFF
--- a/vispy/visuals/volume.py
+++ b/vispy/visuals/volume.py
@@ -1174,17 +1174,21 @@ class VolumeVisual(Visual):
 
         https://github.com/vispy/vispy/pull/2587
 
-        For this reason, this setter raises a ValueError when the value is
+        For this reason, this setter issues a warning when the value is
         smaller than ``side_len / (2 * MAX_CANVAS_SIZE)``, where ``side_len``
         is the smallest side of the volume and ``MAX_CANVAS_SIZE`` is what
         we consider to be the largest likely monitor resolution along its
         longest side: 7680 pixels, equivalent to an 8K monitor.
+
+        This setter also raises a ValueError when the value is 0 or negative.
         """
         value = float(value)
         side_len = np.min(self._vol_shape)
         MAX_CANVAS_SIZE = 7680
         minimum_val = side_len / (2 * MAX_CANVAS_SIZE)
-        if value < minimum_val:
+        if value <= 0:
+            raise ValueError('relative_step_size cannot be 0 or negative.')
+        elif value < minimum_val:
             warnings.warn(
                 f'To display a volume of shape {self._vol_shape} without '
                 f'artifacts, you need a step size no smaller than {side_len} /'


### PR DESCRIPTION
See discussion in #2589 

This changes the the `relative_step_size` setter to:
* raise a `ValueError` when setting to 0 or a negative value
* warn when setting small values between 0 and `side_len / (2 * MAX_CANVAS_SIZE)`
* silently comply otherwise

This is closer to the previous behavior, and I think makes intuitive sense (step size <=0 is non-sensical and could cause degenerate behavior in the shader).

A bit confusing - there is a test for this and it passed on #2589 checks:
https://github.com/vispy/vispy/blob/4f061ba23ddac3131eb0d1d955573dd71c9a3d2f/vispy/visuals/tests/test_volume.py#L46-L48