### PR TITLE
Update linux_full_newqtdeps_apt.txt fix CI for Ubuntu 24.04 runners

### DIFF
--- a/ci/requirements/linux_full_newqtdeps_apt.txt
+++ b/ci/requirements/linux_full_newqtdeps_apt.txt
@@ -15,5 +15,5 @@ libxcb-xinerama0
 libxcb-icccm4-dev
 libxcb-image0-dev
 libxcb-keysyms1
-libegl1-mesa
+libegl1
 x11-utils


### PR DESCRIPTION
This PR fixes CI failure due to runners now being Ubuntu 24.04:
https://github.com/vispy/vispy/actions/runs/12667848614/job/35302054335
libegl1-mesa was a transitional dummy package for libegl1, going back as far as 20.04

See equivalent fix here:
https://github.com/tlambert03/setup-qt-libs/pull/66