### PR TITLE
Fix: Account for newline when positioning first text character

### DIFF
--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -310,7 +310,7 @@ def _text_to_vbo(text, font, anchor_x, anchor_y, lowres_size, line_height):
                 elif anchor_x == 'center':
                     dx = -width / 2.
                 vertices['a_position'][vi_marker:vi+4] += (dx, dy)
-                vi_marker = vi+4
+                vi_marker = (ii + ii_offset) * 4
                 ii_offset -= 1
                 # Reset variables that affects x-direction positioning
                 x_off = -slop


### PR DESCRIPTION
I observed an issue in a napari example: https://napari.org/stable/gallery/3Dimage_plane_rendering.html, as observed in the lower right of the screenshot, the first word "shift" is missing its "s". I was aided by Copilot to track this down to Vispy's calculation of the first position of the character. If the first character has "0" as its value for vi which is how I understand `/n`) then it would not be positioned properly. 
This PR uses the iterating index and its offset so that no matter the value of the first character, letters will get positioned correctly. I actually don't know if this is the correct fix because vispy code is not my forte.

I modified the text example to show this:
```python
import sys

from vispy import scene
from vispy.scene.visuals import Text

# Create canvas with a viewbox at the lower half
canvas = scene.SceneCanvas(keys='interactive')
vb = scene.widgets.ViewBox(parent=canvas.scene, border_color='b')


@canvas.events.resize.connect
def resize(event=None):
    vb.pos = 1, canvas.size[1] // 2 - 1
    vb.size = canvas.size[0] - 2, canvas.size[1] // 2 - 2

test_text = (
"""
abcdefg
hijklgmnop
"""
)

t1 = Text(test_text, parent=canvas.scene, color='red')
t1.font_size = 24
t1.pos = canvas.size[0] // 2, canvas.size[1] // 3

if __name__ == '__main__':
    canvas.show()
    if sys.flags.interactive != 1:
        canvas.app.run()
```


Main: 

<img width="1191" height="897" alt="image" src="https://github.com/user-attachments/assets/2e23f6ca-17fc-42e6-8460-335fa5119231" />


This PR:

<img width="1194" height="898" alt="image" src="https://github.com/user-attachments/assets/3ca36fe8-2981-4217-b473-b48f03067cda" />

