### PR TITLE
Switch CI to use matplotlib-base

### DIFF
--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -11,7 +11,7 @@ meshio
 networkx
 numpy
 pillow
-pyqt=5
+pyside6
 pysdl2
 pytest
 pytest-cov

--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -6,12 +6,12 @@ freetype-py
 glfw!=3.3.1
 imageio
 jupyter
-matplotlib
+matplotlib-base
 meshio
 networkx
 numpy
 pillow
-pyside6
+pyqt=5
 pysdl2
 pytest
 pytest-cov

--- a/vispy/visuals/tests/test_image.py
+++ b/vispy/visuals/tests/test_image.py
@@ -327,7 +327,7 @@ def test_image_interpolation():
         assert np.allclose(render[center_left], black)
         assert np.allclose(render[center_right], white)
 
-        image.interpolation = 'bilinear'
+        image.interpolation = 'linear'
         render = c.render()
         assert np.allclose(render[left], black)
         assert np.allclose(render[right], white)


### PR DESCRIPTION
Continuation of #2611 

Matplotlib on conda-forge is now released with pyside6 instead of qt5. ~We either need to switch our default environment to pyside6, drop matplotlib as a dependency (no testing matplotlib features... :fearful: ), or do some other splitting of testing environments.~

~This PR does the first option, but this means Qt5-based backends are not tested at all in our CI anymore.~

This PR switches to matplotlib-base to not include the pyside6 dependency.

Thoughts?