### PR TITLE
Add parameter to control line height in text visual

### DIFF
--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -258,8 +258,8 @@ def _text_to_vbo(text, font, anchor_x, anchor_y, lowres_size, line_height):
     # trigger SDF rendering, which changes our viewport
     # todo: get rid of call to glGetParameter!
 
-    # Also analyse chars with large ascender and descender, otherwise the
-    # vertical alignment can be very inconsistent
+    # Also analyse chars with large ascender, capitals with diacritics,
+    # and descender, otherwise the vertical alignment can be very inconsistent
     for char in 'ÅÉÑŐjgpqy':
         glyph = font[char]
         y0 = glyph['offset'][1] * ratio + slop
@@ -411,7 +411,7 @@ class TextVisual(Visual):
     }
 
     def __init__(self, text=None, color='black', bold=False,
-                 italic=False, face='OpenSans', font_size=12, line_height=1.2, pos=[0, 0, 0],
+                 italic=False, face='OpenSans', font_size=12, line_height=1.1, pos=[0, 0, 0],
                  rotation=0., anchor_x='center', anchor_y='center',
                  method='cpu', font_manager=None, depth_test=False):
         Visual.__init__(self, vcode=self._shaders['vertex'], fcode=self._shaders['fragment'])


### PR DESCRIPTION
Small addition that allows to set the line height in the text visual.

```py
from vispy import scene
from vispy.scene.visuals import Text

# Create canvas with a viewbox at the lower half
canvas = scene.SceneCanvas(keys='interactive')

t1 = Text('Line height\nis default 1.5', parent=canvas.scene, color='red', font_size=20, line_height=1.5)
t2 = Text('Line height\nlowered to 1', parent=canvas.scene, color='blue', font_size=20, line_height=1)
t3 = Text('Line height\nincreased to 2', parent=canvas.scene, color='magenta', font_size=20, line_height=2)

t1.pos = canvas.size[0] // 2, (canvas.size[1] // 4) * 1
t2.pos = canvas.size[0] // 2, (canvas.size[1] // 4) * 2
t3.pos = canvas.size[0] // 2, (canvas.size[1] // 4) * 3

if __name__ == '__main__':
    canvas.show()
    canvas.app.run()
```

<img width="802" height="602" alt="image" src="https://github.com/user-attachments/assets/939fa8e4-1062-4cde-b588-ba1c7a61b310" />
