### PR TITLE
add set_bad && fix bug in surface_plot

### DIFF
--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -94,7 +94,8 @@ _APPLY_CLIM_FLOAT = """
         // If data is NaN, don't draw it at all
         // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
         if (!(data <= 0.0 || 0.0 <= data)) {
-            discard;
+            // discard;
+            return data;
         }
         data = clamp(data, min($clim.x, $clim.y), max($clim.x, $clim.y));
         data = (data - $clim.x) / ($clim.y - $clim.x);

--- a/vispy/visuals/surface_plot.py
+++ b/vispy/visuals/surface_plot.py
@@ -123,10 +123,11 @@ class SurfacePlotVisual(MeshVisual):
             return
         colors = np.asarray(colors)
         if colors.ndim == 3:
+            assert colors.shape[-1] == 3 or colors.shape[-1] == 4
             # convert (width, height, 4) to (num_verts, 4)
             vert_shape = self.__vertices.shape
             num_vertices = vert_shape[0] * vert_shape[1]
-            colors = colors.reshape(num_vertices, 3)
+            colors = colors.reshape(num_vertices, colors.shape[-1])
         return colors
 
     def set_data(self, x=None, y=None, z=None, colors=None):
@@ -165,14 +166,16 @@ class SurfacePlotVisual(MeshVisual):
 
         colors = self._prepare_mesh_colors(colors)
         update_colors = colors is not None
-        if update_colors:
-            self.__meshdata.set_vertex_colors(colors)
         if update_faces:
             self.__meshdata.set_faces(self.__faces)
         if update_vertices:
             self.__meshdata.set_vertices(
                 self.__vertices.reshape(self.__vertices.shape[0] *
                                         self.__vertices.shape[1], 3))
+         # we need update vertices first, otherwise `set_vertex_colors` 
+         # will raise error. (in meshdata.n_vertices, _vertices is None)
+        if update_colors:
+            self.__meshdata.set_vertex_colors(colors)
         if update_faces or update_vertices or update_colors:
             MeshVisual.set_data(self, meshdata=self.__meshdata)
 


### PR DESCRIPTION
- Add `set_bad` and `get_bad` function of `BaseColormap`.
- Adjust the `map` function of `Colormap` to support inputs for `scalar`, `list`, and `np.array`, while maintaining its shape.
- Fix the bug in `SurfacePlotVisual`, related to #2542 and #2517 