### PR TITLE
fix: prevent zerodiv error when auto-calculating clims in scalable textures

### DIFF
--- a/vispy/visuals/_scalable_textures.py
+++ b/vispy/visuals/_scalable_textures.py
@@ -291,10 +291,11 @@ class CPUScaledTextureMixin(_ScaledTextureMixin):
 
         range_min, range_max = self._data_limits
         clim_min, clim_max = self.clim
-        if clim_min == clim_max:
+        full_range = range_max - range_min
+        if clim_min == clim_max or full_range == 0:
             return 0, np.inf
-        clim_min = (clim_min - range_min) / (range_max - range_min)
-        clim_max = (clim_max - range_min) / (range_max - range_min)
+        clim_min = (clim_min - range_min) / full_range
+        clim_max = (clim_max - range_min) / full_range
         return clim_min, clim_max
 
     @staticmethod


### PR DESCRIPTION
small change here.  I very frequently hit a ZeroDivisionError with scaling in vispy:

```python
  File "/Users/talley/dev/self/orGANelle/.venv/lib/python3.12/site-packages/vispy/visuals/visual.py", line 505, in draw
    if self._prepare_draw(view=self) is False:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/talley/dev/self/orGANelle/.venv/lib/python3.12/site-packages/vispy/visuals/image.py", line 677, in _prepare_draw
    self._build_texture()
  File "/Users/talley/dev/self/orGANelle/.venv/lib/python3.12/site-packages/vispy/visuals/image.py", line 613, in _build_texture
    pre_clims = self._texture.clim_normalized
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/talley/dev/self/orGANelle/.venv/lib/python3.12/site-packages/vispy/visuals/_scalable_textures.py", line 296, in clim_normalized
    clim_min = (clim_min - range_min) / (range_max - range_min)
               ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: float division by zer
```

I could of course try to check ahead of time to prevent asking vispy to autoscale something where the min and max value are the same, but this small change also catches it and works in all the cases i tried.  let me know if you see any problems with it