### PR TITLE
Revert pyopengl pin with `LD_PRELOAD` workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,6 +266,12 @@ jobs:
       run: |
         if [ "${{ matrix.test }}" == 'standard' ]; then
           export DISPLAY=:99.0
+          # this is a workaround for pyopengl 3.1.7+ that changed library resolution order
+          # the new version breaks vispy SDL2 tests in CI, but has not been reproduced locally
+          # see previous discussions in:
+          # * https://github.com/vispy/vispy/pull/2636
+          # * https://github.com/vispy/vispy/pull/2668
+          # * https://github.com/vispy/vispy/pull/2673
           export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGL.so.1
           python make test unit --tb=short
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,6 +266,7 @@ jobs:
       run: |
         if [ "${{ matrix.test }}" == 'standard' ]; then
           export DISPLAY=:99.0
+          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGL.so.1
           python make test unit --tb=short
         fi
         if [ "${{ matrix.test }}" == 'osmesa' ]; then

--- a/ci/requirements/linux_full_deps_conda.txt
+++ b/ci/requirements/linux_full_deps_conda.txt
@@ -16,7 +16,7 @@ pysdl2
 pytest
 pytest-cov
 pytest-sugar
-pyopengl!=3.1.7,!=3.1.8,!=3.1.9
+pyopengl
 scikit-image
 scipy
 networkx


### PR DESCRIPTION
This reverts the pyopengl pin as in #2673 but adds a workaround that let CI pass in my fork.

As best I can understand the issue, pyopengl changed slightly the way it resolves shared libraries in https://github.com/mcfletch/pyopengl/pull/93 (v3.1.7+), which conflicts with how `sdl2` loads the same libraries or expects to find symbols in them...somehow. I can look into an upstream PR to pyopengl to resolve this, but that will take some time and I'm not super confident about making changes there (this is pretty convoluted for me to test).

This PR adds `LD_PRELOAD` (which I admit to not fully understanding) to change which symbols are prioritized when pyopengl loads openGL libraries.

I don't think anyone has reported these issues outside of CI, so I think this workaround is reasonable. If anyone reports such a bug with local usage, hopefully this is a practical workaround for them as well. I'm not sure how often people are using the SDL2 backend anyway, but this feels better than the pyopengl pins/exlusions to me.