### PR TITLE
Bump ubuntu version used for build wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-latest, macos-13, ubuntu-22.04-arm]
+        os: [ubuntu-24.04, windows-2019, macOS-latest, macos-13, ubuntu-24.04-arm]
         arch: [auto]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
In #2600 there is canceled workflow running on ubuntu 20.04.

In five days it will be fully removed. I expect that it may be connected:
https://github.com/actions/runner-images/issues/11101