### PR TITLE
Bug fix: Incorrectly passed flag to re.sub

### DIFF
--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -245,7 +245,7 @@ class Program(GLObject):
         """Parse uniforms, attributes and varyings from the source code."""
         # Get one string of code with comments removed
         code = '\n\n'.join([sh.code for sh in self._shaders])
-        code = re.sub(r'(.*)(//.*)', r'\1', code, re.M)
+        code = re.sub(r'(.*)(//.*)', r'\1', code, flags=re.M)
 
         # Parse uniforms, attributes and varyings
         self._code_variables = {}


### PR DESCRIPTION
The code uses `re.M` as a positional argument instead of as a keyword argument in the `re.sub()` function. This is incorrect because `re.sub()` expects the fourth argument to be count (the maximum number of pattern occurrences to replace), not the flags. 

The bug was found due to the deprecation warning in Python 3.13:
```
vispy/vispy/gloo/program.py:248: DeprecationWarning: 'count' is passed as positional argument!
```