### PR TITLE
Change `logger.warn` to `logger.warning` to silence deprecation warning

### DIFF
--- a/vispy/util/svg/group.py
+++ b/vispy/util/svg/group.py
@@ -26,7 +26,7 @@ class Group(Transformable):
             elif tag == "path":
                 item = Path(element, self)
             else:
-                logger.warn("Unhandled SVG tag (%s)" % tag)
+                logger.warning("Unhandled SVG tag (%s)" % tag)
                 continue
             self._items.append(item)
 


### PR DESCRIPTION
In napari tests we got

```
src/napari/_vispy/_tests/test_canvas.py::test_viewer_overlays
src/napari/_vispy/_tests/test_canvas.py::test_viewer_overlays
src/napari/_vispy/_tests/test_canvas.py::test_viewer_overlays
  /tmp/.tox/py310-linux-pyqt5-no_cov/lib/python3.10/site-packages/vispy/util/svg/group.py:29: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn("Unhandled SVG tag (%s)" % tag)
```

This PR solves this warning. 