### PR TITLE
Fix bad_color handling and simplify some logic

### DIFF
--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -263,7 +263,6 @@ class BaseColormap(object):
         color = Color(color, alpha)
         self._bad_color = color
         r, g, b, a = color.rgba
-        print(color, r, g, b, a)
 
         if a == 0:
             ret_or_discard = "discard"

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -264,14 +264,9 @@ class BaseColormap(object):
         self._bad_color = color
         r, g, b, a = color.rgba
 
-        if a == 0:
-            ret_or_discard = "discard"
-        else:
-            ret_or_discard = f"return vec4({r:.3f}, {g:.3f}, {b:.3f}, {a:.3f})"
-
         bad_color_glsl = f"""// bad_color_start
         if (!(t <= 0.0 || 0.0 <= t)) {{
-            {ret_or_discard};
+            return vec4({r:.3f}, {g:.3f}, {b:.3f}, {a:.3f});
         }} // bad_color_end"""
 
         if '// bad_color_start' in self.glsl_map:

--- a/vispy/color/colormap.py
+++ b/vispy/color/colormap.py
@@ -159,11 +159,12 @@ def _glsl_mix(controls=None, colors=None, texture_map_data=None):
     LUT[:, 0, 2] = np.interp(x, controls, c_rgba[:, 2])
     LUT[:, 0, 3] = np.interp(x, controls, c_rgba[:, 3])
 
-    s2 = "uniform sampler2D texture2D_LUT;"
-    s = "{\n return texture2D(texture2D_LUT, \
-          vec2(0.0, clamp(t, 0.0, 1.0)));\n} "
-
-    return "%s\nvec4 colormap(float t) {\n%s\n}" % (s2, s)
+    return """
+    uniform sampler2D texture2D_LUT;
+    vec4 colormap(float t) {
+        return texture2D(texture2D_LUT, vec2(0.0, clamp(t, 0.0, 1.0)));
+    }
+    """
 
 
 def _glsl_step(controls=None, colors=None, texture_map_data=None):
@@ -193,11 +194,12 @@ def _glsl_step(controls=None, colors=None, texture_map_data=None):
     colors_rgba = ColorArray(colors[:])._rgba
     LUT[:, 0, :] = colors_rgba[j]
 
-    s2 = "uniform sampler2D texture2D_LUT;"
-    s = "{\n return texture2D(texture2D_LUT, \
-           vec2(0.0, clamp(t, 0.0, 1.0)));\n} "
-
-    return "%s\nvec4 colormap(float t) {\n%s\n}" % (s2, s)
+    return """
+    uniform sampler2D texture2D_LUT;
+    vec4 colormap(float t) {
+        return texture2D(texture2D_LUT, vec2(0.0, clamp(t, 0.0, 1.0)));
+    }
+    """
 
 
 # Mini GLSL template system for colors.
@@ -257,16 +259,26 @@ class BaseColormap(object):
         self.set_bad_color()
 
     def set_bad_color(self, color=(0, 0, 0, 0), alpha=None):
+        color = (0, 0, 0, 0) if color is None else color
         color = Color(color, alpha)
         self._bad_color = color
         r, g, b, a = color.rgba
-        vecstr = f'vec4({r:.3f}, {g:.3f}, {b:.3f}, {a:.3f})'
+        print(color, r, g, b, a)
 
-        if '!(t <= 0.0 || 0.0 <= t)' in self.glsl_map:
-            self.glsl_map = re.sub(r'return vec4\([^\)]+\); // bad', f'return {vecstr}; // bad', self.glsl_map, count=1)
+        if a == 0:
+            ret_or_discard = "discard"
         else:
-            if_statement = f"\nif (!(t <= 0.0 || 0.0 <= t)) {{\nreturn {vecstr}; // bad\n}}"
-            self.glsl_map = re.sub(r'float t\) \{', f'float t) {{{if_statement}', self.glsl_map)
+            ret_or_discard = f"return vec4({r:.3f}, {g:.3f}, {b:.3f}, {a:.3f})"
+
+        bad_color_glsl = f"""// bad_color_start
+        if (!(t <= 0.0 || 0.0 <= t)) {{
+            {ret_or_discard};
+        }} // bad_color_end"""
+
+        if '// bad_color_start' in self.glsl_map:
+            self.glsl_map = re.sub(r'// bad_color_start.*// bad_color_end', bad_color_glsl, self.glsl_map, count=1, flags=re.DOTALL)
+        else:
+            self.glsl_map = re.sub(r'float t\) \{', f'float t) {{{bad_color_glsl}', self.glsl_map)
 
     def get_bad_color(self):
         return self._bad_color

--- a/vispy/color/tests/test_color.py
+++ b/vispy/color/tests/test_color.py
@@ -349,4 +349,19 @@ def test_normalize():
     assert_allclose([y.min(), y.max()], [0.2975, 1-0.2975], 1e-1, 1e-1)
 
 
+def test_colormap_bad_color():
+    """Test NaN handling."""
+    fire = get_colormap('fire')
+    assert_array_equal(fire[np.nan].rgba, np.zeros((1, 4)))
+
+    green = (0, 1, 0, 1)
+    fire.set_bad_color(green)
+    assert_array_equal(fire[np.nan].rgba, [green])
+    assert_array_equal(fire.get_bad_color(), green)
+
+    fire.set_bad_color()
+    assert_array_equal(fire[np.nan].rgba, np.zeros((1, 4)))
+
+
+
 run_tests_if_main()

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -89,27 +89,11 @@ _TEXTURE_LOOKUP = """
         return texture2D($texture, texcoord);
     }"""
 
-
-_HANDLE_BAD_COLOR = """
-    vec4 handle_bad_color(vec4 data) {
-        // If data is NaN, use the bad_color or discard the fragment,
-        // otherwise pass the data through
-        // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
-        if (!(data.r <= 0.0 || 0.0 <= data.r) || !(data.g <= 0.0 || 0.0 <= data.g) || !(data.b <= 0.0 || 0.0 <= data.b) || !(data.a <= 0.0 || 0.0 <= data.a)) {
-            if ($bad_color.a == 0) {
-                // more perfomant to not render the fragment
-                discard;
-            } else {
-                return $bad_color;
-            }
-        } else {
-            return data;
-        }
-    }
-"""
-
 _APPLY_CLIM_FLOAT = """
     float apply_clim(float data) {
+        // pass through NaN values to get handled by the colormap
+        if (!(data <= 0.0 || 0.0 <= data)) return data;
+
         data = clamp(data, min($clim.x, $clim.y), max($clim.x, $clim.y));
         data = (data - $clim.x) / ($clim.y - $clim.x);
         return data;
@@ -117,7 +101,7 @@ _APPLY_CLIM_FLOAT = """
 
 _APPLY_CLIM = """
     vec4 apply_clim(vec4 color) {
-        // Handle NaN values
+        // Handle NaN values (clamp them to the minimum value)
         // http://stackoverflow.com/questions/11810158/how-to-deal-with-nan-or-inf-in-opengl-es-2-0-shaders
         color.r = !(color.r <= 0.0 || 0.0 <= color.r) ? min($clim.x, $clim.y) : color.r;
         color.g = !(color.g <= 0.0 || 0.0 <= color.g) ? min($clim.x, $clim.y) : color.g;
@@ -131,6 +115,9 @@ _APPLY_CLIM = """
 
 _APPLY_GAMMA_FLOAT = """
     float apply_gamma(float data) {
+        // pass through NaN values to get handled by the colormap
+        if (!(data <= 0.0 || 0.0 <= data)) return data;
+
         return pow(data, $gamma);
     }"""
 
@@ -143,7 +130,7 @@ _APPLY_GAMMA = """
 
 _NULL_COLOR_TRANSFORM = 'vec4 pass(vec4 color) { return color; }'
 
-_C2L_RED = 'float cmap(vec4 color) { return color.r; }'
+_C2L_RED = 'float color_to_luminance(vec4 color) { return color.r; }'
 
 _CUSTOM_FILTER = """
 vec4 texture_lookup(vec2 texcoord) {
@@ -273,7 +260,6 @@ class ImageVisual(Visual):
         'texture_lookup': _TEXTURE_LOOKUP,
         'clim_float': _APPLY_CLIM_FLOAT,
         'clim': _APPLY_CLIM,
-        'bad_color': _HANDLE_BAD_COLOR,
         'gamma_float': _APPLY_GAMMA_FLOAT,
         'gamma': _APPLY_GAMMA,
         'null_color_transform': _NULL_COLOR_TRANSFORM,
@@ -472,6 +458,17 @@ class ImageVisual(Visual):
         self.update()
 
     @property
+    def bad_color(self):
+        """Color used to render NaN values."""
+        return self._cmap.get_bad_color()
+
+    @bad_color.setter
+    def bad_color(self, color):
+        self._cmap.set_bad_color(color)
+        self._need_colortransform_update = True
+        self.update()
+
+    @property
     def method(self):
         """Get rendering method name."""
         return self._method
@@ -654,23 +651,18 @@ class ImageVisual(Visual):
     def _build_color_transform(self):
         if self._data.ndim == 2 or self._data.shape[2] == 1:
             # luminance data
-            # bad_color handling is part of the colormap already, not needed here,
-            # but we put a noop functions to simplify indexing in the different cases
-            fbad = Function('float noop (float data) {return data;}')
             fclim = Function(self._func_templates['clim_float'])
             fgamma = Function(self._func_templates['gamma_float'])
             # NOTE: red_to_luminance only uses the red component, fancy internalformats
             #   may need to use the other components or a different function chain
             fun = FunctionChain(
-                None, [Function(self._func_templates['red_to_luminance']), fbad, fclim, fgamma, Function(self.cmap.glsl_map)]
+                None, [Function(self._func_templates['red_to_luminance']), fclim, fgamma, Function(self.cmap.glsl_map)]
             )
         else:
             # RGB/A image data (no colormap)
-            fbad = Function(self._func_templates['bad_color'])
-            fbad['bad_color'] = self.cmap.get_bad_color().rgba
             fclim = Function(self._func_templates['clim'])
             fgamma = Function(self._func_templates['gamma'])
-            fun = FunctionChain(None, [Function(self._func_templates['null_color_transform']), fbad, fclim, fgamma])
+            fun = FunctionChain(None, [Function(self._func_templates['null_color_transform']), fclim, fgamma])
         fclim['clim'] = self._texture.clim_normalized
         fgamma['gamma'] = self.gamma
         return fun

--- a/vispy/visuals/image.py
+++ b/vispy/visuals/image.py
@@ -428,7 +428,7 @@ class ImageVisual(Visual):
             return
         else:
             # shortcut so we don't have to rebuild the whole color transform
-            self.shared_program.frag['color_transform'][2]['clim'] = norm_clims
+            self.shared_program.frag['color_transform'][1]['clim'] = norm_clims
 
     @property
     def cmap(self):
@@ -454,7 +454,7 @@ class ImageVisual(Visual):
         self._gamma = float(value)
         # shortcut so we don't have to rebuild the color transform
         if not self._need_colortransform_update:
-            self.shared_program.frag['color_transform'][3]['gamma'] = self._gamma
+            self.shared_program.frag['color_transform'][2]['gamma'] = self._gamma
         self.update()
 
     @property
@@ -639,7 +639,7 @@ class ImageVisual(Visual):
             self._need_colortransform_update = True
         elif new_cl and not self._need_colortransform_update:
             # shortcut so we don't have to rebuild the whole color transform
-            self.shared_program.frag['color_transform'][2]['clim'] = self._texture.clim_normalized
+            self.shared_program.frag['color_transform'][1]['clim'] = self._texture.clim_normalized
         self._need_texture_upload = False
 
     def _compute_bounds(self, axis, view):


### PR DESCRIPTION
Unfortunately I still had unresolved issues when merging #2659. That's what I get for not manually checking if things work one more time after changing "obvious" things...

The main issue is that the order of application of clim, gamma and bad_color were conflicting. By passing through NaN values to the colormap (the last to be applied) fixed and simplified the code significantly on the ImageVisual side.

Anyways, here's a functioning version. To test, use this snipped adapted from #2620:

```py
import sys
from vispy import scene, app
from vispy.color import get_colormap
import numpy as np


canvas = scene.SceneCanvas(keys='interactive', bgcolor='white')
canvas.size = 600, 800
view = canvas.central_widget.add_view()

img_data = np.zeros((500, 500), np.float32)
for i in range(10):
    img_data[i*50:(i+1)*50, :] = i

img_data[:, 20:60] = np.nan

image = scene.visuals.Image(img_data, 
                            cmap='fire',
                            clim=[1, 8],
                            interpolation='cubic', 
                            texture_format='auto')
view.add(image)

view.camera = scene.cameras.TurntableCamera()
view.camera.set_range()
canvas.show()
```

The bad color can now be handled from the image visual directly:

```py
image.bad_color = (0, 1, 0, 1)
```

