### PR TITLE
Use newer windows runner in ci

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2022, macOS-latest, macos-13, ubuntu-24.04-arm]
+        os: [ubuntu-latest, windows-2025, macOS-latest, macos-13, ubuntu-24.04-arm]
         arch: [auto]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest, macos-13, ubuntu-24.04-arm]
+        os: [ubuntu-latest, windows-2025, macOS-latest, macos-13, ubuntu-24.04-arm]
         arch: [auto]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2025, macOS-latest, macos-13, ubuntu-24.04-arm]
+        os: [ubuntu-latest, windows-2022, macOS-latest, macos-13, ubuntu-24.04-arm]
         arch: [auto]
     steps:
     - uses: actions/checkout@v4

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -12,6 +12,7 @@ import pytest
 known_bad_fonts = set([
     'Noto Color Emoji',  # https://github.com/vispy/vispy/issues/1771
     'Bahnschrift',  # https://github.com/vispy/vispy/pull/1974
+    'Segoe UI',  # https://github.com/vispy/vispy/pull/2689
 ])
 
 # try both a vispy and system font   <--- what does this mean???

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -30,7 +30,7 @@ def test_font_list():
 @pytest.mark.parametrize('face', ['OpenSans'] + sorted(sys_fonts))
 def test_font_glyph(face):
     """Test loading glyphs"""
-    if face in known_bad_fonts or face.split(" ")[0] in known_bad_fonts:
+    if any(face.startswith(font_name) for font_name in known_bad_fonts):
         pytest.xfail()
     font_dict = dict(face=face, size=12, bold=False, italic=False)
     glyphs_dict = dict()

--- a/vispy/util/fonts/tests/test_font.py
+++ b/vispy/util/fonts/tests/test_font.py
@@ -12,7 +12,7 @@ import pytest
 known_bad_fonts = set([
     'Noto Color Emoji',  # https://github.com/vispy/vispy/issues/1771
     'Bahnschrift',  # https://github.com/vispy/vispy/pull/1974
-    'Segoe UI',  # https://github.com/vispy/vispy/pull/2689
+    'Segoe UI Variable',  # https://github.com/vispy/vispy/pull/2689
 ])
 
 # try both a vispy and system font   <--- what does this mean???


### PR DESCRIPTION
Tests are failing because we're using an outdated windows runner.