### PR TITLE
Set self._data_dtype in scale_and_set_data for CPU scaled textures

### DIFF
--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -311,7 +311,7 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
     def scale_and_set_data(self, data, offset=None, copy=True):
         """Upload new data to the GPU, scaling if necessary."""
         if self._data_dtype is None:
-            data.dtype == self._data_dtype
+            self._data_dtype = data.dtype
 
         # ensure dtype is the same as it was before, or funny things happen
         # no copy is performed unless asked for or necessary

--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -311,7 +311,7 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
     def scale_and_set_data(self, data, offset=None, copy=True):
         """Upload new data to the GPU, scaling if necessary."""
         if self._data_dtype is None:
-            self._data_dtype = data.dtype
+            data.dtype == self._data_dtype
 
         # ensure dtype is the same as it was before, or funny things happen
         # no copy is performed unless asked for or necessary

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -148,7 +148,6 @@ def test_clim_handling_cpu():
     st.scale_and_set_data(new_data)
     assert st.clim == (5, 255)
     assert st.clim_normalized == (0, 1)
-    print(st.data)
 
 
 def test_clim_handling_gpu():

--- a/vispy/visuals/tests/test_scalable_textures.py
+++ b/vispy/visuals/tests/test_scalable_textures.py
@@ -133,6 +133,23 @@ def test_clim_handling_cpu():
     assert st.clim == (5, 25)
     assert st.clim_normalized == (0, 1)
 
+    # u8 auto -> f32 auto
+    st = CPUScaledStub()
+    st.set_clim("auto")
+    assert st.clim == "auto"
+    st.scale_and_set_data(ref_data.astype(np.uint8))
+    assert st.clim == (5, 25)
+    assert st.clim_normalized == (0, 1)
+    # set new data with an out-of-range value
+    # it should clip at the limits of the original data type
+    st.set_clim("auto")
+    assert st.clim == "auto"
+    new_data = np.array([[10, 10, 5], [15, 2048, 15]], dtype=np.float32)
+    st.scale_and_set_data(new_data)
+    assert st.clim == (5, 255)
+    assert st.clim_normalized == (0, 1)
+    print(st.data)
+
 
 def test_clim_handling_gpu():
     ref_data = np.array([[10, 10, 5], [15, 25, 15]])


### PR DESCRIPTION
I noticed this warning when running tests, and I think it traces back to the change in this PR.

```
vispy/visuals/tests/test_colormap.py: 6 warnings
vispy/visuals/tests/test_image.py: 39 warnings
vispy/visuals/tests/test_scalable_textures.py: 4 warnings
  /Users/aandersoniii/src/vispy/vispy/gloo/texture.py:18: DeprecationWarning: finfo() dtype cannot be None. This behavior will raise an error in the future. (Deprecated in NumPy 1.25)
    info = np.finfo(dtype)
```

See https://github.com/vispy/vispy/pull/2350#discussion_r1638869690 for some context.

I am partly guessing what this code meant to be doing, but here the `_data_dtype` is set the first time `scale_and_set_data` is called. @brisvag at your suggestion I am trying to think of a test that could have caught this, but need to think about it a little more.