### PR TITLE
Fix mesh colors reshaping

### DIFF
--- a/vispy/visuals/surface_plot.py
+++ b/vispy/visuals/surface_plot.py
@@ -126,7 +126,7 @@ class SurfacePlotVisual(MeshVisual):
             # convert (width, height, 4) to (num_verts, 4)
             vert_shape = self.__vertices.shape
             num_vertices = vert_shape[0] * vert_shape[1]
-            colors = colors.reshape(num_vertices, 3)
+            colors = colors.reshape(num_vertices, 4)
         return colors
 
     def set_data(self, x=None, y=None, z=None, colors=None):

--- a/vispy/visuals/surface_plot.py
+++ b/vispy/visuals/surface_plot.py
@@ -126,7 +126,7 @@ class SurfacePlotVisual(MeshVisual):
             # convert (width, height, 4) to (num_verts, 4)
             vert_shape = self.__vertices.shape
             num_vertices = vert_shape[0] * vert_shape[1]
-            colors = colors.reshape(num_vertices, 4)
+            colors = colors.reshape(num_vertices, colors.shape[-1])
         return colors
 
     def set_data(self, x=None, y=None, z=None, colors=None):

--- a/vispy/visuals/tests/test_surface_plot.py
+++ b/vispy/visuals/tests/test_surface_plot.py
@@ -12,7 +12,8 @@ import pytest
 @requires_application()
 @pytest.mark.parametrize('x1dim', [True, False])
 @pytest.mark.parametrize('y1dim', [True, False])
-def test_surface_plot(x1dim:bool, y1dim:bool):
+@pytest.mark.parametrize('use_vertex_colors', [True, False])
+def test_surface_plot(x1dim:bool, y1dim:bool, use_vertex_colors:bool):
     """Test SurfacePlot visual"""
     with TestingCanvas(bgcolor='w') as c:
         
@@ -29,7 +30,8 @@ def test_surface_plot(x1dim:bool, y1dim:bool):
         # color vertices
         cnorm = z / abs(np.amax(z))
         colormap = get_colormap("viridis").map(cnorm)
-        colormap.reshape(z.shape + (-1,))
+        if not use_vertex_colors:
+            colormap = colormap.reshape(z.shape + (-1,))
 
         # 1 or 2 dimensional x and y data
         x_input = x if x1dim else xv
@@ -41,7 +43,10 @@ def test_surface_plot(x1dim:bool, y1dim:bool):
                               y=y_input,
                               shading=None)
         
-        surface.mesh_data.set_vertex_colors(colormap)
+        if use_vertex_colors:
+            surface.mesh_data.set_vertex_colors(colormap)
+        else:
+            surface.set_data(colors=colormap)
 
         # c.draw_visual(surface) 
         view.add(surface)


### PR DESCRIPTION
# Bug Description

Setting `colors` of `SurfacePlot` fails (see below code snippet).

```
from vispy import scene
from numpy.random import rand
p = scene.visuals.SurfacePlot(z=rand(6,6))
p.set_data(colors=rand(6,6,4))
```

# Solution

Fix reshape of colors array to be with a length four last dimension.
