### PR TITLE
Delay importing networkx to NetworkxCoordinates.__init__

### DIFF
--- a/vispy/visuals/graphs/layouts/networkx_layout.py
+++ b/vispy/visuals/graphs/layouts/networkx_layout.py
@@ -3,11 +3,6 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.#!/usr/bin/env python3
 from ..util import _straight_line_vertices, issparse
 import numpy as np
-try:
-    import networkx as nx
-except ModuleNotFoundError:
-    nx = None
-
 
 class NetworkxCoordinates:
     def __init__(self, graph=None, layout=None, **kwargs):
@@ -24,7 +19,9 @@ class NetworkxCoordinates:
         kwargs: dict, optional
         when layout is :str: :kwargs: will act as a setting dictionary for the layout function of networkx
         """
-        if nx is None:
+        try:
+            import networkx as nx
+        except ModuleNotFoundError:
             raise ValueError("networkx not found, please install networkx to use its layouts")
         if isinstance(graph, type(None)):
             raise ValueError("Requires networkx input")


### PR DESCRIPTION
The main motivation is napari, where we use a lot of `vispy.visuals` imports which pulls along networkx, but we don't use `vispy.visuals.graphs.layouts.networkx_layout` so it's a waste of time for our users. Using import timings of napari, networkx is a ~100 ms import that is eagerly triggered by any `vispy.visuals` import, e.g. on main:
`python -X importtime -c 'from vispy.visuals import VolumeVisual' 2>&1 | grep networkx`:
`import time:      6083 |      56805 |           networkx`
(I'm not sure why it's 60 ms in a pure vispy env vs napari import)

And the total import (on main, 2nd run): `python -X importtime -c 'from vispy.visuals import VolumeVisual'`
`import time:       194 |     230860 | vispy.visuals`

In this PR the import is moved into the class, so it's not eagerly imported:
```
python -X importtime -c 'from vispy.visuals import VolumeVisual' 2>&1 | grep networkx
import time:       847 |        847 |         vispy.visuals.graphs.layouts.networkx_layout
```
And the total import 2nd run): `python -X importtime -c 'from vispy.visuals import VolumeVisual'`
`import time:       195 |     172709 | vispy.visuals`

