### PR TITLE
Update for new jupyter_rfb and add experimental Marimo support

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -55,7 +55,7 @@ context. This can be done using any one of the following.
      - Experimental
      - pyopengltk
 
-You can also use a Jupyter notebook with visualizations appearing inline with the ``jupyter_rfb`` backend (requires ``jupyter_rfb`` package).
+You can also use a notebook (Jupyter/VSCode/Colab) with visualizations appearing inline with the ``jupyter_rfb`` backend (requires ``jupyter_rfb`` package).
 
 .. warning::
 
@@ -180,12 +180,17 @@ You can install these versions of the package by doing:
 Jupyter Notebook and Lab
 ------------------------
 
-If you would like to use VisPy in a Jupyter Notebook and have the
+If you would like to use VisPy in a notebook and have the
 visualizations appear inline, we recommend using the "jupyter_rfb" backend.
 This backend depends on
 `jupyter_rfb library <https://jupyter-rfb.readthedocs.io/en/latest/>`_ which
 must be installed before your jupyter notebook or jupyter lab session is
 started.
+
+This backend supports anything that ``anywidget`` supports, e.g. Jupyter, VSCode, Google Colab, and Marimo.
+Marimo support is suboptimal: Vispy canvases *wrap* the native widget,
+and this does not work with Marimo. You can work around this limitation
+by using ``canvas._backend`` when displaying the widget.
 
 Note that the 'jupyter_rfb' library uses the "remote" jupyter kernel
 (the server) to do the drawing of your visualization and then sends the

--- a/vispy/app/application.py
+++ b/vispy/app/application.py
@@ -6,6 +6,7 @@
 
 from __future__ import division
 
+import __main__ as main_module
 import builtins
 import os
 import sys
@@ -116,7 +117,20 @@ class Application(object):
             return False
 
     def is_notebook(self):
-        """Determine if the user is executing in a Jupyter Notebook"""
+        """Determine if the user is executing in a Jupyter/Marimo Notebook"""
+
+        # Detect Marimo: https://github.com/marimo-team/marimo/discussions/8865
+        #
+        # For now, anywidgets that are wapped don't work in Marimo;
+        # our _repr_mimebundle_ delegation does not work. So users will have
+        # to display ``canvas._backend`` until that is fixed.
+        # See https://github.com/manzt/anywidget/issues/792
+        try:
+            main_module.__marimo__
+            return True
+        except AttributeError:
+            pass
+
         try:
             # 'get_ipython' is available in globals when running from
             # IPython/Jupyter

--- a/vispy/app/application.py
+++ b/vispy/app/application.py
@@ -6,7 +6,6 @@
 
 from __future__ import division
 
-import __main__ as main_module
 import builtins
 import os
 import sys
@@ -125,11 +124,9 @@ class Application(object):
         # our _repr_mimebundle_ delegation does not work. So users will have
         # to display ``canvas._backend`` until that is fixed.
         # See https://github.com/manzt/anywidget/issues/792
-        try:
-            main_module.__marimo__
-            return True
-        except AttributeError:
-            pass
+        if "marimo" in sys.modules:
+            if sys.modules["marimo"].running_in_notebook():
+                return True
 
         try:
             # 'get_ipython' is available in globals when running from

--- a/vispy/app/application.py
+++ b/vispy/app/application.py
@@ -119,11 +119,6 @@ class Application(object):
         """Determine if the user is executing in a Jupyter/Marimo Notebook"""
 
         # Detect Marimo: https://github.com/marimo-team/marimo/discussions/8865
-        #
-        # For now, anywidgets that are wapped don't work in Marimo;
-        # our _repr_mimebundle_ delegation does not work. So users will have
-        # to display ``canvas._backend`` until that is fixed.
-        # See https://github.com/manzt/anywidget/issues/792
         if "marimo" in sys.modules:
             if sys.modules["marimo"].running_in_notebook():
                 return True

--- a/vispy/app/backends/_jupyter_rfb.py
+++ b/vispy/app/backends/_jupyter_rfb.py
@@ -20,7 +20,7 @@ else:
 # -------------------------------------------------------------- capability ---
 
 capability = dict(
-    title=False,
+    title=True,
     size=True,
     position=False,
     show=False,
@@ -72,6 +72,9 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
 
     _double_click_supported = True
 
+    # Set jupyter_rfb bitmask to accept new style events with 'type' 'timestamp' and 'ratio'
+    _event_compatibility = 2
+
     def __init__(self, vispy_canvas, **kwargs):
         BaseCanvasBackend.__init__(self, vispy_canvas)
         RemoteFrameBuffer.__init__(self)
@@ -91,10 +94,17 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         self._vispy_update()
 
     def handle_event(self, ev):
-        type = ev["event_type"]
+        # From jupyter_rfb 1.0 it uses the renderview event spec wich was
+        # changed a tiny bit from the 0.x jupyter event spec.
+        # (event_type -> type, time_stamp -> timestamp, pixel_ratio -> ratio).
+        # We use ev.get() where necessary to make it backwards compatible.
+        # These could be removed when we pin jupyter_rfb to 1.x
+        type = ev.get("type", None) or ev["event_type"]
+        assert type
         if type == "resize":
             # Note that jupyter_rfb already throttles this event
-            w, h, r = ev["width"], ev["height"], ev["pixel_ratio"]
+            w, h = ev["width"], ev["height"],
+            r = ev.get("ratio", None) or ev["pixel_ratio"]
             self._logical_size = w, h
             self._physical_size = int(w * r), int(h * r)
             self._helper.set_physical_size(*self._physical_size)
@@ -216,7 +226,8 @@ class CanvasBackend(BaseCanvasBackend, RemoteFrameBuffer):
         pass
 
     def _vispy_set_title(self, title):
-        pass
+        self.title = title
+        self.has_titlebar = bool(title)  # show titlebar when a title is set
 
     def _vispy_set_size(self, w, h):
         self.css_width = f"{w}px"

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -526,8 +526,7 @@ class Canvas(object):
         if f is not None:
             return f(*args, **kwargs)
         else:
-            # Let Jupyter know this failed - otherwise the standard repr is not shown
-            raise NotImplementedError()
+            return {"text/plain": self.__repr__()}
 
     def _ipython_display_(self):
         """If the backend implements _ipython_display_, we proxy it here.


### PR DESCRIPTION
Jupyter_rfb underwent some massive refactoring lately to (finally) use anywidget!

### Compatibility

This PR updates to the new version, although it is still compatible with older versions of jupyter_rfb.

Jupyter_rfb has a flag to help in the transition process (`_event_compatibility`). This PR sets it to get the new-style events. This means that once Vispy uses this for say a year, jupyter_rfb can remove its compatibility logic for the old-style events.

Once the new jupyter_rfb has been tested in the field for a while, we can pin in to 1.x, and remove some of the compatibility code in *our* module.

### Titlebar

The new widget supports a titlebar, so we can show titles too. Currently I set it up to show the titlebar if there is a title, and hide it when the title is an empty string.

### Marimo

With anywidget, we can also use the marimo notebook! There are two open issues though. I just created/commented them, so we can wait for an answer.

* I'm not sure what the recommended way to detect Marimo is. I implemented something, but maybe a better method exists. See https://github.com/marimo-team/marimo/discussions/8865
* The `canvas._backend` is an anywidget, the `canvas` itself is not. In Marimo, the `_repr_mimetype_` delegation is not enough. See https://github.com/manzt/anywidget/issues/792
