### PR TITLE
Fix type of vertice passed to function for adding triangles

### DIFF
--- a/vispy/geometry/triangulation.py
+++ b/vispy/geometry/triangulation.py
@@ -185,7 +185,7 @@ class Triangulation(object):
                 for j in self._bottoms[self._tops == i]:
                     # Make sure edge (j, i) is present in mesh
                     # because edge event may have created a new front list
-                    self._edge_event(i, j)
+                    self._edge_event(i, int(j))
                     front = self._front
 
         self._finalize()


### PR DESCRIPTION
Since numpy 2.0 The `arr[ind]` is `np.int(64)`, not `int` that lead to not finding edge later when construct triangulation. 

This PR fixes it by converting it to python int. 