### PR TITLE
Set depth buffer for gridlines

### DIFF
--- a/vispy/visuals/gridlines.py
+++ b/vispy/visuals/gridlines.py
@@ -18,6 +18,7 @@ uniform float u_border_width;
 vec4 grid_color(vec2 pos) {
     vec4 px_pos = $map_to_doc(vec4(pos, 0, 1));
     px_pos /= px_pos.w;
+    gl_FragDepth = px_pos.z * 0.5 + 0.5;
 
     // Compute vectors representing width, height of pixel in local coords
     vec4 local_pos = $map_doc_to_local(px_pos);

--- a/vispy/visuals/tests/test_gridlines.py
+++ b/vispy/visuals/tests/test_gridlines.py
@@ -8,7 +8,7 @@ Tests for GridLines
 
 import numpy as np
 
-from vispy.scene import GridLines, STTransform
+from vispy.scene import GridLines, STTransform, Rectangle, MatrixTransform
 from vispy.testing import (requires_application, TestingCanvas,
                            run_tests_if_main)
 
@@ -23,6 +23,45 @@ def test_gridlines():
         np.testing.assert_array_equal(render[50, 50], (0, 0, 0, 255))
 
         grid.grid_bounds = (-10, 10, -10, 10)
+        render = c.render()
+        np.testing.assert_array_equal(render[50, 50], (255, 255, 255, 255))
+
+
+@requires_application()
+def test_gridlines_depth():
+    with TestingCanvas(size=(80, 80)) as c:
+        view = c.central_widget.add_view() 
+        view.camera = 'arcball'
+
+        # create a grid and a rectangle; the rect is closed to the camera an should
+        # hide the grid if the depth tests are working
+        rect = Rectangle(center=(0, 0, 0), height=20, width=20, color='white', parent=view.scene)
+        rect.transform = MatrixTransform()
+        rect.transform.rotate(90, (1, 0, 0))
+        rect.transform.translate((0, -1, 0))
+
+        grid = GridLines(color='red', parent=view.scene)
+        grid.transform = MatrixTransform()
+        grid.transform.rotate(90, (1, 0, 0))
+
+        # translucent preset to ensure depth test
+        grid.update_gl_state(preset='translucent')
+        rect.update_gl_state(preset='translucent')
+
+        render = c.render()
+
+        # should be all white
+        np.testing.assert_array_equal(render[40, 40], (255, 255, 255, 255))
+        np.testing.assert_array_equal(render[45, 45], (255, 255, 255, 255))
+
+        # move the rect behind, we should now see the grid
+        rect.transform.translate((0, 2, 0))
+        render = c.render()
+
+        # not pure red in the render due to interpolation, but should be non-white
+        np.testing.assert_array_equal(render[40, 40], (255, 104, 104, 255))
+        np.testing.assert_array_equal(render[45, 45], (255, 255, 255, 255))
+
         render = c.render()
         np.testing.assert_array_equal(render[50, 50], (255, 255, 255, 255))
 


### PR DESCRIPTION
Currently the gridlines visual does not set the depth buffer. This is not important in 2D, buut when using it in 3D the depth is set to a plane parallel to the screen (cause of the impostor rendering as a screen-covering quad). This PR sets the depth buffer correctly, so this is no longer a problem.

Here's an example:

```py
from vispy import scene
import numpy as np

canvas = scene.SceneCanvas(show=True)

view = canvas.central_widget.add_view()
view.camera = 'arcball'
view.camera.scale_factor = 30

grid = scene.GridLines(parent=view.scene)
grid.transform = scene.STTransform(translate=(0, 0, -5))
grid.update_gl_state(preset='translucent')

cube = scene.Cube(size=10, parent=view.scene)
cube.transform = scene.STTransform(translate=(0, 0, 5))
cube.update_gl_state(preset='translucent')
```

On main, you'll see no cube, regardless of rotation, cause the grid wind the depth test all the time. On this pr, the grid and cube exist in space as expected.

<img width="802" height="602" alt="image" src="https://github.com/user-attachments/assets/0141416f-420b-4890-b11e-79ac39663c4e" />

