### PR TITLE
Fix padding in grid widget

### DIFF
--- a/vispy/scene/widgets/grid.py
+++ b/vispy/scene/widgets/grid.py
@@ -555,7 +555,7 @@ class Grid(Widget):
         if ymax <= 0 or xmax <= 0:
             return
 
-        rect = self.rect  # .padded(self.padding + self.margin)
+        rect = self.rect.padded(self.padding + self.margin)
         if rect.width <= 0 or rect.height <= 0:
             return
         if self._need_solver_recreate:
@@ -607,6 +607,9 @@ class Grid(Widget):
                 y = 0
             else:
                 y = np.sum(value_vectorized(self._height_grid[col][:row])) + spacing_height_offset
+
+            x += self.padding
+            y += self.padding
 
             if isinstance(widget, ViewBox):
                 widget.rect = Rect(x, y, width, height)


### PR DESCRIPTION
Following up #2671, I noticed that the `padding` was essentially disabled in the grid.

This was pretty simple to reenable!

Here's the code from the discussion in #2671 plus just `grid.padding = 20`:


![image](https://github.com/user-attachments/assets/5c64e024-befb-42d9-8ad8-5c8b410130a8)

cc @melonora 