### PR TITLE
Skip conda pyopengl 3.1.9

### DIFF
--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -16,7 +16,7 @@ pysdl2
 pytest
 pytest-cov
 pytest-sugar
-pyopengl!=3.1.7,!=3.1.9
+pyopengl!=3.1.7,!=3.1.8,!=3.1.9
 scikit-image
 scipy
 networkx

--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -16,7 +16,7 @@ pysdl2
 pytest
 pytest-cov
 pytest-sugar
-pyopengl!=3.1.7
+pyopengl!=3.1.7,!=3.1.9
 scikit-image
 scipy
 networkx


### PR DESCRIPTION
Continuing issue from #2636.

For context: there's currently some issue with the conda-forge package for pyopengl. It's causing several problems (not just our CI failures). We are in the process of figuring out the issue, but for the time being we just blacklist these versions here. This only affects CI and it allows us to actually cut a release.