### PR TITLE
Only use last 2 event dimensions for arcball calculation

### DIFF
--- a/vispy/scene/cameras/arcball.py
+++ b/vispy/scene/cameras/arcball.py
@@ -60,8 +60,9 @@ class ArcballCamera(Base3DRotationCamera):
         if self._event_value is None:
             self._event_value = p2
         wh = self._viewbox.size
+        p1 = self._event_value[:2]
         self._quaternion = (Quaternion(*_arcball(p2, wh)) *
-                            Quaternion(*_arcball(self._event_value, wh)) *
+                            Quaternion(*_arcball(p1, wh)) *
                             self._quaternion)
         self._event_value = p2
         self.view_changed()


### PR DESCRIPTION
When using arcball camera and pressing shift to switch from rotating panning, if shift is released before the drag is finished, one receives this traceback:


```py
Traceback (most recent call last):
  File ".../lib/site-packages/vispy/util/event.py", line 469, in _invoke_callback
    cb(event)
  File ".../lib/site-packages/napari/_vispy/camera.py", line 244, in viewbox_mouse_event
<class 'TypeError'> SceneMouseEvent type 'mouse_move' has no scale <traceback object at 0x000002867B3AFE00>
    super().viewbox_mouse_event(event)
  File ".../lib/site-packages/vispy/scene/cameras/perspective.py", line 233, in viewbox_mouse_event
    self._update_rotation(event)
  File ".../lib/site-packages/vispy/scene/cameras/arcball.py", line 65, in _update_rotation
    Quaternion(*_arcball(self._event_value, wh)) *
  File ".../lib/site-packages/vispy/scene/cameras/arcball.py", line 101, in _arcball
    x, y = xy
ValueError: too many values to unpack (expected 2)

[...]
```


This is because in that specific moment, the event received will have a 3dimensional position instead of a 2D canvas position. I simply copied how the `p2` wa taking the last 2 dims, and everything works fine.


Related issues:

- https://forum.image.sc/t/sometimes-the-3d-viewer-of-napari-crashes-when-moving-the-center-of-the-camera/112571
- https://github.com/napari/napari/issues/6806

