### PR TITLE
Ensure proper `quartz` cdll loading on macOS (cocoapy)

### DIFF
--- a/vispy/ext/cocoapy.py
+++ b/vispy/ext/cocoapy.py
@@ -18,26 +18,6 @@ else:
     string_types = basestring,  # noqa
 
 
-# handle dlopen cache changes in macOS 11 (Big Sur)
-# ref https://stackoverflow.com/questions/63475461/unable-to-import-opengl-gl-in-python-on-macos
-try:
-    import OpenGL.GL   # noqa
-except ImportError:
-    # print('Drat, patching for Big Sur')
-    orig_util_find_library = util.find_library
-
-    def new_util_find_library(name):
-        res = orig_util_find_library(name)
-        if res:
-            return res
-        lut = {
-            'objc': 'libobjc.dylib',
-            'quartz': 'Quartz.framework/Quartz'
-        }
-        return lut.get(name, name+'.framework/'+name)
-    util.find_library = new_util_find_library
-
-
 # Based on Pyglet code
 
 ##############################################################################
@@ -1285,7 +1265,7 @@ NSApplicationActivationPolicyProhibited = 2
 
 # QUARTZ / COREGRAPHICS
 
-quartz = cdll.LoadLibrary(util.find_library('quartz'))
+quartz = cdll.LoadLibrary(util.find_library('Quartz'))
 
 CGDirectDisplayID = c_uint32     # CGDirectDisplay.h
 CGError = c_int32                # CGError.h


### PR DESCRIPTION
Alternative to: https://github.com/vispy/vispy/pull/2549

This PR drops the monkeypatch because:
- The fix in ctypes for cdlls in bigsur is out in python >3.8:
https://bugs.python.org/issue41100
- The remaining issue was python 3.8, which has been dropped in https://github.com/vispy/vispy/pull/2599

Also, changes the name of the library to the proper `Quartz`, as per:
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html
The lower case may work due with case insensitive file system, but as noted by Ashley, with caching, it may fail.