### PR TITLE
Keep hold of vertex data on cpu

### DIFF
--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -425,6 +425,7 @@ class TextVisual(Visual):
         self._bold = bold
         self._italic = italic
         self._update_font()
+        self._vertices_data = None
         self._vertices = None
         self._color_vbo = None
         self._anchors = (anchor_x, anchor_y)
@@ -530,7 +531,7 @@ class TextVisual(Visual):
             n_char = sum(len(t) for t in text)
             # we delay creating vertices because it requires a context,
             # which may or may not exist when the object is initialized
-            self._vertices = np.concatenate([
+            self._vertices_data = np.concatenate([
                 _text_to_vbo(t, self._font, self._anchors[0], self._anchors[1],
                              self._font._lowres_size) for t in text])
             self._vertices = VertexBuffer(self._vertices)


### PR DESCRIPTION
Currently it's impossible to get any info about the *rendered* dimensions of the text. This is relevant for things like https://github.com/napari/napari/pull/7836, where we need to know how *big* the rendered text is on the cpu.

In order to allow downstream users to infer things like this, it pretty easy for us to simply save the original vertex buffer on the CPU. I hesitate to expose publicly, but at least this will unblock the feature above.