### PR TITLE
Ignore unhandled Qt events

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -493,41 +493,49 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
     def mousePressEvent(self, ev):
         if self._vispy_canvas is None:
             return
-        self._vispy_mouse_press(
+        vispy_event = self._vispy_mouse_press(
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP.get(ev.button(), 0),
             modifiers=self._modifiers(ev),
         )
+        if not vispy_event.handled:
+            ev.ignore()
 
     def mouseReleaseEvent(self, ev):
         if self._vispy_canvas is None:
             return
-        self._vispy_mouse_release(
+        vispy_event = self._vispy_mouse_release(
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP[ev.button()],
             modifiers=self._modifiers(ev),
         )
+        if not vispy_event.handled:
+            ev.ignore()
 
     def mouseDoubleClickEvent(self, ev):
         if self._vispy_canvas is None:
             return
-        self._vispy_mouse_double_click(
+        vispy_event = self._vispy_mouse_double_click(
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP.get(ev.button(), 0),
             modifiers=self._modifiers(ev),
         )
+        if not vispy_event.handled:
+            ev.ignore()
 
     def mouseMoveEvent(self, ev):
         if self._vispy_canvas is None:
             return
-        self._vispy_mouse_move(
+        vispy_event = self._vispy_mouse_move(
             native=ev,
             pos=_get_event_xy(ev),
             modifiers=self._modifiers(ev),
         )
+        if not vispy_event.handled:
+            ev.ignore()
 
     def wheelEvent(self, ev):
         if self._vispy_canvas is None:
@@ -544,12 +552,14 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             delta = ev.angleDelta()
             deltax, deltay = delta.x() / 120.0, delta.y() / 120.0
         # Emit event
-        self._vispy_canvas.events.mouse_wheel(
+        vispy_event = self._vispy_canvas.events.mouse_wheel(
             native=ev,
             delta=(deltax, deltay),
             pos=_get_event_xy(ev),
             modifiers=self._modifiers(ev),
         )
+        if not vispy_event.handled:
+            ev.ignore()
 
     def keyPressEvent(self, ev):
         self._keyEvent(self._vispy_canvas.events.key_press, ev)
@@ -571,15 +581,16 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             pos = self.mapFromGlobal(ev.globalPos())
         pos = pos.x(), pos.y()
 
+        vispy_event = None
         if t == QtCore.Qt.NativeGestureType.BeginNativeGesture:
-            self._vispy_canvas.events.touch(
+            vispy_event = self._vispy_canvas.events.touch(
                 type='gesture_begin',
                 pos=_get_event_xy(ev),
             )
         elif t == QtCore.Qt.NativeGestureType.EndNativeGesture:
             self._native_touch_total_rotation = []
             self._native_touch_total_scale = []
-            self._vispy_canvas.events.touch(
+            vispy_event = self._vispy_canvas.events.touch(
                 type='gesture_end',
                 pos=_get_event_xy(ev),
             )
@@ -592,7 +603,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             )
             self._native_gesture_rotation_values.append(angle)
             total_rotation_angle = math.fsum(self._native_gesture_rotation_values)
-            self._vispy_canvas.events.touch(
+            vispy_event = self._vispy_canvas.events.touch(
                 type="gesture_rotate",
                 pos=pos,
                 rotation=angle,
@@ -608,7 +619,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             )
             self._native_gesture_scale_values.append(scale)
             total_scale_factor = math.fsum(self._native_gesture_scale_values)
-            self._vispy_canvas.events.touch(
+            vispy_event = self._vispy_canvas.events.touch(
                 type="gesture_zoom",
                 pos=pos,
                 last_scale=last_scale,
@@ -621,6 +632,8 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         # Two finger pan events are anyway converted to scroll/wheel events.
         # On macOS, more fingers are usually swallowed by the OS (by spaces,
         # mission control, etc.).
+        if vispy_event is not None and not vispy_event.handled:
+            ev.ignore()
 
     def event(self, ev):
         out = super(QtBaseCanvasBackend, self).event(ev)
@@ -644,7 +657,9 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         else:
             key = None
         mod = self._modifiers(ev)
-        func(native=ev, key=key, text=str(ev.text()), modifiers=mod)
+        vispy_event = func(native=ev, key=key, text=str(ev.text()), modifiers=mod)
+        if not vispy_event.handled:
+            ev.ignore()
 
     def _modifiers(self, event):
         # Convert the QT modifier state into a tuple of active modifier keys.
@@ -771,7 +786,9 @@ class CanvasBackendEgl(QtBaseCanvasBackend, QWidget):
 
     def resizeEvent(self, event):
         w, h = event.size().width(), event.size().height()
-        self._vispy_canvas.events.resize(size=(w, h))
+        vispy_event = self._vispy_canvas.events.resize(size=(w, h))
+        if not vispy_event.handled:
+            event.ignore()
 
     def paintEvent(self, event):
         self._vispy_canvas.events.draw(region=None)

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -499,6 +499,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             button=BUTTONMAP.get(ev.button(), 0),
             modifiers=self._modifiers(ev),
         )
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             ev.ignore()
 
@@ -511,6 +512,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             button=BUTTONMAP[ev.button()],
             modifiers=self._modifiers(ev),
         )
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             ev.ignore()
 
@@ -523,6 +525,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             button=BUTTONMAP.get(ev.button(), 0),
             modifiers=self._modifiers(ev),
         )
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             ev.ignore()
 
@@ -535,6 +538,8 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             pos=_get_event_xy(ev),
             modifiers=self._modifiers(ev),
         )
+        # If vispy did not handle the event, clear the accept parameter of the qt event
+        # Note that the handler can return None, this is equivalent to not handling the event
         if vispy_event is None or not vispy_event.handled:
             # Theoretically, a parent widget might want to listen to all of
             # the mouse move events, including those that VisPy ignores
@@ -561,6 +566,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             pos=_get_event_xy(ev),
             modifiers=self._modifiers(ev),
         )
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             ev.ignore()
 
@@ -635,7 +641,10 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         # Two finger pan events are anyway converted to scroll/wheel events.
         # On macOS, more fingers are usually swallowed by the OS (by spaces,
         # mission control, etc.).
-        if vispy_event is not None and not vispy_event.handled:
+
+        # If vispy did not handle the event, clear the accept parameter of the qt event
+        # Note that some handlers return None, this is equivalent to not handling the event
+        if vispy_event is None or not vispy_event.handled:
             ev.ignore()
 
     def event(self, ev):
@@ -661,6 +670,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             key = None
         mod = self._modifiers(ev)
         vispy_event = func(native=ev, key=key, text=str(ev.text()), modifiers=mod)
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             ev.ignore()
 
@@ -790,6 +800,7 @@ class CanvasBackendEgl(QtBaseCanvasBackend, QWidget):
     def resizeEvent(self, event):
         w, h = event.size().width(), event.size().height()
         vispy_event = self._vispy_canvas.events.resize(size=(w, h))
+        # If vispy did not handle the event, clear the accept parameter of the qt event
         if not vispy_event.handled:
             event.ignore()
 

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -529,12 +529,15 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
     def mouseMoveEvent(self, ev):
         if self._vispy_canvas is None:
             return
+        # NB ignores events, returns None for events in quick succession
         vispy_event = self._vispy_mouse_move(
             native=ev,
             pos=_get_event_xy(ev),
             modifiers=self._modifiers(ev),
         )
-        if not vispy_event.handled:
+        if vispy_event is None or not vispy_event.handled:
+            # Theoretically, a parent widget might want to listen to all of
+            # the mouse move events, including those that VisPy ignores
             ev.ignore()
 
     def wheelEvent(self, ev):


### PR DESCRIPTION
Currently, the Qt backend eats all events, regardless of whether vispy actually acts upon them. In my judgement, this seems contrary to the "best practices" of Qt, where events should be passed along if they are not acted upon.

This changeset calls [`QEvent.ignore()`](https://doc.qt.io/qt-6/qevent.html#ignore) in all of the relevant locations I could find (if there are some I missed, we should probably add this code there too), allowing parent widgets the chance to respond to unhandled events.

I'm wary about this change introducing other bugs, specifically in parent Qt widgets who are now receiving events they were not expecting - this changeset is likely a tradeoff that I think is worth consideration.

I'm not terribly sure whether this changeset warrants any changes to test code, and/or where those changes would be. If you'd like me to write tests, I'm happy to do so, I'd just appreciate a little direction on where to start!

