### PR TITLE
[maint] Defer importing scipy.sparse

### DIFF
--- a/vispy/visuals/graphs/layouts/force_directed.py
+++ b/vispy/visuals/graphs/layouts/force_directed.py
@@ -13,13 +13,7 @@ reach a state which requires the minimum energy.
 
 import numpy as np
 
-try:
-    from scipy.sparse import issparse
-except ImportError:
-    def issparse(*args, **kwargs):
-        return False
-
-from ..util import _straight_line_vertices, _rescale_layout
+from ..util import _straight_line_vertices, _rescale_layout, issparse
 
 
 class fruchterman_reingold(object):

--- a/vispy/visuals/graphs/util.py
+++ b/vispy/visuals/graphs/util.py
@@ -14,7 +14,7 @@ def issparse(obj):
     try:
         from scipy.sparse import issparse as _issparse
         return _issparse(obj)
-    except ImportError:
+    except ModuleNotFoundError:
         return False
 
 

--- a/vispy/visuals/graphs/util.py
+++ b/vispy/visuals/graphs/util.py
@@ -10,11 +10,11 @@ A module containing several graph utility functions.
 
 import numpy as np
 
-try:
-    from scipy.sparse import issparse
-    from scipy import sparse
-except ImportError:
-    def issparse(*args, **kwargs):
+def issparse(obj):
+    try:
+        from scipy.sparse import issparse as _issparse
+        return _issparse(obj)
+    except ImportError:
         return False
 
 
@@ -36,14 +36,15 @@ def _ndarray_get_edges(adjacency_mat):
 
 
 def _get_directed_edges(adjacency_mat):
-    func = _sparse_get_edges if issparse(adjacency_mat) else _ndarray_get_edges
-
     if issparse(adjacency_mat):
+        from scipy import sparse
         triu = sparse.triu
         tril = sparse.tril
+        func = _sparse_get_edges
     else:
         triu = np.triu
         tril = np.tril
+        func = _ndarray_get_edges
 
     upper = triu(adjacency_mat)
     lower = tril(adjacency_mat)


### PR DESCRIPTION
Followup to: https://github.com/vispy/vispy/pull/2726
part of the efforts to improve napari startup time: https://github.com/napari/napari/issues/8689

Importing a visual also imports scipy.sparse via
vispy.visuals ->
  vispy.visuals.graphs -> vispy.visuals.graphs.layouts.random -> vispy.visuals.graphs.util -> scipy.sparse

In this PR I remove the duplicated code in `force_directed.py` and defer the import of scipy.sparse.

main, second run:
`python -X importtime -c 'from vispy.visuals import VolumeVisual' 2>&1 | grep scipy`
`import time:       250 |      73988 |             scipy.sparse`

this branch same command returns nothing.