### PR TITLE
Use np.reshape instead of setting shape attr

### DIFF
--- a/vispy/geometry/calculations.py
+++ b/vispy/geometry/calculations.py
@@ -149,8 +149,12 @@ def resize(image, shape, kind='linear'):
 
         c_1 = np.minimum(c_1, image.shape[1] - 1)
         r_1 = np.minimum(r_1, image.shape[0] - 1)
-        for arr in (top, bot, lef, rig):
-            arr.shape = arr.shape + (1,) * (image.ndim - 2)
+
+        top = np.reshape(top, (top.shape + (1,) * (image.ndim - 2)))
+        bot = np.reshape(bot, (bot.shape + (1,) * (image.ndim - 2)))
+        lef = np.reshape(lef, (lef.shape + (1,) * (image.ndim - 2)))
+        rig = np.reshape(rig, (rig.shape + (1,) * (image.ndim - 2)))
+
         out = top * rig * image[r_0][:, c_0, ...]
         out += bot * rig * image[r_1][:, c_0, ...]
         out += top * lef * image[r_0][:, c_1, ...]

--- a/vispy/gloo/gl/tests/test_functionality.py
+++ b/vispy/gloo/gl/tests/test_functionality.py
@@ -548,7 +548,7 @@ def _check_result(assert_result=True):
     x, y, w, h = gl.glGetParameter(gl.GL_VIEWPORT)
     data = gl.glReadPixels(x, y, w, h, gl.GL_RGB, gl.GL_UNSIGNED_BYTE)
     im = np.frombuffer(data, np.uint8)
-    im.shape = h, w, 3
+    im = im.reshape(h, w, 3)
 
     # Get center pixel from each quadrant
     pix1 = tuple(im[int(1*h/4), int(1*w/4)])

--- a/vispy/gloo/program.py
+++ b/vispy/gloo/program.py
@@ -431,7 +431,7 @@ class Program(GLObject):
                     dtype, numel = self._gtypes[type_]
                     data = np.array(data, dtype=dtype)
                     if data.ndim == 0:
-                        data.shape = data.size
+                        data = data.reshape(data.size)
                     if data.size != numel:
                         raise ValueError('Attribute %r needs %i elements, '
                                          'not %i.' % (name, numel, data.size))

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -690,7 +690,7 @@ def read_pixels(viewport=None, alpha=True, mode='color', out_type='unsigned_byte
         np_dtype = np.uint8 if type_ == gl.GL_UNSIGNED_BYTE else np.float32
         im = np.frombuffer(im, np_dtype)
 
-    im.shape = shape
+    im = im.reshape(shape)
     im = im[::-1, ...]  # flip the image
     return im
 

--- a/vispy/testing/image_tester.py
+++ b/vispy/testing/image_tester.py
@@ -308,7 +308,7 @@ def downsample(data, n, axis=0):
     sl = [slice(None)] * data.ndim
     sl[axis] = slice(0, nPts*n)
     d1 = data[tuple(sl)]
-    d1.shape = tuple(s)
+    d1 = d1.reshape(s)
     d2 = d1.mean(axis+1)
 
     return d2

--- a/vispy/util/fonts/_freetype.py
+++ b/vispy/util/fonts/_freetype.py
@@ -56,7 +56,7 @@ def _load_glyph(f, char, glyphs_dict):
     height = face.glyph.bitmap.rows
     bitmap = np.array(bitmap.buffer)
     w0 = bitmap.size // height if bitmap.size > 0 else 0
-    bitmap.shape = (height, w0)
+    bitmap = bitmap.reshape(height, w0)
     bitmap = bitmap[:, :width].astype(np.ubyte)
 
     left = face.glyph.bitmap_left

--- a/vispy/util/fonts/_quartz.py
+++ b/vispy/util/fonts/_quartz.py
@@ -147,7 +147,7 @@ def _load_glyph(f, char, glyphs_dict):
 
     # reshape bitmap (don't know why it's only alpha on OSX...)
     bitmap = np.array(buffer, np.ubyte)
-    bitmap.shape = (height, width, 4)
+    bitmap = bitmap.reshape(height, width, 4)
     bitmap = bitmap[:, :, 3].copy()
     glyph = dict(char=char, offset=(left, top), bitmap=bitmap,
                  advance=advance, kerning={})


### PR DESCRIPTION
NumPy deprecated setting the shape attribute with [`v2.5.0`](https://github.com/numpy/numpy/releases/tag/v2.5.0). This PR fixes the warnings arising from doing so within the vispy codebase, or at least the ones I found by running `git grep "\.shape\s=[^=]"`

The current calls to `reshape` only copy the underlying data if a copy-free reshape is impossible. I do not fully understand when that happens, but if a copy would be a problem we could explicitly pass `copy=False` - let me know what you think!