### PR TITLE
Fix KeyError when releasing extra mouse buttons on Qt backend

### DIFF
--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -381,6 +381,29 @@ def _get_qpoint_pos(pos):
     return pos.x(), pos.y()
 
 
+def _buttonmap_to_list(buttons) -> list[int]:
+    """Map Qt mouse button flags to VisPy button ids.
+
+    Module-level (no ``self``) so tests can call it without a backend
+    instance. Preserves BUTTONMAP order: standard 1-5, then
+    ExtraButton3..24 as 6-27 when present on this Qt build.
+    """
+    if buttons == QtCore.Qt.MouseButton.NoButton:
+        return []
+
+    mouse_buttons = []
+    if PYQT6_API or PYSIDE6_API:
+        for qt_button, vispy_button in BUTTONMAP.items():
+            if vispy_button and qt_button in buttons:
+                mouse_buttons.append(vispy_button)
+    else:
+        for qt_button, vispy_button in BUTTONMAP.items():
+            if vispy_button and (buttons & qt_button) != QtCore.Qt.MouseButton.NoButton:
+                mouse_buttons.append(vispy_button)
+
+    return mouse_buttons
+
+
 class QtBaseCanvasBackend(BaseCanvasBackend):
     """Base functionality of Qt backend. No OpenGL Stuff."""
 
@@ -511,23 +534,6 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
     def sizeHint(self):
         return self.size()
 
-    def _buttonmap_to_list(self, buttons) -> list[int]:
-        if buttons == QtCore.Qt.MouseButton.NoButton:
-            return []
-
-        # Preserve BUTTONMAP order (standard 1-5, then ExtraButton3..24 as 6-27).
-        mouse_buttons = []
-        if PYQT6_API or PYSIDE6_API:
-            for qt_button, vispy_button in BUTTONMAP.items():
-                if vispy_button and qt_button in buttons:
-                    mouse_buttons.append(vispy_button)
-        else:
-            for qt_button, vispy_button in BUTTONMAP.items():
-                if vispy_button and (buttons & qt_button) != QtCore.Qt.MouseButton.NoButton:
-                    mouse_buttons.append(vispy_button)
-
-        return mouse_buttons
-
     def mousePressEvent(self, ev):
         if self._vispy_canvas is None:
             return
@@ -536,7 +542,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP.get(ev.button(), 0),
-            buttons=self._buttonmap_to_list(ev.buttons()),
+            buttons=_buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )
         # If vispy did not handle the event, clear the accept parameter of the qt event
@@ -550,7 +556,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP.get(ev.button(), 0),
-            buttons=self._buttonmap_to_list(ev.buttons()),
+            buttons=_buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )
         # If vispy did not handle the event, clear the accept parameter of the qt event
@@ -564,7 +570,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             native=ev,
             pos=_get_event_xy(ev),
             button=BUTTONMAP.get(ev.button(), 0),
-            buttons=self._buttonmap_to_list(ev.buttons()),
+            buttons=_buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )
         # If vispy did not handle the event, clear the accept parameter of the qt event
@@ -578,7 +584,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         vispy_event = self._vispy_mouse_move(
             native=ev,
             pos=_get_event_xy(ev),
-            buttons=self._buttonmap_to_list(ev.buttons()),
+            buttons=_buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )
         # If vispy did not handle the event, clear the accept parameter of the qt event
@@ -607,7 +613,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
             native=ev,
             delta=(deltax, deltay),
             pos=_get_event_xy(ev),
-            buttons=self._buttonmap_to_list(ev.buttons()),
+            buttons=_buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )
         # If vispy did not handle the event, clear the accept parameter of the qt event

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -193,16 +193,29 @@ KEYMAP = {
     qt_keys.Key_Tab: keys.TAB,
 }
 if PYQT6_API or PYSIDE6_API:
+    # VisPy buttons 1-5 are Left/Right/Middle/Back/Forward.
+    # Qt also exposes ExtraButton1..24 (ExtraButton1/2 alias Back/Forward;
+    # ExtraButton3 is TaskButton). Map ExtraButton3..24 to VisPy 6..27 so
+    # unmapped side/extra buttons stay distinguishable instead of collapsing
+    # to 0 via BUTTONMAP.get(..., 0).
     BUTTONMAP = {
         QtCore.Qt.MouseButton.NoButton: 0,
         QtCore.Qt.MouseButton.LeftButton: 1,
         QtCore.Qt.MouseButton.RightButton: 2,
         QtCore.Qt.MouseButton.MiddleButton: 3,
         QtCore.Qt.MouseButton.BackButton: 4,
-        QtCore.Qt.MouseButton.ForwardButton: 5
+        QtCore.Qt.MouseButton.ForwardButton: 5,
     }
+    for _extra_i in range(3, 25):
+        BUTTONMAP[getattr(QtCore.Qt.MouseButton, f'ExtraButton{_extra_i}')] = (
+            _extra_i + 3
+        )
 else:
+    # Qt5 bit values: No=0, Left=1, Right=2, Mid=4, X1/Back=8, X2/Fwd=16,
+    # then ExtraButton3..24 as 1 << (n + 1) for n=3..24.
     BUTTONMAP = {0: 0, 1: 1, 2: 2, 4: 3, 8: 4, 16: 5}
+    for _extra_i in range(3, 25):
+        BUTTONMAP[1 << (_extra_i + 1)] = _extra_i + 3
 
 
 # Properly log Qt messages
@@ -494,30 +507,16 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         if buttons == QtCore.Qt.MouseButton.NoButton:
             return []
 
+        # Preserve BUTTONMAP order (standard 1-5, then ExtraButton3..24 as 6-27).
         mouse_buttons = []
-
         if PYQT6_API or PYSIDE6_API:
-            if QtCore.Qt.MouseButton.LeftButton in buttons:
-                mouse_buttons.append(1)
-            if QtCore.Qt.MouseButton.RightButton in buttons:
-                mouse_buttons.append(2)
-            if QtCore.Qt.MouseButton.MiddleButton in buttons:
-                mouse_buttons.append(3)
-            if QtCore.Qt.MouseButton.BackButton in buttons:
-                mouse_buttons.append(4)
-            if QtCore.Qt.MouseButton.ForwardButton in buttons:
-                mouse_buttons.append(5)
+            for qt_button, vispy_button in BUTTONMAP.items():
+                if vispy_button and qt_button in buttons:
+                    mouse_buttons.append(vispy_button)
         else:
-            if buttons & QtCore.Qt.MouseButton.LeftButton != QtCore.Qt.MouseButton.NoButton:
-                mouse_buttons.append(1)
-            if buttons & QtCore.Qt.MouseButton.RightButton != QtCore.Qt.MouseButton.NoButton:
-                mouse_buttons.append(2)
-            if buttons & QtCore.Qt.MouseButton.MiddleButton != QtCore.Qt.MouseButton.NoButton:
-                mouse_buttons.append(3)
-            if buttons & QtCore.Qt.MouseButton.BackButton != QtCore.Qt.MouseButton.NoButton:
-                mouse_buttons.append(4)
-            if buttons & QtCore.Qt.MouseButton.ForwardButton != QtCore.Qt.MouseButton.NoButton:
-                mouse_buttons.append(5)
+            for qt_button, vispy_button in BUTTONMAP.items():
+                if vispy_button and (buttons & qt_button) != QtCore.Qt.MouseButton.NoButton:
+                    mouse_buttons.append(vispy_button)
 
         return mouse_buttons
 

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -194,10 +194,12 @@ KEYMAP = {
 }
 if PYQT6_API or PYSIDE6_API:
     # VisPy buttons 1-5 are Left/Right/Middle/Back/Forward.
-    # Qt also exposes ExtraButton1..24 (ExtraButton1/2 alias Back/Forward;
-    # ExtraButton3 is TaskButton). Map ExtraButton3..24 to VisPy 6..27 so
-    # unmapped side/extra buttons stay distinguishable instead of collapsing
-    # to 0 via BUTTONMAP.get(..., 0).
+    # Qt 5.0+ also exposes ExtraButton1..24 (ExtraButton1/2 alias Back/Forward;
+    # ExtraButton3 is TaskButton). They were not present in Qt 4. Map any
+    # ExtraButton3..24 that exist on this Qt build to VisPy 6..27 so extra
+    # buttons stay distinguishable instead of collapsing to 0.
+    # Docs: https://doc.qt.io/qt-5/qt.html#MouseButton-enum
+    #       https://doc.qt.io/qt-6/qt.html#MouseButton-enum
     BUTTONMAP = {
         QtCore.Qt.MouseButton.NoButton: 0,
         QtCore.Qt.MouseButton.LeftButton: 1,
@@ -207,15 +209,21 @@ if PYQT6_API or PYSIDE6_API:
         QtCore.Qt.MouseButton.ForwardButton: 5,
     }
     for _extra_i in range(3, 25):
-        BUTTONMAP[getattr(QtCore.Qt.MouseButton, f'ExtraButton{_extra_i}')] = (
-            _extra_i + 3
-        )
+        _qt_btn = getattr(QtCore.Qt.MouseButton, f'ExtraButton{_extra_i}', None)
+        if _qt_btn is not None:
+            BUTTONMAP[_qt_btn] = _extra_i + 3
 else:
-    # Qt5 bit values: No=0, Left=1, Right=2, Mid=4, X1/Back=8, X2/Fwd=16,
-    # then ExtraButton3..24 as 1 << (n + 1) for n=3..24.
+    # Qt5 (and older) path uses integer button codes as keys. ExtraButton3..24
+    # exist from Qt 5.0; Qt 4 only had XButton1/2. Add them only when present.
     BUTTONMAP = {0: 0, 1: 1, 2: 2, 4: 3, 8: 4, 16: 5}
+    _mouse_button = getattr(QtCore.Qt, 'MouseButton', QtCore.Qt)
     for _extra_i in range(3, 25):
-        BUTTONMAP[1 << (_extra_i + 1)] = _extra_i + 3
+        _qt_btn = getattr(_mouse_button, f'ExtraButton{_extra_i}', None)
+        if _qt_btn is None:
+            _qt_btn = getattr(QtCore.Qt, f'ExtraButton{_extra_i}', None)
+        if _qt_btn is not None:
+            _code = int(getattr(_qt_btn, 'value', _qt_btn))
+            BUTTONMAP[_code] = _extra_i + 3
 
 
 # Properly log Qt messages

--- a/vispy/app/backends/_qt.py
+++ b/vispy/app/backends/_qt.py
@@ -542,7 +542,7 @@ class QtBaseCanvasBackend(BaseCanvasBackend):
         vispy_event = self._vispy_mouse_release(
             native=ev,
             pos=_get_event_xy(ev),
-            button=BUTTONMAP[ev.button()],
+            button=BUTTONMAP.get(ev.button(), 0),
             buttons=self._buttonmap_to_list(ev.buttons()),
             modifiers=self._modifiers(ev),
         )

--- a/vispy/app/tests/test_qt_mouse_buttons.py
+++ b/vispy/app/tests/test_qt_mouse_buttons.py
@@ -3,26 +3,21 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 """Functional regression tests for Qt mouse button mapping (#2751)."""
 
+import pytest
+
 from vispy.app import Canvas, use_app
 from vispy.testing import run_tests_if_main, requires_application
 
 
-def _qt_modules():
-    """Return (QtCore, QtGui, backend_module) after loading PyQt6."""
-    use_app('pyqt6')
-    from PyQt6 import QtCore, QtGui
-    import sys
-    qt_backend = sys.modules['vispy.app.backends._qt']
-    return QtCore, QtGui, qt_backend
-
-
-def _make_mouse_event(QtCore, QtGui, event_type, button, buttons=None):
+def _make_mouse_event(event_type_name, button, buttons=None):
     """Build a real Qt mouse event for the given button."""
+    from PyQt6 import QtCore, QtGui
+
     if buttons is None:
         buttons = QtCore.Qt.MouseButton.NoButton
     pos = QtCore.QPointF(12.0, 34.0)
     return QtGui.QMouseEvent(
-        event_type,
+        getattr(QtCore.QEvent.Type, event_type_name),
         pos,
         pos,  # global position
         button,
@@ -34,19 +29,19 @@ def _make_mouse_event(QtCore, QtGui, event_type, button, buttons=None):
 class _UnknownButtonEvent:
     """Minimal stand-in for a Qt mouse event with an unmapped button value."""
 
-    def __init__(self, button_value, QtCore):
+    def __init__(self, button_value):
         self._button_value = button_value
-        self._QtCore = QtCore
         self.ignored = False
 
     def button(self):
         return self._button_value
 
     def buttons(self):
-        return self._QtCore.Qt.MouseButton.NoButton
+        from PyQt6 import QtCore
+
+        return QtCore.Qt.MouseButton.NoButton
 
     def pos(self):
-        # Used by _get_event_xy on some Qt bindings.
         class _P:
             def x(self):
                 return 1
@@ -60,48 +55,74 @@ class _UnknownButtonEvent:
         return self.pos()
 
     def modifiers(self):
-        return self._QtCore.Qt.KeyboardModifier.NoModifier
+        from PyQt6 import QtCore
+
+        return QtCore.Qt.KeyboardModifier.NoModifier
 
     def ignore(self):
         self.ignored = True
 
 
+# (event_name, qt_event_type, qt_button, expected_vispy_button, buttons_flag)
+_EVENT_CASES = [
+    ('release', 'MouseButtonRelease', 'LeftButton', 1, None),
+    ('release', 'MouseButtonRelease', 'RightButton', 2, None),
+    ('release', 'MouseButtonRelease', 'MiddleButton', 3, None),
+    ('release', 'MouseButtonRelease', 'BackButton', 4, None),
+    ('release', 'MouseButtonRelease', 'ForwardButton', 5, None),
+    ('release', 'MouseButtonRelease', 'ExtraButton3', 6, None),
+    ('release', 'MouseButtonRelease', 'ExtraButton4', 7, None),
+    ('release', 'MouseButtonRelease', 'ExtraButton24', 27, None),
+    ('press', 'MouseButtonPress', 'ExtraButton4', 7, 'ExtraButton4'),
+    ('double_click', 'MouseButtonDblClick', 'ExtraButton3', 6, None),
+]
+
+_HANDLER = {
+    'press': 'mousePressEvent',
+    'release': 'mouseReleaseEvent',
+    'double_click': 'mouseDoubleClickEvent',
+}
+
+_VISPY_EVENT = {
+    'press': 'mouse_press',
+    'release': 'mouse_release',
+    'double_click': 'mouse_double_click',
+}
+
+
 @requires_application('pyqt6')
-def test_standard_and_extra_button_release_events():
-    """Release of standard and Extra buttons must emit the mapped VisPy id."""
-    QtCore, QtGui, qt_backend = _qt_modules()
-    mb = QtCore.Qt.MouseButton
-    buttonmap = qt_backend.BUTTONMAP
-
-    cases = [
-        (mb.LeftButton, 1),
-        (mb.RightButton, 2),
-        (mb.MiddleButton, 3),
-        (mb.BackButton, 4),
-        (mb.ForwardButton, 5),
-        (mb.ExtraButton3, 6),   # TaskButton
-        (mb.ExtraButton4, 7),
-        (mb.ExtraButton24, 27),
-    ]
-    # Sanity: mapping table matches expectations.
-    for qt_button, vispy_button in cases:
-        assert buttonmap[qt_button] == vispy_button
-
+@pytest.mark.parametrize(
+    'event_name, event_type, qt_button, vispy_button, buttons_flag',
+    _EVENT_CASES,
+    ids=[
+        f'{name}-{vispy}'
+        for name, _, _, vispy, _ in _EVENT_CASES
+    ],
+)
+def test_mapped_button_events(event_name, event_type, qt_button, vispy_button,
+                              buttons_flag):
+    """Press / release / double-click must emit the mapped VisPy button id."""
     app = use_app('pyqt6')
+    from PyQt6 import QtCore
+    from vispy.app.backends import _qt as qt_backend
+
+    qt_button = getattr(QtCore.Qt.MouseButton, qt_button)
+    if buttons_flag is not None:
+        buttons_flag = getattr(QtCore.Qt.MouseButton, buttons_flag)
+    assert qt_backend.BUTTONMAP[qt_button] == vispy_button
+
     canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
     try:
-        backend = canvas._backend
-        for qt_button, vispy_button in cases:
-            seen = []
-            canvas.events.mouse_release.connect(lambda e, s=seen: s.append(e))
-            ev = _make_mouse_event(
-                QtCore, QtGui, QtCore.QEvent.Type.MouseButtonRelease, qt_button
-            )
-            backend.mouseReleaseEvent(ev)
-            assert len(seen) == 1, (qt_button, vispy_button)
-            assert seen[0].button == vispy_button
+        seen = []
+        canvas.events[_VISPY_EVENT[event_name]].connect(lambda e: seen.append(e))
+        ev = _make_mouse_event(event_type, qt_button, buttons=buttons_flag)
+        getattr(canvas._backend, _HANDLER[event_name])(ev)
+        assert len(seen) == 1
+        assert seen[0].button == vispy_button
+        if event_name == 'release':
             assert tuple(seen[0].pos) == (12.0, 34.0)
-            canvas.events.mouse_release.disconnect()
+        if buttons_flag is not None:
+            assert vispy_button in seen[0].buttons
     finally:
         canvas.close()
 
@@ -109,17 +130,17 @@ def test_standard_and_extra_button_release_events():
 @requires_application('pyqt6')
 def test_unmapped_button_release_does_not_raise():
     """#2751: unknown Qt button on release must not KeyError; VisPy gets 0."""
-    QtCore, QtGui, qt_backend = _qt_modules()
     app = use_app('pyqt6')
+    from vispy.app.backends import _qt as qt_backend
+
     canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
     try:
         seen = []
         canvas.events.mouse_release.connect(lambda e: seen.append(e))
-        # Choose a value that is not a MouseButton flag in BUTTONMAP.
         unknown = object()
         assert unknown not in qt_backend.BUTTONMAP
-        fake = _UnknownButtonEvent(unknown, QtCore)
-        # Must not raise KeyError (the original bug).
+        fake = _UnknownButtonEvent(unknown)
+        # Must not raise KeyError (the original bug in GH #2751).
         canvas._backend.mouseReleaseEvent(fake)
         assert len(seen) == 1
         assert seen[0].button == 0
@@ -128,52 +149,15 @@ def test_unmapped_button_release_does_not_raise():
 
 
 @requires_application('pyqt6')
-def test_press_and_double_click_extra_buttons():
-    """Press / double-click must use the same mapping as release."""
-    QtCore, QtGui, qt_backend = _qt_modules()
-    mb = QtCore.Qt.MouseButton
-    app = use_app('pyqt6')
-    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
-    try:
-        backend = canvas._backend
-
-        press_seen = []
-        canvas.events.mouse_press.connect(lambda e: press_seen.append(e))
-        press_ev = _make_mouse_event(
-            QtCore, QtGui, QtCore.QEvent.Type.MouseButtonPress, mb.ExtraButton4,
-            buttons=mb.ExtraButton4,
-        )
-        backend.mousePressEvent(press_ev)
-        assert len(press_seen) == 1
-        assert press_seen[0].button == 7
-        assert 7 in press_seen[0].buttons
-
-        dbl_seen = []
-        canvas.events.mouse_double_click.connect(lambda e: dbl_seen.append(e))
-        dbl_ev = _make_mouse_event(
-            QtCore, QtGui,
-            QtCore.QEvent.Type.MouseButtonDblClick,
-            mb.ExtraButton3,
-        )
-        backend.mouseDoubleClickEvent(dbl_ev)
-        assert len(dbl_seen) == 1
-        assert dbl_seen[0].button == 6
-    finally:
-        canvas.close()
-
-
-@requires_application('pyqt6')
 def test_buttonmap_to_list_includes_extra_buttons():
     """Multi-button state must report Extra buttons, not only 1-5."""
-    QtCore, QtGui, qt_backend = _qt_modules()
+    use_app('pyqt6')
+    from PyQt6 import QtCore
+    from vispy.app.backends import _qt as qt_backend
+
     mb = QtCore.Qt.MouseButton
-    helper = qt_backend.QtBaseCanvasBackend._buttonmap_to_list
-
-    class _Dummy:
-        pass
-
     mixed = mb.LeftButton | mb.ForwardButton | mb.ExtraButton4
-    assert helper(_Dummy(), mixed) == [1, 5, 7]
+    assert qt_backend._buttonmap_to_list(mixed) == [1, 5, 7]
 
 
 run_tests_if_main()

--- a/vispy/app/tests/test_qt_mouse_buttons.py
+++ b/vispy/app/tests/test_qt_mouse_buttons.py
@@ -111,8 +111,7 @@ def test_mapped_button_events(event_name, event_type, qt_button, vispy_button,
         buttons_flag = getattr(QtCore.Qt.MouseButton, buttons_flag)
     assert qt_backend.BUTTONMAP[qt_button] == vispy_button
 
-    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
-    try:
+    with Canvas(app=app, size=(80, 80), create_native=True) as canvas:
         seen = []
         canvas.events[_VISPY_EVENT[event_name]].connect(lambda e: seen.append(e))
         ev = _make_mouse_event(event_type, qt_button, buttons=buttons_flag)
@@ -123,8 +122,6 @@ def test_mapped_button_events(event_name, event_type, qt_button, vispy_button,
             assert tuple(seen[0].pos) == (12.0, 34.0)
         if buttons_flag is not None:
             assert vispy_button in seen[0].buttons
-    finally:
-        canvas.close()
 
 
 @requires_application('pyqt6')
@@ -133,8 +130,7 @@ def test_unmapped_button_release_does_not_raise():
     app = use_app('pyqt6')
     from vispy.app.backends import _qt as qt_backend
 
-    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
-    try:
+    with Canvas(app=app, size=(80, 80), create_native=True) as canvas:
         seen = []
         canvas.events.mouse_release.connect(lambda e: seen.append(e))
         unknown = object()
@@ -144,8 +140,6 @@ def test_unmapped_button_release_does_not_raise():
         canvas._backend.mouseReleaseEvent(fake)
         assert len(seen) == 1
         assert seen[0].button == 0
-    finally:
-        canvas.close()
 
 
 @requires_application('pyqt6')

--- a/vispy/app/tests/test_qt_mouse_buttons.py
+++ b/vispy/app/tests/test_qt_mouse_buttons.py
@@ -1,108 +1,179 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
-"""Regression tests for Qt mouse button mapping (#2751)."""
+"""Functional regression tests for Qt mouse button mapping (#2751)."""
 
-import sys
-from pathlib import Path
-
+from vispy.app import Canvas, use_app
 from vispy.testing import run_tests_if_main, requires_application
 
 
-def _qt_backend_source() -> str:
-    try:
-        from vispy.app import use_app
-        use_app('pyqt6')  # ensure _qt is loaded when available
-    except Exception:
-        pass
-    qt_mod = sys.modules.get('vispy.app.backends._qt')
-    if qt_mod is not None:
-        return Path(qt_mod.__file__).read_text(encoding='utf-8')
-    here = Path(__file__).resolve()
-    qt_path = here.parents[1] / 'backends' / '_qt.py'
-    return qt_path.read_text(encoding='utf-8')
-
-
-def _method_body(src: str, method_name: str) -> str:
-    token = f'def {method_name}'
-    start = src.index(token)
-    next_def = src.find('\n    def ', start + len(token))
-    if next_def == -1:
-        return src[start:]
-    return src[start:next_def]
-
-
-def _load_qt_backend():
-    from vispy.app import use_app
+def _qt_modules():
+    """Return (QtCore, QtGui, backend_module) after loading PyQt6."""
     use_app('pyqt6')
-    qt_mod = sys.modules.get('vispy.app.backends._qt')
-    if qt_mod is None:
-        raise RuntimeError('Qt backend module was not loaded')
-    return qt_mod
+    from PyQt6 import QtCore, QtGui
+    import sys
+    qt_backend = sys.modules['vispy.app.backends._qt']
+    return QtCore, QtGui, qt_backend
 
 
-def test_mouse_release_uses_buttonmap_get():
-    """Extra mouse buttons must not KeyError on release (#2751)."""
-    src = _qt_backend_source()
-    body = _method_body(src, 'mouseReleaseEvent')
-    assert 'BUTTONMAP.get(' in body
-    assert 'BUTTONMAP[ev.button()]' not in body
+def _make_mouse_event(QtCore, QtGui, event_type, button, buttons=None):
+    """Build a real Qt mouse event for the given button."""
+    if buttons is None:
+        buttons = QtCore.Qt.MouseButton.NoButton
+    pos = QtCore.QPointF(12.0, 34.0)
+    return QtGui.QMouseEvent(
+        event_type,
+        pos,
+        pos,  # global position
+        button,
+        buttons,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
 
 
-def test_mouse_press_and_double_click_keep_get():
-    src = _qt_backend_source()
-    assert 'BUTTONMAP.get(' in _method_body(src, 'mousePressEvent')
-    assert 'BUTTONMAP.get(' in _method_body(src, 'mouseDoubleClickEvent')
+class _UnknownButtonEvent:
+    """Minimal stand-in for a Qt mouse event with an unmapped button value."""
 
+    def __init__(self, button_value, QtCore):
+        self._button_value = button_value
+        self._QtCore = QtCore
+        self.ignored = False
 
-def test_buttonmap_get_fallback_semantics():
-    sample = {1: 1, 2: 2, 4: 3}
-    assert sample.get(8, 0) == 0
-    assert sample.get(1, 0) == 1
+    def button(self):
+        return self._button_value
+
+    def buttons(self):
+        return self._QtCore.Qt.MouseButton.NoButton
+
+    def pos(self):
+        # Used by _get_event_xy on some Qt bindings.
+        class _P:
+            def x(self):
+                return 1
+
+            def y(self):
+                return 2
+
+        return _P()
+
+    def position(self):
+        return self.pos()
+
+    def modifiers(self):
+        return self._QtCore.Qt.KeyboardModifier.NoModifier
+
+    def ignore(self):
+        self.ignored = True
 
 
 @requires_application('pyqt6')
-def test_buttonmap_includes_qt_extra_buttons():
-    """Qt ExtraButton3..24 should map to distinct VisPy ids 6..27."""
-    from PyQt6.QtCore import Qt
-
-    qt_backend = _load_qt_backend()
+def test_standard_and_extra_button_release_events():
+    """Release of standard and Extra buttons must emit the mapped VisPy id."""
+    QtCore, QtGui, qt_backend = _qt_modules()
+    mb = QtCore.Qt.MouseButton
     buttonmap = qt_backend.BUTTONMAP
-    mb = Qt.MouseButton
 
-    # Standard buttons keep historical VisPy ids.
-    assert buttonmap[mb.NoButton] == 0
-    assert buttonmap[mb.LeftButton] == 1
-    assert buttonmap[mb.RightButton] == 2
-    assert buttonmap[mb.MiddleButton] == 3
-    assert buttonmap[mb.BackButton] == 4
-    assert buttonmap[mb.ForwardButton] == 5
+    cases = [
+        (mb.LeftButton, 1),
+        (mb.RightButton, 2),
+        (mb.MiddleButton, 3),
+        (mb.BackButton, 4),
+        (mb.ForwardButton, 5),
+        (mb.ExtraButton3, 6),   # TaskButton
+        (mb.ExtraButton4, 7),
+        (mb.ExtraButton24, 27),
+    ]
+    # Sanity: mapping table matches expectations.
+    for qt_button, vispy_button in cases:
+        assert buttonmap[qt_button] == vispy_button
 
-    # ExtraButton1/2 are aliases of Back/Forward (already 4/5).
-    assert mb.ExtraButton1 == mb.BackButton
-    assert mb.ExtraButton2 == mb.ForwardButton
-
-    # ExtraButton3..24 become VisPy 6..27 so callers can bind them.
-    for extra_i in range(3, 25):
-        qt_button = getattr(mb, f'ExtraButton{extra_i}')
-        assert buttonmap[qt_button] == extra_i + 3
+    app = use_app('pyqt6')
+    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
+    try:
+        backend = canvas._backend
+        for qt_button, vispy_button in cases:
+            seen = []
+            canvas.events.mouse_release.connect(lambda e, s=seen: s.append(e))
+            ev = _make_mouse_event(
+                QtCore, QtGui, QtCore.QEvent.Type.MouseButtonRelease, qt_button
+            )
+            backend.mouseReleaseEvent(ev)
+            assert len(seen) == 1, (qt_button, vispy_button)
+            assert seen[0].button == vispy_button
+            assert tuple(seen[0].pos) == (12.0, 34.0)
+            canvas.events.mouse_release.disconnect()
+    finally:
+        canvas.close()
 
 
 @requires_application('pyqt6')
-def test_buttonmap_to_list_reports_extra_buttons():
-    from PyQt6.QtCore import Qt
+def test_unmapped_button_release_does_not_raise():
+    """#2751: unknown Qt button on release must not KeyError; VisPy gets 0."""
+    QtCore, QtGui, qt_backend = _qt_modules()
+    app = use_app('pyqt6')
+    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
+    try:
+        seen = []
+        canvas.events.mouse_release.connect(lambda e: seen.append(e))
+        # Choose a value that is not a MouseButton flag in BUTTONMAP.
+        unknown = object()
+        assert unknown not in qt_backend.BUTTONMAP
+        fake = _UnknownButtonEvent(unknown, QtCore)
+        # Must not raise KeyError (the original bug).
+        canvas._backend.mouseReleaseEvent(fake)
+        assert len(seen) == 1
+        assert seen[0].button == 0
+    finally:
+        canvas.close()
 
-    qt_backend = _load_qt_backend()
+
+@requires_application('pyqt6')
+def test_press_and_double_click_extra_buttons():
+    """Press / double-click must use the same mapping as release."""
+    QtCore, QtGui, qt_backend = _qt_modules()
+    mb = QtCore.Qt.MouseButton
+    app = use_app('pyqt6')
+    canvas = Canvas(app=app, size=(80, 80), show=False, create_native=True)
+    try:
+        backend = canvas._backend
+
+        press_seen = []
+        canvas.events.mouse_press.connect(lambda e: press_seen.append(e))
+        press_ev = _make_mouse_event(
+            QtCore, QtGui, QtCore.QEvent.Type.MouseButtonPress, mb.ExtraButton4,
+            buttons=mb.ExtraButton4,
+        )
+        backend.mousePressEvent(press_ev)
+        assert len(press_seen) == 1
+        assert press_seen[0].button == 7
+        assert 7 in press_seen[0].buttons
+
+        dbl_seen = []
+        canvas.events.mouse_double_click.connect(lambda e: dbl_seen.append(e))
+        dbl_ev = _make_mouse_event(
+            QtCore, QtGui,
+            QtCore.QEvent.Type.MouseButtonDblClick,
+            mb.ExtraButton3,
+        )
+        backend.mouseDoubleClickEvent(dbl_ev)
+        assert len(dbl_seen) == 1
+        assert dbl_seen[0].button == 6
+    finally:
+        canvas.close()
+
+
+@requires_application('pyqt6')
+def test_buttonmap_to_list_includes_extra_buttons():
+    """Multi-button state must report Extra buttons, not only 1-5."""
+    QtCore, QtGui, qt_backend = _qt_modules()
+    mb = QtCore.Qt.MouseButton
     helper = qt_backend.QtBaseCanvasBackend._buttonmap_to_list
 
     class _Dummy:
         pass
 
-    mb = Qt.MouseButton
-    mixed = mb.LeftButton | mb.ExtraButton4 | mb.ForwardButton
-    got = helper(_Dummy(), mixed)
-    # Left=1, Forward=5, ExtraButton4 -> VisPy 7
-    assert got == [1, 5, 7]
+    mixed = mb.LeftButton | mb.ForwardButton | mb.ExtraButton4
+    assert helper(_Dummy(), mixed) == [1, 5, 7]
 
 
 run_tests_if_main()

--- a/vispy/app/tests/test_qt_mouse_buttons.py
+++ b/vispy/app/tests/test_qt_mouse_buttons.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""Regression tests for Qt mouse button mapping (#2751)."""
+
+from pathlib import Path
+
+from vispy.testing import run_tests_if_main
+
+
+def _qt_backend_source() -> str:
+    try:
+        from vispy.app.backends import _qt as qt_backend
+        return Path(qt_backend.__file__).read_text(encoding='utf-8')
+    except Exception:
+        here = Path(__file__).resolve()
+        qt_path = here.parents[1] / 'backends' / '_qt.py'
+        return qt_path.read_text(encoding='utf-8')
+
+
+def _method_body(src: str, method_name: str) -> str:
+    token = f'def {method_name}'
+    start = src.index(token)
+    next_def = src.find('\n    def ', start + len(token))
+    if next_def == -1:
+        return src[start:]
+    return src[start:next_def]
+
+
+def test_mouse_release_uses_buttonmap_get():
+    """Extra mouse buttons must not KeyError on release (#2751)."""
+    src = _qt_backend_source()
+    body = _method_body(src, 'mouseReleaseEvent')
+    assert 'BUTTONMAP.get(' in body
+    assert 'BUTTONMAP[ev.button()]' not in body
+
+
+def test_mouse_press_and_double_click_keep_get():
+    src = _qt_backend_source()
+    assert 'BUTTONMAP.get(' in _method_body(src, 'mousePressEvent')
+    assert 'BUTTONMAP.get(' in _method_body(src, 'mouseDoubleClickEvent')
+
+
+def test_buttonmap_get_fallback_semantics():
+    sample = {1: 1, 2: 2, 4: 3}
+    assert sample.get(8, 0) == 0
+    assert sample.get(1, 0) == 1
+
+
+run_tests_if_main()

--- a/vispy/app/tests/test_qt_mouse_buttons.py
+++ b/vispy/app/tests/test_qt_mouse_buttons.py
@@ -3,19 +3,24 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 """Regression tests for Qt mouse button mapping (#2751)."""
 
+import sys
 from pathlib import Path
 
-from vispy.testing import run_tests_if_main
+from vispy.testing import run_tests_if_main, requires_application
 
 
 def _qt_backend_source() -> str:
     try:
-        from vispy.app.backends import _qt as qt_backend
-        return Path(qt_backend.__file__).read_text(encoding='utf-8')
+        from vispy.app import use_app
+        use_app('pyqt6')  # ensure _qt is loaded when available
     except Exception:
-        here = Path(__file__).resolve()
-        qt_path = here.parents[1] / 'backends' / '_qt.py'
-        return qt_path.read_text(encoding='utf-8')
+        pass
+    qt_mod = sys.modules.get('vispy.app.backends._qt')
+    if qt_mod is not None:
+        return Path(qt_mod.__file__).read_text(encoding='utf-8')
+    here = Path(__file__).resolve()
+    qt_path = here.parents[1] / 'backends' / '_qt.py'
+    return qt_path.read_text(encoding='utf-8')
 
 
 def _method_body(src: str, method_name: str) -> str:
@@ -25,6 +30,15 @@ def _method_body(src: str, method_name: str) -> str:
     if next_def == -1:
         return src[start:]
     return src[start:next_def]
+
+
+def _load_qt_backend():
+    from vispy.app import use_app
+    use_app('pyqt6')
+    qt_mod = sys.modules.get('vispy.app.backends._qt')
+    if qt_mod is None:
+        raise RuntimeError('Qt backend module was not loaded')
+    return qt_mod
 
 
 def test_mouse_release_uses_buttonmap_get():
@@ -45,6 +59,50 @@ def test_buttonmap_get_fallback_semantics():
     sample = {1: 1, 2: 2, 4: 3}
     assert sample.get(8, 0) == 0
     assert sample.get(1, 0) == 1
+
+
+@requires_application('pyqt6')
+def test_buttonmap_includes_qt_extra_buttons():
+    """Qt ExtraButton3..24 should map to distinct VisPy ids 6..27."""
+    from PyQt6.QtCore import Qt
+
+    qt_backend = _load_qt_backend()
+    buttonmap = qt_backend.BUTTONMAP
+    mb = Qt.MouseButton
+
+    # Standard buttons keep historical VisPy ids.
+    assert buttonmap[mb.NoButton] == 0
+    assert buttonmap[mb.LeftButton] == 1
+    assert buttonmap[mb.RightButton] == 2
+    assert buttonmap[mb.MiddleButton] == 3
+    assert buttonmap[mb.BackButton] == 4
+    assert buttonmap[mb.ForwardButton] == 5
+
+    # ExtraButton1/2 are aliases of Back/Forward (already 4/5).
+    assert mb.ExtraButton1 == mb.BackButton
+    assert mb.ExtraButton2 == mb.ForwardButton
+
+    # ExtraButton3..24 become VisPy 6..27 so callers can bind them.
+    for extra_i in range(3, 25):
+        qt_button = getattr(mb, f'ExtraButton{extra_i}')
+        assert buttonmap[qt_button] == extra_i + 3
+
+
+@requires_application('pyqt6')
+def test_buttonmap_to_list_reports_extra_buttons():
+    from PyQt6.QtCore import Qt
+
+    qt_backend = _load_qt_backend()
+    helper = qt_backend.QtBaseCanvasBackend._buttonmap_to_list
+
+    class _Dummy:
+        pass
+
+    mb = Qt.MouseButton
+    mixed = mb.LeftButton | mb.ExtraButton4 | mb.ForwardButton
+    got = helper(_Dummy(), mixed)
+    # Left=1, Forward=5, ExtraButton4 -> VisPy 7
+    assert got == [1, 5, 7]
 
 
 run_tests_if_main()


### PR DESCRIPTION
The original crash was a hard `BUTTONMAP[ev.button()]` lookup in the Qt `mouseReleaseEvent` path. Press and double-click already used a safe lookup, so releasing an unmapped extra mouse button could raise `KeyError` and crash the app. This PR makes release use the same fallback path (`0`, VisPy’s no/unknown button) and keeps the Qt button-state helper driven from the same map.

While testing the fix, the PR now also maps Qt `ExtraButton3..24` when those enum members exist, preserving the existing VisPy IDs 1–5 for Left/Right/Middle/Back/Forward and assigning extra buttons 6–27. This keeps side-button events distinguishable instead of collapsing mapped extra buttons to `0`, while still falling back to `0` for truly unknown/unmapped buttons.

The regression tests now exercise real Qt backend mouse handlers for press, release, and double-click, including standard buttons, extra buttons, and the unknown-release fallback. The PyQt6 imports are inside the PyQt6-guarded tests/helpers so documentation/test collection still works when PyQt6 is not installed.

Closes #2751
