### PR TITLE
change cancelation policy of wheel workflow to base on ref

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,7 +2,7 @@ name: cibuildwheel
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 # https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  group: ${{ github.ref }}-${{ github.event.type }}
   cancel-in-progress: true
 
 on: [push, pull_request]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,7 +2,7 @@ name: cibuildwheel
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 # https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
 concurrency:
-  group: ${{ github.ref }}-${{ github.event.type }}
+  group: wheel-${{ github.ref }}-${{ github.event.type }}
   cancel-in-progress: true
 
 on: [push, pull_request]


### PR DESCRIPTION
implements https://github.com/vispy/vispy/pull/2672#issuecomment-2882016826

github ref contains branch trigger name, so fon main it will be `refs/heads/main` but for tagged commit something like `refs/heads/tag` 

Each PR has a unique ref, but I left `event_type` for in-repo PRs 