### PR TITLE
Expose modifiers in SceneMouseEvent API

### DIFF
--- a/vispy/scene/events.py
+++ b/vispy/scene/events.py
@@ -67,6 +67,13 @@ class SceneMouseEvent(Event):
         return self.mouse_event.buttons
 
     @property
+    def modifiers(self):
+        """Tuple that specifies which modifier keys were pressed down at the
+        time of the event (shift, control, alt, meta).
+        """
+        return self.mouse_event.modifiers
+
+    @property
     def delta(self):
         """The increment by which the mouse wheel has moved."""
         return self.mouse_event.delta


### PR DESCRIPTION
Hi!

For my use case I would like to know whether shift was pressed when a `SceneMouseEvent` happened, but the docs gave me no indication of such a function. By reading the source code I found out that I could grab them via the `mouse_event` attribute, but I figure it's not supposed to be accessed directly because it's not marked as a property. This PR thus exposes the modifiers as a property of `SceneMouseEvent`.