### PR TITLE
Add NumPy 2.0 support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.18.1
       env:
-        CIBW_SKIP: "cp36-* pp* *-win32 *-manylinux_i686 *-musllinux*"
+        CIBW_SKIP: "pp* *-win32 *-manylinux_i686 *-musllinux*"
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}
         CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow sphinx_gallery imageio"
         CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test('nobackend')\""
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.7'
+        python-version: '3.9'
     - name: Build sdist
       run: |
         python -m pip install --upgrade pip setuptools build wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
     "wheel",
-    "oldest-supported-numpy",
     "setuptools>=42",
+    # see https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+    "numpy>=2.0.0rc2",
     "setuptools_scm[toml]>=7.1",
     "Cython>=3.0.0"
 ]

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     long_description_content_type='text/x-rst',
     platforms='any',
     provides=['vispy'],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=install_requires,
     extras_require={
         'ipython-static': ['ipython'],
@@ -151,10 +151,10 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: IPython'
     ],
 )

--- a/vispy/geometry/__init__.py
+++ b/vispy/geometry/__init__.py
@@ -16,7 +16,7 @@ from .meshdata import MeshData  # noqa
 from .rect import Rect  # noqa
 from .triangulation import Triangulation, triangulate  # noqa
 from .torusknot import TorusKnot  # noqa
-from .calculations import (_calculate_normals, _fast_cross_3d,  # noqa
+from .calculations import (_calculate_normals, _cross_2d, _fast_cross_3d,  # noqa
                            resize)  # noqa
 from .generation import (create_arrow, create_box, create_cone,  # noqa
                          create_cube, create_cylinder, create_grid_mesh,  # noqa

--- a/vispy/geometry/calculations.py
+++ b/vispy/geometry/calculations.py
@@ -7,8 +7,33 @@
 import numpy as np
 
 
-###############################################################################
-# These fast normal calculation routines are adapted from mne-python
+def _cross_2d(x, y):
+    """Compute the z-component of the cross product of (arrays of) 2D vectors.
+
+    This is meant to replicate the 2D functionality of np.cross(), which is
+    deprecated in numpy 2.0.
+
+    x and y must have broadcastable shapes, with the last dimension being 2.
+
+    Parameters
+    ----------
+    x : array
+        Input array 1, shape (..., 2).
+    y : array
+        Input array 2, shape (..., 2).
+
+    Returns
+    -------
+    z : array
+        z-component of cross products of x and y.
+
+    See: https://github.com/numpy/numpy/issues/26620
+    """
+    if x.shape[-1] != 2 or y.shape[-1] != 2:
+        raise ValueError("Input arrays must have shape (..., 2)")
+
+    return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
 
 def _fast_cross_3d(x, y):
     """Compute cross product between list of 3D vectors
@@ -46,6 +71,9 @@ def _fast_cross_3d(x, y):
     else:
         return np.cross(x, y)
 
+
+###############################################################################
+# These fast normal calculation routines are adapted from mne-python
 
 def _calculate_normals(rr, tris):
     """Efficiently compute vertex normals for triangulated surface"""

--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -7,6 +7,8 @@ import numpy as np
 
 from collections import OrderedDict
 
+from .calculations import _cross_2d
+
 
 class Triangulation(object):
     """Constrained delaunay triangulation
@@ -676,7 +678,7 @@ class Triangulation(object):
         A = self.pts[a]
         B = self.pts[b]
         C = self.pts[c]
-        return np.cross(B-A, C-B) > 0
+        return _cross_2d(B - A, C - B) > 0
 
     def _edges_intersect(self, edge1, edge2):
         """Return 1 if edges intersect completely (endpoints excluded)"""
@@ -739,7 +741,7 @@ class Triangulation(object):
         """
         v1 = self.pts[point] - self.pts[edge[0]]
         v2 = self.pts[edge[1]] - self.pts[edge[0]]
-        c = np.cross(v1, v2)  # positive if v1 is CW from v2
+        c = _cross_2d(v1, v2)  # positive if v1 is CW from v2
         return 1 if c > 0 else (-1 if c < 0 else 0)
 
     def _add_tri(self, a, b, c):

--- a/vispy/gloo/buffer.py
+++ b/vispy/gloo/buffer.py
@@ -10,7 +10,7 @@ from traceback import extract_stack, format_list
 import weakref
 
 from . globject import GLObject
-from ..util import logger
+from ..util import logger, np_copy_if_needed
 
 
 # ------------------------------------------------------------ Buffer class ---
@@ -70,7 +70,7 @@ class Buffer(GLObject):
             data is actually uploaded to GPU memory.
             Asking explicitly for a copy will prevent this behavior.
         """
-        data = np.array(data, copy=copy)
+        data = np.array(data, copy=copy or np_copy_if_needed)
         nbytes = data.nbytes
 
         if offset < 0:
@@ -98,7 +98,7 @@ class Buffer(GLObject):
             data is actually uploaded to GPU memory.
             Asking explicitly for a copy will prevent this behavior.
         """
-        data = np.array(data, copy=copy)
+        data = np.array(data, copy=copy or np_copy_if_needed)
         nbytes = data.nbytes
 
         if nbytes != self._nbytes:
@@ -283,7 +283,7 @@ class DataBuffer(Buffer):
 
         # Make sure data is an array
         if not isinstance(data, np.ndarray):
-            data = np.array(data, dtype=self.dtype, copy=False)
+            data = np.array(data, dtype=self.dtype)
 
         # Make sure data is big enough
         if data.size < stop - start:

--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -192,7 +192,7 @@ quad = np.array([[0, 0, 0], [-1, 0, 0], [-1, -1, 0],
 N = quad.shape[0] * 4
 
 # buf3 contains coordinates in device coordinates for four quadrants
-buf3 = np.row_stack([quad + (0, 0, 0), quad + (0, 1, 0),
+buf3 = np.vstack([quad + (0, 0, 0), quad + (0, 1, 0),
                      quad + (1, 1, 0), quad + (1, 0, 0)]).astype(np.float32)
 
 # buf2 is texture coords. Note that this is a view on buf2

--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -192,8 +192,10 @@ quad = np.array([[0, 0, 0], [-1, 0, 0], [-1, -1, 0],
 N = quad.shape[0] * 4
 
 # buf3 contains coordinates in device coordinates for four quadrants
-buf3 = np.vstack([quad + (0, 0, 0), quad + (0, 1, 0),
-                     quad + (1, 1, 0), quad + (1, 0, 0)]).astype(np.float32)
+buf3 = np.vstack([
+    quad + (0, 0, 0), quad + (0, 1, 0),
+    quad + (1, 1, 0), quad + (1, 0, 0),
+]).astype(np.float32)
 
 # buf2 is texture coords. Note that this is a view on buf2
 buf2 = ((buf3+1.0)*0.5)[:, :2]   # not C-contiguous

--- a/vispy/gloo/texture.py
+++ b/vispy/gloo/texture.py
@@ -11,6 +11,7 @@ import warnings
 
 from .globject import GLObject
 from .util import check_enum
+from ..util import np_copy_if_needed
 
 
 def get_dtype_limits(dtype):
@@ -29,7 +30,7 @@ def convert_dtype_and_clip(data, dtype, copy=False):
     new_min, new_max = get_dtype_limits(dtype)
     if new_max >= old_max and new_min <= old_min:
         # no need to clip
-        return np.array(data, dtype=dtype, copy=copy)
+        return np.array(data, dtype=dtype, copy=copy or np_copy_if_needed)
     else:
         # to reduce copying, we clip into a pre-generated array of the right dtype
         new_data = np.empty_like(data, dtype=dtype)
@@ -158,7 +159,7 @@ class BaseTexture(GLObject):
         if data is not None:
             if shape is not None:
                 raise ValueError('Texture needs data or shape, not both.')
-            data = np.array(data, copy=False)
+            data = np.array(data)
             # So we can test the combination
             self._resize(data.shape, format, internalformat)
             self._set_data(data)
@@ -427,7 +428,7 @@ class BaseTexture(GLObject):
 
         # Make sure data is an array
         if not isinstance(data, np.ndarray):
-            data = np.array(data, copy=False)
+            data = np.array(data)
         # Make sure data is big enough
         if data.shape != shape:
             data = np.resize(data, shape)

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -377,7 +377,7 @@ def run_tests_if_main():
     import __main__
     try:
         import pytest
-        pytest.main(['-s', '--tb=short', fname])
+        pytest.main(['-s', '--tb=short', '-vvv', fname])
     except ImportError:
         print('==== Running tests in script\n==== %s' % fname)
         run_tests_in_object(__main__)

--- a/vispy/testing/_testing.py
+++ b/vispy/testing/_testing.py
@@ -377,7 +377,7 @@ def run_tests_if_main():
     import __main__
     try:
         import pytest
-        pytest.main(['-s', '--tb=short', '-vvv', fname])
+        pytest.main(['-s', '--tb=short', fname])
     except ImportError:
         print('==== Running tests in script\n==== %s' % fname)
         run_tests_in_object(__main__)

--- a/vispy/util/__init__.py
+++ b/vispy/util/__init__.py
@@ -23,18 +23,10 @@ import numpy as np
 # `copy` keyword semantics changed in NumPy 2.0
 # this maintains compatibility with older versions
 # if/when NumPy 2.0 becomes the minimum version, we can remove this
+# we don't worry about early dev versions of NumPy 2.0 (that may or may not have the kwarg) here
 # see:
 #  https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
 #  https://github.com/scipy/scipy/pull/20172
-np_copy_if_needed: Optional[bool]
-if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
-    np_copy_if_needed = None
-elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+np_copy_if_needed: Optional[bool] = None
+if np.lib.NumpyVersion(np.__version__) < "1.28.0":
     np_copy_if_needed = False
-else:
-    # 2.0.0 dev versions, handle cases where copy may or may not exist
-    try:
-        np.array([1]).__array__(copy=None)  # type: ignore[call-overload]
-        np_copy_if_needed = None
-    except TypeError:
-        np_copy_if_needed = False

--- a/vispy/util/__init__.py
+++ b/vispy/util/__init__.py
@@ -15,3 +15,26 @@ from . import fonts       # noqa
 from . import transforms  # noqa
 from .wrappers import use, run_subprocess  # noqa
 from .bunch import SimpleBunch  # noqa
+
+from typing import Optional
+
+import numpy as np
+
+# `copy` keyword semantics changed in NumPy 2.0
+# this maintains compatibility with older versions
+# if/when NumPy 2.0 becomes the minimum version, we can remove this
+# see:
+#  https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
+#  https://github.com/scipy/scipy/pull/20172
+np_copy_if_needed: Optional[bool]
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    np_copy_if_needed = None
+elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+    np_copy_if_needed = False
+else:
+    # 2.0.0 dev versions, handle cases where copy may or may not exist
+    try:
+        np.array([1]).__array__(copy=None)  # type: ignore[call-overload]
+        np_copy_if_needed = None
+    except TypeError:
+        np_copy_if_needed = False

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 from vispy.gloo.texture import Texture2D, Texture3D, convert_dtype_and_clip
+from vispy.util import np_copy_if_needed
 
 
 def get_default_clim_from_dtype(dtype):
@@ -298,7 +299,7 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
 
     @staticmethod
     def _scale_data_on_cpu(data, clim, copy=True):
-        data = np.array(data, dtype=np.float32, copy=copy)
+        data = np.array(data, dtype=np.float32, copy=copy or np_copy_if_needed)
         if clim[0] != clim[1]:
             # we always must copy the data if we change it here, otherwise it might change
             # unexpectedly the data held outside of here

--- a/vispy/visuals/collections/array_list.py
+++ b/vispy/visuals/collections/array_list.py
@@ -73,7 +73,7 @@ class ArrayList(object):
                 if isinstance(data[0], (list, tuple)):
                     itemsize = [len(sublist) for sublist in data]
                     data = [item for sublist in data for item in sublist]
-            self._data = np.array(data, copy=False)
+            self._data = np.array(data)
             self._size = self._data.size
 
             # Default is one group with all data inside
@@ -88,7 +88,7 @@ class ArrayList(object):
                     _itemsize = np.ones(
                         self._count, dtype=int) * (self._size // self._count)
                 else:
-                    _itemsize = np.array(itemsize, copy=False)
+                    _itemsize = np.array(itemsize)
                     self._count = len(itemsize)
                     if _itemsize.sum() != self._size:
                         raise ValueError("Cannot partition data as requested")
@@ -302,7 +302,7 @@ class ArrayList(object):
             itemsize = [len(sublist) for sublist in data]
             data = [item for sublist in data for item in sublist]
 
-        data = np.array(data, copy=False).ravel()
+        data = np.array(data).ravel()
         size = data.size
 
         # Check item size and get item number
@@ -313,7 +313,7 @@ class ArrayList(object):
                 _count = size // itemsize
                 _itemsize = np.ones(_count, dtype=int) * (size // _count)
             else:
-                _itemsize = np.array(itemsize, copy=False)
+                _itemsize = np.array(itemsize)
                 _count = len(itemsize)
                 if _itemsize.sum() != size:
                     raise ValueError("Cannot partition data as requested")

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -16,6 +16,7 @@ from .transforms import NullTransform
 from .visual import Visual
 from ..io import load_spatial_filters
 from ._scalable_textures import CPUScaledTexture2D, GPUScaledTexture2D
+from ..util import np_copy_if_needed
 
 
 _VERTEX_SHADER = """
@@ -380,6 +381,8 @@ class ImageVisual(Visual):
         texture_format : str or None
 
         """
+        if not copy:
+            copy = np_copy_if_needed
         data = np.array(image, copy=copy)
         if np.iscomplexobj(data):
             raise TypeError(

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -381,9 +381,7 @@ class ImageVisual(Visual):
         texture_format : str or None
 
         """
-        if not copy:
-            copy = np_copy_if_needed
-        data = np.array(image, copy=copy)
+        data = np.array(image, copy=copy or np_copy_if_needed)
         if np.iscomplexobj(data):
             raise TypeError(
                 "Complex data types not supported. Please use 'ComplexImage' instead"

--- a/vispy/visuals/text/_sdf_cpu.pyx
+++ b/vispy/visuals/text/_sdf_cpu.pyx
@@ -7,6 +7,8 @@ cimport numpy as np
 from libc.math cimport sqrt
 cimport cython
 
+np.import_array()
+
 __all__ = ['_get_distance_field']
 
 dtype = np.float32


### PR DESCRIPTION
This introduces numpy 2.0 support. napari has started looking into support, and ran into a few small issues using vispy testing against it. See the [napari zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/handling.20the.20numpy.202.2E0.20release/near/381330412) for some discussion and relevant links.

The process for adding support in this PR was:
* Run the ruff numpy 2.0 support check and fix:
```
ruff check vispy --select NPY201
ruff check vispy --select NPY201 --fix
```
* Run tests, fix issues and warnings
* Update for changes to behavior of the `copy` kwarg in `np.array`
    * Add `vispy.util.np_copy_if_needed` value (`False` for numpy < 1.28, `None` for numpy >= 2.0)
    * Search for `copy=False` used in `no.array` and remove it
    * Search for `copy=copy` used in `np.array`, replace with `copy=vispy.util.np_copy_if_needed`
    * See references for more information
        * [NumPy 2.0 Migration Guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword)
        * [SciPy PR doing the same](https://github.com/scipy/scipy/pull/20172)
        * [napari PR doing the same](https://github.com/napari/napari/pull/6932)
* Update build configuration for Cython code
    * Previously, it was important to link against the oldest compatible numpy version to ensure
      forward compatibility. This was accomplished by depending on
      [oldest-supported-numpy](https://pypi.org/project/oldest-supported-numpy/).
    * Now, you can just depend on `numpy>=2.0.0rc1`, and the build will be compatible with both 1.x
      and 2.x.
    * This is updated in the `[build-system]` section of `pyproject.toml`
    * See [Depending on NumPy](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice) for more information


I think this is ready for review, but I'm going to try creating a wheel and using to run napari tests with numpy 2.0 as well. I'll mark it non-draft after I do that.