### PR TITLE
discard marker fragments if size was zero

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -102,10 +102,21 @@ varying float v_depth_middle;
 varying float v_alias_ratio;
 varying float v_symbol;
 
+
+bool isnan(float val) {
+  return ( val < 0.0 || 0.0 < val || val == 0.0 ) ? false : true;
+}
+
+bool isinf(float val) {
+    return (val != 0.0 && val * 2.0 == val) ? true : false;
+}
+
 void main()
 {
-    // Discard plotting marker body and edge if zero-size
-    if ($v_size <= 0.)
+    // Discard plotting marker body and edge if zero-size or nan/inf.
+    // Sometimes edgewidth becomes nan/inf even if size is not exactly zero here due to float
+    // imprecision. We really are checking for `a_size == 0`, but this is the fragment shader proxy
+    if ($v_size <= 0. || isnan($v_size) || isinf($v_size) || isnan(v_edgewidth) || isinf(v_edgewidth))
         discard;
 
     float edgealphafactor = min(v_edgewidth, 1.0);


### PR DESCRIPTION
Noticed when working on https://github.com/napari/napari/pull/8223.

In some hardware (linux + nvidia is at least one), setting the size of markers to `0` results in a value of `inf` for the border width due to a division by zero.
This can have crazy results like the above link. In general, if the point size is 0 we should simply not render it, I think, so this PR simply discards the affected fragments.
