### PR TITLE
Add modifiers to QT native gesture events

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -575,6 +575,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             self._vispy_canvas.events.touch(
                 type='gesture_begin',
                 pos=_get_event_xy(ev),
+                modifiers=self._modifiers(ev),
             )
         elif t == QtCore.Qt.NativeGestureType.EndNativeGesture:
             self._native_touch_total_rotation = []
@@ -582,6 +583,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             self._vispy_canvas.events.touch(
                 type='gesture_end',
                 pos=_get_event_xy(ev),
+                modifiers=self._modifiers(ev),
             )
         elif t == QtCore.Qt.NativeGestureType.RotateNativeGesture:
             angle = ev.value()
@@ -598,6 +600,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
                 rotation=angle,
                 last_rotation=last_angle,
                 total_rotation_angle=total_rotation_angle,
+                modifiers=self._modifiers(ev),
             )
         elif t == QtCore.Qt.NativeGestureType.ZoomNativeGesture:
             scale = ev.value()
@@ -614,6 +617,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
                 last_scale=last_scale,
                 scale=scale,
                 total_scale_factor=total_scale_factor,
+                modifiers=self._modifiers(ev),
             )
         # QtCore.Qt.NativeGestureType.PanNativeGesture
         # Qt6 docs seem to imply this is only supported on Wayland but I have


### PR DESCRIPTION
### Why this PR?

Mouse Events forwarded from QT to the canvas events have a `modifers` attribute that is very useful to create enhanced interactions. For instance it can be used to make CONTROL + zoom behave like a slower zoom to better manipulate the camera.

Sadly when the QT event is a NativeGesture event, the current qt backend (_qt.py) does not forward this list of modifiers.

This PR fixes this so that we can have access to the modifiers when handling a QT native gesture event in vispy.

### What are the changes?

This PR just adds a `modifiers` attribute to these events, exactly as it's done with the classic mouse events. It works the same because QNativeGestureEvent inherits from QInputEvent (https://doc.qt.io/qtforpython-6/PySide6/QtGui/QInputEvent.html#PySide6.QtGui.QInputEvent) that has the `modifiers` method.

### About the tests

I couldn't find any test about the forwarding of QT events so I didn't change any specific test in this PR

### Note

For the moment QT does not forward the keys pressed to the `modifiers` of the QNativeGestureEvents but : 
- the interface exists on the QT side (the method `modifiers` exists)
- it allows for a more homogenous interface on vispy side (mouse events & gesture events share a better interface)
- QT will hopefully fill in the modifiers in QNativeGestureEvents in a future update: better be ready ;) 