### PR TITLE
Fix CI: failing tests and linting errors not failing checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,9 @@ jobs:
     name: OpenGL checks
     runs-on: ubuntu-latest
     defaults:
+      # use login shell to make use of .bash_profile /.bashrc
       run:
-        shell: bash -l {0}
+        shell: bash --login -e {0}
     steps:
     - name: Install OpenGL
       run: |
@@ -79,7 +80,7 @@ jobs:
     defaults:
       # use login shell to make use of .bash_profile /.bashrc
       run:
-        shell: bash -l {0}
+        shell: bash --login -e {0}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -163,7 +164,7 @@ jobs:
     defaults:
       # use login shell to make use of .bash_profile /.bashrc
       run:
-        shell: bash -l {0}
+        shell: bash --login -e {0}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
         python make test lineendings
     - name: Lint with flake8
       run: |
-        python make test flake
+        # FIXME: deliberately ignore linting errors for now
+        python make test flake || true
 # FIXME: Re-enable this when all docstrings are fixed
 #    - name: Test docstring parameters
 #      run: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,9 +145,9 @@ html_theme = 'pydata_sphinx_theme'
 # We precompute this so the values in the `html_context` are static, and it can be cached
 # `modules.rst` is a special case, and we link it to the main `vispy` package
 edit_link_paths = {"api/modules.rst": "vispy/__init__.py"}
-for root, dirs, files in Path("../vispy").walk():
+for root, dirs, files in os.walk("../vispy"):
     # remove leading "../"
-    root = root.relative_to("..")
+    root = Path(root).relative_to("..")
     if root.name == "__pycache__":
         continue
     for file in files:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,6 @@ apidoc_excluded_paths = ["../vispy/ext"]
 apidoc_separate_modules = True
 
 # Sphinx Gallery
-from sphinx_gallery.sorting import FileNameSortKey
 
 # the following files are ignored from gallery processing
 ignore_files = ['plotting/export.py',
@@ -67,7 +66,7 @@ sphinx_gallery_conf = {
     'image_scrapers': ('vispy',),
     'reset_modules': tuple(),  # remove default matplotlib/seaborn resetters
     'first_notebook_cell': '%gui qt',  # tell notebooks to use Qt backend
-    'within_subsection_order': FileNameSortKey,
+    'within_subsection_order': "FileNameSortKey",
 }
 # Let vispy.app.application:Application.run know that we are generating gallery images
 os.environ["_VISPY_RUNNING_GALLERY_EXAMPLES"] = "1"
@@ -168,6 +167,12 @@ def _custom_edit_url(github_user, github_repo, github_version, doc_path, file_na
                                                  doc_path=doc_path,
                                                  file_name=file_name)
 
+
+# FIXME: including a function (_custom_edit_url) in html_context causes a warning in the build in CI
+# we fail on warnings, so suppress it for now. I think we need to suppress all similar warnings.
+# WARNING: cannot cache unpickable configuration value: 'html_context'
+# (because it contains a function, class, or module object)
+suppress_warnings = ["config.cache"]
 
 html_context = {
     "github_user": "vispy",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,8 @@ from datetime import date
 import sys
 import os
 import re
+from pathlib import Path
+
 import vispy
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -143,20 +145,20 @@ html_theme = 'pydata_sphinx_theme'
 # We precompute this so the values in the `html_context` are static, and it can be cached
 # `modules.rst` is a special case, and we link it to the main `vispy` package
 edit_link_paths = {"api/modules.rst": "vispy/__init__.py"}
-for root, dirs, files in os.walk("../vispy"):
+for root, dirs, files in Path("../vispy").walk():
     # remove leading "../"
-    root = root[3:]
-    if root.endswith("__pycache__"):
+    root = root.relative_to("..")
+    if root.name == "__pycache__":
         continue
     for file in files:
-        full_path = os.path.join(root, file)
-        if full_path.endswith("__init__.py"):
-            package_name = root.replace(os.sep, ".")
-            apidoc_file_name = "api/" + package_name + ".rst"
-        elif full_path.endswith(".py"):
-            module_name = os.path.splitext(full_path)[0].replace(os.sep, ".")
-            apidoc_file_name = "api/" + module_name + ".rst"
-        edit_link_paths[apidoc_file_name] = full_path
+        full_path = root / file
+        if full_path.name == "__init__.py":
+            package_name = ".".join(root.parts)
+            apidoc_file_name = "api" / Path(package_name).with_suffix(".rst")
+        elif full_path.suffix == ".py":
+            module_name = ".".join(Path(full_path).with_suffix("").parts)
+            apidoc_file_name = "api" / Path(module_name).with_suffix(".rst")
+        edit_link_paths[str(apidoc_file_name)] = full_path
 
 
 edit_page_url_template = """\

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -141,7 +141,8 @@ html_theme = 'pydata_sphinx_theme'
 
 # Create custom 'edit' URLs for API modules since they are dynamically generated.
 # We precompute this so the values in the `html_context` are static, and it can be cached
-edit_link_paths = {}
+# `modules.rst` is a special case, and we link it to the main `vispy` package
+edit_link_paths = {"api/modules.rst": "vispy/__init__.py"}
 for root, dirs, files in os.walk("../vispy"):
     # remove leading "../"
     root = root[3:]
@@ -157,12 +158,14 @@ for root, dirs, files in os.walk("../vispy"):
             apidoc_file_name = "api/" + module_name + ".rst"
         edit_link_paths[apidoc_file_name] = full_path
 
+
 edit_page_url_template = """\
 {%- if file_name in edit_link_paths %}
     {% set file_name = edit_link_paths[file_name] %}
     https://github.com/{{github_user}}/{{github_repo}}/edit/{{github_version}}/{{file_name}}
 {%- else %}
-    https://github.com/{{github_user}}/{{github_repo}}/edit/{{github_version}}/{{doc_path}}/{{file_name}}
+    {# the last slash between doc_path and file_name is not needed for non-apidoc files #}
+    https://github.com/{{github_user}}/{{github_repo}}/edit/{{github_version}}/{{doc_path}}{{file_name}}
 {%- endif %}
 """
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,12 +154,11 @@ for root, dirs, files in os.walk("../vispy"):
         full_path = root / file
         if full_path.name == "__init__.py":
             package_name = ".".join(root.parts)
-            apidoc_file_name = "api" / Path(package_name).with_suffix(".rst")
+            apidoc_file_name = "api" / Path(package_name + ".rst")
         elif full_path.suffix == ".py":
-            module_name = ".".join(Path(full_path).with_suffix("").parts)
-            apidoc_file_name = "api" / Path(module_name).with_suffix(".rst")
+            module_name = ".".join(full_path.with_suffix("").parts)
+            apidoc_file_name = "api" / Path(module_name + ".rst")
         edit_link_paths[str(apidoc_file_name)] = full_path
-
 
 edit_page_url_template = """\
 {%- if file_name in edit_link_paths %}

--- a/vispy/io/tests/test_image.py
+++ b/vispy/io/tests/test_image.py
@@ -7,10 +7,15 @@ from os import path as op
 import warnings
 
 from vispy.io import load_crate, imsave, imread, read_png, write_png
-from vispy.testing import requires_img_lib, run_tests_if_main
+from vispy.testing import requires_img_lib, requires_pyopengl, run_tests_if_main
 from vispy.util import _TempDir
 
 temp_dir = _TempDir()
+
+
+@requires_pyopengl()
+def test_failure():
+    assert False, "Forcing a failure to make sure CI is properly failing"
 
 
 def test_make_png():

--- a/vispy/io/tests/test_image.py
+++ b/vispy/io/tests/test_image.py
@@ -7,15 +7,10 @@ from os import path as op
 import warnings
 
 from vispy.io import load_crate, imsave, imread, read_png, write_png
-from vispy.testing import requires_img_lib, requires_pyopengl, run_tests_if_main
+from vispy.testing import requires_img_lib, run_tests_if_main
 from vispy.util import _TempDir
 
 temp_dir = _TempDir()
-
-
-@requires_pyopengl()
-def test_failure():
-    assert False, "Forcing a failure to make sure CI is properly failing"
 
 
 def test_make_png():

--- a/vispy/testing/_runners.py
+++ b/vispy/testing/_runners.py
@@ -164,7 +164,9 @@ def _flake():
         print('Running flake8... ')  # if end='', first error gets ugly
         sys.stdout.flush()
         try:
-            main()
+            # flake8 used to exit on failure, but instead `main` now returns an exit code
+            # see https://github.com/PyCQA/flake8/pull/1461
+            raise SystemExit(main())
         except SystemExit as ex:
             if ex.code in (None, 0):
                 pass  # do not exit yet, we want to print a success msg


### PR DESCRIPTION
I think I've sorted out the problem causing #2596. Sorry this is a lot to take in. I'm just trying to be thorough and keep track for my own purposes as well.

Before I write any more I'll try to be clear:
* _tests_ are the individual test functions in the test suite
* _checks_ are the the output of GitHub actions workflows
* _steps_ are the individual steps in a workflow
* _commands_ are the individual lines in a `run` step

### Tests
The issue was that the GitHub actions workflow is replacing the default shell with `bash -l {0}`.
https://github.com/vispy/vispy/blob/4f061ba23ddac3131eb0d1d955573dd71c9a3d2f/.github/workflows/main.yml#L163-L166

This is problematic because it does not fail a run step if a command fails. I've changed the shell to `bash --login -e {0}` which will fail the run step if any command fails. The default shell on GitHub actions sets `-e`, and I think it's what we want. Without this, the step (and check) will only fail if the _last_ command in the step fails. I didn't test, but I believe the login shell may be required for some conda things.

Many checks would fail not directly because the test failed, but because the subsequent coverage commands would fail (because the tests failed in a way that didn't produce coverage).
https://github.com/vispy/vispy/blob/4f061ba23ddac3131eb0d1d955573dd71c9a3d2f/.github/workflows/main.yml#L274-L275

Because of all this, I think the only tests that would actually be missed were any marked
`@requires_pyopengl()` but not `@requires_application()` (as the in the case in #2589).

Documenting the process in this PR:
* See this log showing a check that passed, but should have failed (5964e1e12ec435e345bcd4be303dd8523e239859):
https://github.com/aganders3/vispy/actions/runs/9388966425/job/25855466353#step:11:647
* See here for a check that failed as expected, after changing the shell (8a314d29):
https://github.com/aganders3/vispy/actions/runs/9389260260/job/25856378619?pr=6#step:11:647

The remaining failing test should be resolved by #2595. Fortunately it seems there are no additional missed failing tests, this may be luck but let's chalk it up to rigor! I think it's been this way for a long time.

### Linting
Linting errors have been ignored for a totally different reason. The way the linting is set up, it invokes `flake8` by importing and running its `main` function. This is not officially supported, and there was a breaking change introduced in flake8 v5.0.0. The `main` function now returns an exit code instead of exiting (`sys.exit` or `raise SystemExit`). This is also fixed here, but given there are a number of linting errors I've deliberately disabled the check. I can open another PR to fix the lint errors if there is bandwidth to review it (or I can revive [my PR that blackens the code](https://github.com/vispy/vispy/pull/2503)).

There was some discussion these were deliberately disabled before, but I think that was only the docstring checks:
https://github.com/vispy/vispy/blob/4f061ba23ddac3131eb0d1d955573dd71c9a3d2f/.github/workflows/main.yml#L70-L73

Linting process in this PR:
* See here for linting errors properly failing (fdb78e00):
https://github.com/aganders3/vispy/actions/runs/9389579018/job/25857384162
* See here for linting errors reported but deliberately ignored (bd2a2993):
https://github.com/aganders3/vispy/actions/runs/9389634299/job/25857588048
