### PR TITLE
Allow local font registration

### DIFF
--- a/vispy/util/fonts/__init__.py
+++ b/vispy/util/fonts/__init__.py
@@ -11,4 +11,4 @@ fonts.
 __all__ = ['list_fonts']
 
 from ._triage import _load_glyph, list_fonts  # noqa, analysis:ignore
-from ._vispy_fonts import _vispy_fonts  # noqa, analysis:ignore
+from ._vispy_fonts import _vispy_fonts, register_vispy_font  # noqa, analysis:ignore

--- a/vispy/util/fonts/_vispy_fonts.py
+++ b/vispy/util/fonts/_vispy_fonts.py
@@ -4,10 +4,11 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 # -----------------------------------------------------------------------------
 
-import os.path as op
+from pathlib import Path
 
 # List the vispy fonts made available online
-_vispy_fonts = ('OpenSans',)
+_vispy_fonts = {'OpenSans'}
+_vispy_font_dirs = {Path(__file__).parent / 'data'}
 
 
 def _get_vispy_font_filename(face, bold, italic):
@@ -16,5 +17,12 @@ def _get_vispy_font_filename(face, bold, italic):
     name += 'Regular' if not bold and not italic else ''
     name += 'Bold' if bold else ''
     name += 'Italic' if italic else ''
-    name += '.ttf'
-    return op.join(op.dirname(__file__), 'data', name)
+    for font_dir in _vispy_font_dirs:
+        if (fontfile := font_dir / f'{name}.ttf').exists():
+            return str(fontfile)
+    raise ValueError(f'Font "{name}" is not available. Did you forget to register it?')
+
+
+def register_vispy_font(path, face, bold, italic):
+    _vispy_fonts.add(face)
+    _vispy_font_dirs.add(Path(path))


### PR DESCRIPTION
Allow registering local fonts other than the vispy-provided one, without forcing to use complex runtime quartz/freetype workarounds (see napari/napari#8117 for context).

Despite being in theory super easy to register a new font with vispy (we just need the `_vispy_fonts` tuple to be modified and the `_get_vispy_font_filename()` function to also search elsewhere), this is basically impossible to do downstream, because this tuple is immutable and imported everywhere. I tried monkeypatching in many ways, to no avail.

I think this is a pretty small change for a great benefit :)
