### PR TITLE
Fix instanced markers perspective

### DIFF
--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -675,7 +675,7 @@ class MarkersVisual(Visual):
             # offset the framebuffer position to match gl_PointSize behavior (but without aliasing)
             apply_offset_func = Function("""
                 vec4 apply_offset(vec4 fb_pos, float total_size) {
-                    vec2 offset = $a_quad_pos * total_size;
+                    vec2 offset = $a_quad_pos * total_size * fb_pos.w;
                     return fb_pos + vec4(offset, 0, 0);
                 }
             """)


### PR DESCRIPTION
This bug slipped through in #2701 as we forgot to test properly in 3D. It's just a matter of not using homogeneous coordinates where we should have :P

to test:

```py
from vispy import app, scene, use
import numpy as np

use(gl='gl+')

canvas = scene.SceneCanvas(keys='interactive', size=(600, 600), show=True)
view = canvas.central_widget.add_view()
view.camera = scene.cameras.ArcballCamera(fov=0)
view.camera.scale_factor = 500

pos = np.random.rand(10, 3) * 100 - 50
markers = scene.visuals.Markers(pos=pos, size=30, face_color='red', scaling=True, method='instanced', parent=view.scene)
```

On main, if you shit+right click drag to change the fov, you'll see the points basically disappear. On this PR, they work as expected.

Closes napari/napari#9089.
