### PR TITLE
Fix perspective for text

### DIFF
--- a/examples/scene/text.py
+++ b/examples/scene/text.py
@@ -36,8 +36,8 @@ t1.font_size = 24
 t1.pos = canvas.size[0] // 2, canvas.size[1] // 3
 
 t2 = Text('Text in viewbox (18 pt)', parent=vb.scene, color='green',
-          rotation=30)
-t2.font_size = 18
+          rotation=30, scaling=True)
+t2.font_size = .2  # scaling True means this size is in scene coordinates
 t2.pos = 0.5, 0.3
 
 # Add a line so you can see translate/scale of camera

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -449,7 +449,7 @@ class TextVisual(Visual):
     def __init__(self, text=None, color='black', bold=False,
                  italic=False, face='OpenSans', font_size=12, line_height=1.1, pos=[0, 0, 0],
                  rotation=0., anchor_x='center', anchor_y='center',
-                 method='cpu', font_manager=None, depth_test=False, scaling=True):
+                 method='cpu', font_manager=None, depth_test=False, scaling=False):
         Visual.__init__(self, vcode=self._shaders['vertex'], fcode=self._shaders['fragment'])
         # Check input
         valid_keys = ('top', 'center', 'middle', 'baseline', 'bottom')

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -21,7 +21,6 @@ from ...gloo import (TextureAtlas, IndexBuffer, VertexBuffer)
 from ...gloo import context
 from ...gloo.wrappers import _check_valid
 from ...util.fonts import _load_glyph
-from ..transforms import STTransform
 from ...color import ColorArray
 from ..visual import Visual
 from ...io import load_spatial_filters
@@ -150,6 +149,9 @@ class FontManager(object):
 # The visual
 
 _VERTEX_SHADER = """
+    uniform bool u_scaling;
+    uniform vec2 u_px_scale;
+    uniform float u_npix;
     attribute float a_rotation;  // rotation in rad
     attribute vec2 a_position; // in point units
     attribute vec2 a_texcoord;
@@ -162,10 +164,38 @@ _VERTEX_SHADER = """
         mat4 rot = mat4(cos(a_rotation), -sin(a_rotation), 0, 0,
                         sin(a_rotation), cos(a_rotation), 0, 0,
                         0, 0, 1, 0, 0, 0, 0, 1);
-        // when scaling is enabled, text_scale is enlarged/reduced per-instance on
-        // the CPU so the text resizes with zoom and FOV while staying billboarded.
-        vec4 pos = $transform(vec4(a_pos, 1.0));
-        vec4 offset = $text_scale(rot * vec4(a_position, 0.0, 1.0));
+        vec4 pos = $transform(vec4(a_pos, 1));
+        vec2 vertex = (rot * vec4(a_position, 0, 1)).xy;
+        vec2 px_direction = normalize(u_px_scale);
+
+        float scale;
+
+        if ( u_scaling ) {
+            // small step along each axis for jacobian by finite-differences
+            vec2 ndc_anchor = pos.xy / pos.w;
+            float e = 1e-3;
+            vec4 cx = $transform(vec4(a_pos + vec3(e, 0, 0), 1));
+            vec4 cy = $transform(vec4(a_pos + vec3(0, e, 0), 1));
+            vec4 cz = $transform(vec4(a_pos + vec3(0, 0, e), 1));
+            vec2 dx = cx.xy / cx.w - ndc_anchor;
+            vec2 dy = cy.xy / cy.w - ndc_anchor;
+            vec2 dz = cz.xy / cz.w - ndc_anchor;
+
+            float world_mag = sqrt(dot(dx, dx) + dot(dy, dy) + dot(dz, dz)) / e;
+            // non-positive clip.w means the anchor (or a step) is behind the camera
+            if (pos.w <= 0 || cx.w <= 0 || cy.w <= 0 || cz.w <= 0) {
+                world_mag = 0;
+            }
+
+            scale = u_npix * world_mag;
+        } else {
+            scale = u_npix * length(u_px_scale);
+        }
+
+        float scale_x = scale * px_direction.x * vertex.x;
+        float scale_y = scale * px_direction.y * vertex.y;
+        vec4 offset = vec4(scale_x, scale_y, 0, 1);
+
         gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
         v_texcoord = a_texcoord;
         v_color = $color;
@@ -445,7 +475,6 @@ class TextVisual(Visual):
         self.pos = pos
         self.rotation = rotation
         self.scaling = scaling
-        self._text_scale = STTransform()
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
@@ -540,43 +569,6 @@ class TextVisual(Visual):
         self._pos_changed = True
         self.update()
 
-    def _world_scale(self, tr, coord):
-        """Screen-pixel scale at coord (for billboarded test).
-
-        tr is the full visual->render transform (the camera projection plus
-        the canvas mapping).
- 
-        Returns the scale for how much the text grows/shrinks with the scene.
-        """
-        coord = np.asarray(coord, dtype=np.float64)
-        if coord.shape[0] == 2:
-            coord = np.array([coord[0], coord[1], 0.0])
-        p = coord
-        # jacobian by finite differences along the world x, y and z axes
-        e = 1e-6
-        pts = np.array([
-            [p[0],     p[1],     p[2],     1],
-            [p[0] + e, p[1],     p[2],     1],
-            [p[0],     p[1] + e, p[2],     1],
-            [p[0],     p[1],     p[2] + e, 1],
-        ])
-        # map from screen coords to world coords
-        clip = tr.map(pts)
-        w = clip[:, 3]
-
-        # non-positive clip.w means the anchor is on/behind the camera's
-        # focal plane; there is no well-defined on-screen size, so report 0.
-        if np.any(w <= 0):
-            return 0
-
-        # ndc coordinates to account for zoom and FOV
-        ndc = clip[:, :2] / w[:, None]
-        # subtracting the original points gives us the displacement in each axis
-        # direction, which gives us the full "stretch" of the unit in this position
-        disp = (ndc[1:] - ndc[0]) / e
-        # good ol' pythagoras
-        return float(np.sqrt(np.sum(np.linalg.norm(disp) ** 2)))
-
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
         if len(self.text) == 0:
@@ -650,35 +642,11 @@ class TextVisual(Visual):
 
         transforms = self.transforms
         n_pix = (self._font_size / 72.) * transforms.dpi  # logical pix
-        # Base (billboarded) scale: a fixed number of screen pixels.
         tr = transforms.get_transform('document', 'render')
         px_scale = (tr.map((1, 0)) - tr.map((0, 1)))[:2]
-        scale = px_scale * n_pix
-        if self._scaling:
-            # we need to rescale text based on camera zoom and fov;
-            # we do everything relative to the anchor point
-            anchor = self.pos
-            anchor_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
-                            else anchor[0])
-            anchor_point = np.asarray(anchor_point, dtype=np.float64)
-            if anchor_point.shape[0] == 2:
-                anchor_point = np.array([anchor_point[0], anchor_point[1], 0.0])
-
-            tr_full = transforms.get_transform('visual', 'render')
-            view_scale = self._world_scale(tr_full, anchor_point)
-
-            # normalize the jacobian by the px scale (since at neutral framing
-            # they are equal); necessary to get the font size to have absolute
-            # meaning in screen pixels.
-            px_scale_mag = np.linalg.norm(px_scale)
-            if view_scale and px_scale_mag:
-                scale = scale * (view_scale / px_scale_mag)
-            else:
-                # we're behind the camera or some other degenerate case, just drop it
-                scale = 0
-        self._text_scale.scale = scale
-        self.shared_program.vert['text_scale'] = self._text_scale
         self.shared_program['u_npix'] = n_pix
+        self.shared_program['u_px_scale'] = px_scale
+        self.shared_program['u_scaling'] = self._scaling
         self.shared_program['u_kernel'] = self._font._kernel
         self.shared_program['u_color'] = self._color.rgba
         self.shared_program['u_font_atlas'] = self._font._atlas

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -161,9 +161,9 @@ _VERTEX_SHADER = """
         mat4 rot = mat4(cos(a_rotation), -sin(a_rotation), 0, 0,
                         sin(a_rotation), cos(a_rotation), 0, 0,
                         0, 0, 1, 0, 0, 0, 0, 1);
-        vec4 pos = $transform(vec4(a_pos, 1.0)) +
-                   vec4($text_scale(rot * vec4(a_position, 0.0, 1.0)).xyz, 0.0);
-        gl_Position = pos;
+        vec4 pos = $transform(vec4(a_pos, 1.0));
+        vec4 offset = $text_scale(rot * vec4(a_position, 0.0, 1.0));
+        gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
         v_texcoord = a_texcoord;
         v_color = $color;
     }

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -447,12 +447,13 @@ class TextVisual(Visual):
         self.line_height = line_height
         self.pos = pos
         self.rotation = rotation
-        self.scaling = True
+        self.scaling = scaling
         self._text_scale = STTransform()
         # Reference scale (visual -> document) captured when the font size or
         # scaling mode changes. The glyph offset is stored in world units
-        # relative to this reference so that it scales with zoom/FOV instead
-        # of staying a fixed number of pixels.
+        # relative to this reference so that it scales with zoom (and is
+        # independent of FOV and camera rotation) instead of staying a fixed
+        # number of pixels.
         self._scaling_reference_scale = None
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
@@ -552,40 +553,49 @@ class TextVisual(Visual):
     def _world_scale(self, tr, point, fov=None):
         """On-screen scale (NDC per world unit) at *point*, for billboarded text.
 
-        The returned scalar drives how much the text grows/shrinks with the
-        scene. It is chosen so that the billboarded text:
+        ``tr`` is the full visual->render transform (the camera projection plus
+        the canvas mapping). The returned scalar drives how much the text grows /
+        shrinks with the scene.
 
-        * keeps a *constant* size while the camera is rotated (the value is
-          evaluated at the camera orbit center and is rotation-invariant), and
-        * resizes with zoom, but is *independent of the camera field of view*.
+        The scale is the size (in NDC) of one world unit, computed *after* the
+        perspective divide: for a unit world step along each axis we take
+        ``clip.xy / clip.w`` at the anchor and at the anchor-plus-step and measure
+        the NDC displacement. Because this uses the camera's *actual* projection
+        (which becomes orthographic as the FOV tends to 0), the measure:
 
-        For a perspective camera (``fov`` given) the projection divides by the
-        camera distance, so the raw NDC-per-world scale is proportional to the
-        focal length (``1/tan(fov/2)``) and to ``1/distance``. We remove the
-        focal-length term and keep only ``1/distance`` (the true camera
-        distance, ``|w| * tan(fov/2)``), which makes the text follow zoom but
-        ignore FOV changes.
+        * is *anchor based* -- a nearer text (smaller ``clip.w``) maps to a larger
+          on-screen size than a farther one, so text follows its position;
+        * is *bounded* for any on-screen point (``clip.w > 0``) and never blows up
+          at edge-on views -- a point on/behind the focal plane (``clip.w <= 0``)
+          is off-screen and reported as 0;
+        * is *continuous as the FOV tends to 0* (it reduces smoothly to the
+          orthographic size, so there is no "pop" when leaving FOV 0); and
+        * *resizes with zoom* (orbiting / zooming changes ``clip.w``).
 
-        For an orthographic camera (no ``fov``) the on-screen scale is simply
-        the Frobenius norm of the world->NDC Jacobian, which is already
-        zoom-responsive and FOV-independent.
+        ``fov`` is accepted for interface compatibility but is not needed: the
+        post-divide NDC displacement already handles both orthographic and
+        perspective cameras.
         """
         point = np.asarray(point, dtype=np.float64)
         if point.shape[0] == 2:
             point = np.array([point[0], point[1], 0.0])
-        o = tr.map(np.array([[point[0], point[1], point[2], 1.0]]))[0]
-        if fov and fov > 1e-2:
-            w = float(abs(o[3]))
-            if w == 0:
-                return 0.0
-            return 1.0 / (w * math.tan(math.radians(fov) / 2.0))
-        ex = tr.map(np.array([[point[0] + 1.0, point[1], point[2], 1.0]]))[0]
-        ey = tr.map(np.array([[point[0], point[1] + 1.0, point[2], 1.0]]))[0]
-        ez = tr.map(np.array([[point[0], point[1], point[2] + 1.0, 1.0]]))[0]
-        sx = float(np.linalg.norm(ex[:2] - o[:2]))
-        sy = float(np.linalg.norm(ey[:2] - o[:2]))
-        sz = float(np.linalg.norm(ez[:2] - o[:2]))
-        return math.sqrt(sx * sx + sy * sy + sz * sz)
+        p = point
+        pts = np.array([
+            [p[0], p[1], p[2], 1.0],
+            [p[0] + 1.0, p[1], p[2], 1.0],
+            [p[0], p[1] + 1.0, p[2], 1.0],
+            [p[0], p[1], p[2] + 1.0, 1.0],
+        ])
+        c = tr.map(pts)
+        w = c[:, 3]
+        # A zero (or negative) clip-w means the anchor is on/behind the camera's
+        # focal plane; there is no well-defined on-screen size, so report 0.
+        if np.any(w <= 0):
+            return 0.0
+        ndc = c[:, :2] / w[:, None]
+        disp = ndc[1:] - ndc[0]
+        s = np.linalg.norm(disp, axis=1)
+        return float(np.sqrt(float((s * s).sum())))
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
@@ -666,19 +676,16 @@ class TextVisual(Visual):
         scale = px_scale * n_pix
         if self._scaling:
             # Resize the text with the scene while keeping it a billboard. The
-            # on-screen size of one world unit (an isotropic, rotation-invariant
-            # scalar) is scaled by the ratio of the current value to a reference
-            # captured when the font size or scaling mode last changed. Because
-            # the scale is rotation-invariant, the text stays a constant size
-            # while the camera is rotated, while still growing/shrinking with
-            # zoom and FOV.
+            # on-screen size of one world unit (an isotropic scalar) is scaled by
+            # the ratio of the current value to a reference captured when the font
+            # size or scaling mode last changed. The scale is evaluated at the
+            # text's own *anchor* (see ``_world_scale``) against a reference at the
+            # camera orbit center, so:
             #
-            # The scale is evaluated at the camera's orbit center rather than at
-            # the text anchor: the orbit center stays at a constant distance
-            # from the camera, so it does not change under rotation, whereas an
-            # off-center anchor would otherwise drift in depth as it orbits.
-            tr_full = transforms.get_transform('visual', 'render')
-            ref_point = None
+            # * a nearer text is larger and a farther one smaller (its size follows
+            #   its position in the scene),
+            # * it is bounded -- no blow-up at edge-on views, and
+            # * it is independent of the camera field of view and resizes with zoom.
             fov = None
             # The camera is not reachable from ``view`` (which is the visual
             # itself); walk up the scene graph to the ViewBox that owns it.
@@ -689,18 +696,39 @@ class TextVisual(Visual):
                     break
                 node = getattr(node, 'parent', None)
             if camera is not None:
-                center = getattr(camera, 'center', None)
-                if center is not None:
-                    ref_point = np.asarray(center, dtype=np.float64)
                 fov = getattr(camera, 'fov', None)
+            # The actual visual->render transform (camera projection + canvas). Its
+            # post-divide NDC displacement already encodes both orthographic and
+            # perspective sizing and is continuous as the FOV tends to 0, so it is
+            # the right quantity to drive the billboard size.
+            tr_full = transforms.get_transform('visual', 'render')
+            anchor = self._pos
+            anchor_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
+                            else anchor[0])
+            anchor_point = np.asarray(anchor_point, dtype=np.float64)
+            if anchor_point.shape[0] == 2:
+                anchor_point = np.array([anchor_point[0], anchor_point[1], 0.0])
+            # Scale at the text's own anchor so a nearer text is larger and a
+            # farther one smaller (its size follows its position in the scene).
+            # The reference is a *shared* point at the camera orbit center,
+            # captured when the font size / scaling mode last changed. Dividing by
+            # a per-anchor reference would cancel the anchor's own depth (every text
+            # the same size), so the center is used instead. Because the reference
+            # is fixed at enable time, ordinary *zoom* (which moves the camera, not
+            # the reference) resizes the text, while changing the FOV keeps the
+            # framing and therefore leaves the size unchanged (no "pop" at FOV 0).
+            view_scale = self._world_scale(tr_full, anchor_point, fov)
+            ref_point = getattr(camera, 'center', None)
             if ref_point is None:
-                anchor = self._pos
-                ref_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
-                             else anchor[0])
-            view_scale = self._world_scale(tr_full, ref_point, fov)
+                ref_point = anchor_point
+            else:
+                ref_point = np.asarray(ref_point, dtype=np.float64)
+                if ref_point.shape[0] == 2:
+                    ref_point = np.array([ref_point[0], ref_point[1], 0.0])
+            ref_scale = self._world_scale(tr_full, ref_point, fov)
             if self._scaling_reference_scale is None or \
                     self._scaling_reference_scale == 0:
-                self._scaling_reference_scale = view_scale
+                self._scaling_reference_scale = ref_scale
             if self._scaling_reference_scale != 0 and view_scale != 0:
                 scale = scale * (view_scale / self._scaling_reference_scale)
         self._text_scale.scale = scale

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -162,11 +162,8 @@ _VERTEX_SHADER = """
         mat4 rot = mat4(cos(a_rotation), -sin(a_rotation), 0, 0,
                         sin(a_rotation), cos(a_rotation), 0, 0,
                         0, 0, 1, 0, 0, 0, 0, 1);
-        // The glyph offset is always expressed in normalized device
-        // coordinates (added after the perspective divide via *pos.w), so the
-        // text stays a screen-aligned billboard regardless of the camera.
-        // When scaling is enabled, $text_scale is enlarged/reduced on the CPU
-        // so that the text resizes with zoom and FOV while staying billboarded.
+        // when scaling is enabled, text_scale is enlarged/reduced per-instance on
+        // the CPU so the text resizes with zoom and FOV while staying billboarded.
         vec4 pos = $transform(vec4(a_pos, 1.0));
         vec4 offset = $text_scale(rot * vec4(a_position, 0.0, 1.0));
         gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
@@ -449,11 +446,6 @@ class TextVisual(Visual):
         self.rotation = rotation
         self.scaling = scaling
         self._text_scale = STTransform()
-        # Reference scale (visual -> document) captured when the font size or
-        # scaling mode changes. The glyph offset is stored in world units
-        # relative to this reference so that it scales with zoom (and is
-        # independent of FOV and camera rotation) instead of staying a fixed
-        # number of pixels.
         self._scaling_reference_scale = None
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
@@ -550,52 +542,41 @@ class TextVisual(Visual):
         self._pos_changed = True
         self.update()
 
-    def _world_scale(self, tr, point, fov=None):
-        """On-screen scale (NDC per world unit) at *point*, for billboarded text.
+    def _world_scale(self, tr, coord):
+        """Screen-pixel scale at coord (for billboarded test).
 
-        ``tr`` is the full visual->render transform (the camera projection plus
-        the canvas mapping). The returned scalar drives how much the text grows /
-        shrinks with the scene.
+        tr is the full visual->render transform (the camera projection plus
+        the canvas mapping).
 
-        The scale is the size (in NDC) of one world unit, computed *after* the
-        perspective divide: for a unit world step along each axis we take
-        ``clip.xy / clip.w`` at the anchor and at the anchor-plus-step and measure
-        the NDC displacement. Because this uses the camera's *actual* projection
-        (which becomes orthographic as the FOV tends to 0), the measure:
-
-        * is *anchor based* -- a nearer text (smaller ``clip.w``) maps to a larger
-          on-screen size than a farther one, so text follows its position;
-        * is *bounded* for any on-screen point (``clip.w > 0``) and never blows up
-          at edge-on views -- a point on/behind the focal plane (``clip.w <= 0``)
-          is off-screen and reported as 0;
-        * is *continuous as the FOV tends to 0* (it reduces smoothly to the
-          orthographic size, so there is no "pop" when leaving FOV 0); and
-        * *resizes with zoom* (orbiting / zooming changes ``clip.w``).
-
-        ``fov`` is accepted for interface compatibility but is not needed: the
-        post-divide NDC displacement already handles both orthographic and
-        perspective cameras.
+        Returns the scale for how much the text grows/shrinks with the scene.
         """
-        point = np.asarray(point, dtype=np.float64)
-        if point.shape[0] == 2:
-            point = np.array([point[0], point[1], 0.0])
-        p = point
+        coord = np.asarray(coord, dtype=np.float64)
+        if coord.shape[0] == 2:
+            coord = np.array([coord[0], coord[1], 0.0])
+        p = coord
+        # jacobian by finite differences: step 1 unit in each axis direction, then
+        # apply the transform which gives us the clip coordinates
         pts = np.array([
-            [p[0], p[1], p[2], 1.0],
-            [p[0] + 1.0, p[1], p[2], 1.0],
-            [p[0], p[1] + 1.0, p[2], 1.0],
-            [p[0], p[1], p[2] + 1.0, 1.0],
+            [p[0],     p[1],     p[2],     1],
+            [p[0] + 1, p[1],     p[2],     1],
+            [p[0],     p[1] + 1, p[2],     1],
+            [p[0],     p[1],     p[2] + 1, 1],
         ])
-        c = tr.map(pts)
-        w = c[:, 3]
-        # A zero (or negative) clip-w means the anchor is on/behind the camera's
+        clip = tr.map(pts)
+        w = clip[:, 3]
+
+        # non-positive clip.w means the anchor is on/behind the camera's
         # focal plane; there is no well-defined on-screen size, so report 0.
         if np.any(w <= 0):
             return 0.0
-        ndc = c[:, :2] / w[:, None]
+
+        # ndc coordinates to account for FOV
+        ndc = clip[:, :2] / w[:, None]
+        # subtracting the original points gives us the displacement in each axis direction,
+        # which gives us the full "stretch" of the unit in this position
         disp = ndc[1:] - ndc[0]
         s = np.linalg.norm(disp, axis=1)
-        return float(np.sqrt(float((s * s).sum())))
+        return float(np.sqrt(np.sum(s * s)))
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
@@ -675,49 +656,22 @@ class TextVisual(Visual):
         px_scale = (tr.map((1, 0)) - tr.map((0, 1)))[:2]
         scale = px_scale * n_pix
         if self._scaling:
-            # Resize the text with the scene while keeping it a billboard. The
-            # on-screen size of one world unit (an isotropic scalar) is scaled by
-            # the ratio of the current value to a reference captured when the font
-            # size or scaling mode last changed. The scale is evaluated at the
-            # text's own *anchor* (see ``_world_scale``) against a reference at the
-            # camera orbit center, so:
-            #
-            # * a nearer text is larger and a farther one smaller (its size follows
-            #   its position in the scene),
-            # * it is bounded -- no blow-up at edge-on views, and
-            # * it is independent of the camera field of view and resizes with zoom.
-            fov = None
-            # The camera is not reachable from ``view`` (which is the visual
-            # itself); walk up the scene graph to the ViewBox that owns it.
+            anchor = self.pos
+            anchor_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
+                            else anchor[0])
+            anchor_point = np.asarray(anchor_point, dtype=np.float64)
+            if anchor_point.shape[0] == 2:
+                anchor_point = np.array([anchor_point[0], anchor_point[1], 0.0])
+
+            # camera is not reachable from view; walk up the scene graph
+            # TODO: can I get the center in a less dumb way?
             node = view
             while node is not None:
                 camera = getattr(node, 'camera', None)
                 if camera is not None:
                     break
                 node = getattr(node, 'parent', None)
-            if camera is not None:
-                fov = getattr(camera, 'fov', None)
-            # The actual visual->render transform (camera projection + canvas). Its
-            # post-divide NDC displacement already encodes both orthographic and
-            # perspective sizing and is continuous as the FOV tends to 0, so it is
-            # the right quantity to drive the billboard size.
-            tr_full = transforms.get_transform('visual', 'render')
-            anchor = self._pos
-            anchor_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
-                            else anchor[0])
-            anchor_point = np.asarray(anchor_point, dtype=np.float64)
-            if anchor_point.shape[0] == 2:
-                anchor_point = np.array([anchor_point[0], anchor_point[1], 0.0])
-            # Scale at the text's own anchor so a nearer text is larger and a
-            # farther one smaller (its size follows its position in the scene).
-            # The reference is a *shared* point at the camera orbit center,
-            # captured when the font size / scaling mode last changed. Dividing by
-            # a per-anchor reference would cancel the anchor's own depth (every text
-            # the same size), so the center is used instead. Because the reference
-            # is fixed at enable time, ordinary *zoom* (which moves the camera, not
-            # the reference) resizes the text, while changing the FOV keeps the
-            # framing and therefore leaves the size unchanged (no "pop" at FOV 0).
-            view_scale = self._world_scale(tr_full, anchor_point, fov)
+
             ref_point = getattr(camera, 'center', None)
             if ref_point is None:
                 ref_point = anchor_point
@@ -725,11 +679,13 @@ class TextVisual(Visual):
                 ref_point = np.asarray(ref_point, dtype=np.float64)
                 if ref_point.shape[0] == 2:
                     ref_point = np.array([ref_point[0], ref_point[1], 0.0])
-            ref_scale = self._world_scale(tr_full, ref_point, fov)
-            if self._scaling_reference_scale is None or \
-                    self._scaling_reference_scale == 0:
-                self._scaling_reference_scale = ref_scale
-            if self._scaling_reference_scale != 0 and view_scale != 0:
+
+            tr_full = transforms.get_transform('visual', 'render')
+            view_scale = self._world_scale(tr_full, anchor_point)
+            ref_scale = self._world_scale(tr_full, ref_point)
+
+            self._scaling_reference_scale = self._scaling_reference_scale or ref_scale
+            if self._scaling_reference_scale and view_scale:
                 scale = scale * (view_scale / self._scaling_reference_scale)
         self._text_scale.scale = scale
         self.shared_program.vert['text_scale'] = self._text_scale

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -545,22 +545,22 @@ class TextVisual(Visual):
 
         tr is the full visual->render transform (the camera projection plus
         the canvas mapping).
-
+ 
         Returns the scale for how much the text grows/shrinks with the scene.
         """
         coord = np.asarray(coord, dtype=np.float64)
         if coord.shape[0] == 2:
             coord = np.array([coord[0], coord[1], 0.0])
         p = coord
-        # jacobian by finite differences: step a small amount unit in each axis direction, then
-        # apply the transform which gives us the clip coordinates
+        # jacobian by finite differences along the world x and y axes (the
+        # screen plane); e is a small step
         e = 1e-6
         pts = np.array([
-            [p[0],     p[1],     p[2],     1],
-            [p[0] + e, p[1],     p[2],     1],
-            [p[0],     p[1] + e, p[2],     1],
-            [p[0],     p[1],     p[2] + e, 1],
+            [p[0],     p[1], p[2], 1],
+            [p[0] + e, p[1], p[2], 1],
+            [p[0],     p[1] + e, p[2], 1],
         ])
+        # map from screen coords to world coords
         clip = tr.map(pts)
         w = clip[:, 3]
 
@@ -569,13 +569,15 @@ class TextVisual(Visual):
         if np.any(w <= 0):
             return 0
 
-        # ndc coordinates to account for FOV
+        # ndc coordinates to account for zoom and FOV
         ndc = clip[:, :2] / w[:, None]
         # subtracting the original points gives us the displacement in each axis direction,
         # which gives us the full "stretch" of the unit in this position
-        disp = ndc[1:] - ndc[0]
-        s = np.linalg.norm(disp, axis=1)
-        return float(np.sqrt(np.sum(s**2)))
+        disp_x = (ndc[1] - ndc[0]) / e
+        disp_y = (ndc[2] - ndc[0]) / e
+        # good ol' pythagoras
+        return float(np.sqrt(np.linalg.norm(disp_x) ** 2 +
+                             np.linalg.norm(disp_y) ** 2))
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
@@ -662,28 +664,11 @@ class TextVisual(Visual):
             if anchor_point.shape[0] == 2:
                 anchor_point = np.array([anchor_point[0], anchor_point[1], 0.0])
 
-            # camera is not reachable from view; walk up the scene graph
-            # TODO: can I get the center in a less dumb way?
-            node = view
-            while node is not None:
-                camera = getattr(node, 'camera', None)
-                if camera is not None:
-                    break
-                node = getattr(node, 'parent', None)
-            ref_point = getattr(camera, 'center', None)
-            if ref_point is None:
-                ref_point = anchor_point
-            else:
-                ref_point = np.asarray(ref_point, dtype=np.float64)
-                if ref_point.shape[0] == 2:
-                    ref_point = np.array([ref_point[0], ref_point[1], 0.0])
-
             tr_full = transforms.get_transform('visual', 'render')
             view_scale = self._world_scale(tr_full, anchor_point)
-            ref_scale = self._world_scale(tr_full, ref_point)
 
-            if ref_scale and view_scale:
-                scale = scale * (view_scale / ref_scale)
+            if view_scale:
+                scale = scale * view_scale
             else:
                 # we're behind the camera, just drop it
                 scale = 0

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -13,6 +13,7 @@ from __future__ import division
 import numpy as np
 from copy import deepcopy
 import sys
+import math
 
 from ._sdf_gpu import SDFRendererGPU
 from ._sdf_cpu import _calc_distance_field
@@ -149,7 +150,6 @@ class FontManager(object):
 # The visual
 
 _VERTEX_SHADER = """
-    uniform bool u_scaling;
     attribute float a_rotation;  // rotation in rad
     attribute vec2 a_position; // in point units
     attribute vec2 a_texcoord;
@@ -162,13 +162,14 @@ _VERTEX_SHADER = """
         mat4 rot = mat4(cos(a_rotation), -sin(a_rotation), 0, 0,
                         sin(a_rotation), cos(a_rotation), 0, 0,
                         0, 0, 1, 0, 0, 0, 0, 1);
+        // The glyph offset is always expressed in normalized device
+        // coordinates (added after the perspective divide via *pos.w), so the
+        // text stays a screen-aligned billboard regardless of the camera.
+        // When scaling is enabled, $text_scale is enlarged/reduced on the CPU
+        // so that the text resizes with zoom and FOV while staying billboarded.
         vec4 pos = $transform(vec4(a_pos, 1.0));
         vec4 offset = $text_scale(rot * vec4(a_position, 0.0, 1.0));
-        if (u_scaling) {
-            gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
-        } else {
-            gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
-        }
+        gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
         v_texcoord = a_texcoord;
         v_color = $color;
     }
@@ -448,6 +449,11 @@ class TextVisual(Visual):
         self.rotation = rotation
         self.scaling = True
         self._text_scale = STTransform()
+        # Reference scale (visual -> document) captured when the font size or
+        # scaling mode changes. The glyph offset is stored in world units
+        # relative to this reference so that it scales with zoom/FOV instead
+        # of staying a fixed number of pixels.
+        self._scaling_reference_scale = None
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
@@ -489,6 +495,7 @@ class TextVisual(Visual):
     @font_size.setter
     def font_size(self, size):
         self._font_size = max(0.0, float(size))
+        self._scaling_reference_scale = None
         self.update()
 
     @property
@@ -541,6 +548,44 @@ class TextVisual(Visual):
         self._pos = pos
         self._pos_changed = True
         self.update()
+
+    def _world_scale(self, tr, point, fov=None):
+        """On-screen scale (NDC per world unit) at *point*, for billboarded text.
+
+        The returned scalar drives how much the text grows/shrinks with the
+        scene. It is chosen so that the billboarded text:
+
+        * keeps a *constant* size while the camera is rotated (the value is
+          evaluated at the camera orbit center and is rotation-invariant), and
+        * resizes with zoom, but is *independent of the camera field of view*.
+
+        For a perspective camera (``fov`` given) the projection divides by the
+        camera distance, so the raw NDC-per-world scale is proportional to the
+        focal length (``1/tan(fov/2)``) and to ``1/distance``. We remove the
+        focal-length term and keep only ``1/distance`` (the true camera
+        distance, ``|w| * tan(fov/2)``), which makes the text follow zoom but
+        ignore FOV changes.
+
+        For an orthographic camera (no ``fov``) the on-screen scale is simply
+        the Frobenius norm of the world->NDC Jacobian, which is already
+        zoom-responsive and FOV-independent.
+        """
+        point = np.asarray(point, dtype=np.float64)
+        if point.shape[0] == 2:
+            point = np.array([point[0], point[1], 0.0])
+        o = tr.map(np.array([[point[0], point[1], point[2], 1.0]]))[0]
+        if fov and fov > 1e-2:
+            w = float(abs(o[3]))
+            if w == 0:
+                return 0.0
+            return 1.0 / (w * math.tan(math.radians(fov) / 2.0))
+        ex = tr.map(np.array([[point[0] + 1.0, point[1], point[2], 1.0]]))[0]
+        ey = tr.map(np.array([[point[0], point[1] + 1.0, point[2], 1.0]]))[0]
+        ez = tr.map(np.array([[point[0], point[1], point[2] + 1.0, 1.0]]))[0]
+        sx = float(np.linalg.norm(ex[:2] - o[:2]))
+        sy = float(np.linalg.norm(ey[:2] - o[:2]))
+        sz = float(np.linalg.norm(ez[:2] - o[:2]))
+        return math.sqrt(sx * sx + sy * sy + sz * sz)
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
@@ -615,11 +660,51 @@ class TextVisual(Visual):
 
         transforms = self.transforms
         n_pix = (self._font_size / 72.) * transforms.dpi  # logical pix
+        # Base (billboarded) scale: a fixed number of screen pixels.
         tr = transforms.get_transform('document', 'render')
         px_scale = (tr.map((1, 0)) - tr.map((0, 1)))[:2]
-        self._text_scale.scale = px_scale * n_pix
+        scale = px_scale * n_pix
+        if self._scaling:
+            # Resize the text with the scene while keeping it a billboard. The
+            # on-screen size of one world unit (an isotropic, rotation-invariant
+            # scalar) is scaled by the ratio of the current value to a reference
+            # captured when the font size or scaling mode last changed. Because
+            # the scale is rotation-invariant, the text stays a constant size
+            # while the camera is rotated, while still growing/shrinking with
+            # zoom and FOV.
+            #
+            # The scale is evaluated at the camera's orbit center rather than at
+            # the text anchor: the orbit center stays at a constant distance
+            # from the camera, so it does not change under rotation, whereas an
+            # off-center anchor would otherwise drift in depth as it orbits.
+            tr_full = transforms.get_transform('visual', 'render')
+            ref_point = None
+            fov = None
+            # The camera is not reachable from ``view`` (which is the visual
+            # itself); walk up the scene graph to the ViewBox that owns it.
+            node = view
+            while node is not None:
+                camera = getattr(node, 'camera', None)
+                if camera is not None:
+                    break
+                node = getattr(node, 'parent', None)
+            if camera is not None:
+                center = getattr(camera, 'center', None)
+                if center is not None:
+                    ref_point = np.asarray(center, dtype=np.float64)
+                fov = getattr(camera, 'fov', None)
+            if ref_point is None:
+                anchor = self._pos
+                ref_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
+                             else anchor[0])
+            view_scale = self._world_scale(tr_full, ref_point, fov)
+            if self._scaling_reference_scale is None or \
+                    self._scaling_reference_scale == 0:
+                self._scaling_reference_scale = view_scale
+            if self._scaling_reference_scale != 0 and view_scale != 0:
+                scale = scale * (view_scale / self._scaling_reference_scale)
+        self._text_scale.scale = scale
         self.shared_program.vert['text_scale'] = self._text_scale
-        self.shared_program['u_scaling'] = self._scaling
         self.shared_program['u_npix'] = n_pix
         self.shared_program['u_kernel'] = self._font._kernel
         self.shared_program['u_color'] = self._color.rgba
@@ -674,6 +759,7 @@ class TextVisual(Visual):
     @scaling.setter
     def scaling(self, value):
         self._scaling = bool(value)
+        self._scaling_reference_scale = None
         self.update()
 
 

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -149,6 +149,7 @@ class FontManager(object):
 # The visual
 
 _VERTEX_SHADER = """
+    uniform bool u_scaling;
     attribute float a_rotation;  // rotation in rad
     attribute vec2 a_position; // in point units
     attribute vec2 a_texcoord;
@@ -163,7 +164,11 @@ _VERTEX_SHADER = """
                         0, 0, 1, 0, 0, 0, 0, 1);
         vec4 pos = $transform(vec4(a_pos, 1.0));
         vec4 offset = $text_scale(rot * vec4(a_position, 0.0, 1.0));
-        gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
+        if (u_scaling) {
+            gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
+        } else {
+            gl_Position = vec4(pos.xyz + offset.xyz * pos.w, pos.w);
+        }
         v_texcoord = a_texcoord;
         v_color = $color;
     }
@@ -403,6 +408,9 @@ class TextVisual(Visual):
         Whether to apply depth testing. Default False. If False, the text
         behaves like an overlay that does not get hidden behind other
         visuals in the scene.
+    scaling : bool
+        Whether the text size scales with zoom and FOV (True, default) or
+        stays fixed in canvas pixels.
     """
 
     _shaders = {
@@ -413,7 +421,7 @@ class TextVisual(Visual):
     def __init__(self, text=None, color='black', bold=False,
                  italic=False, face='OpenSans', font_size=12, line_height=1.1, pos=[0, 0, 0],
                  rotation=0., anchor_x='center', anchor_y='center',
-                 method='cpu', font_manager=None, depth_test=False):
+                 method='cpu', font_manager=None, depth_test=False, scaling=True):
         Visual.__init__(self, vcode=self._shaders['vertex'], fcode=self._shaders['fragment'])
         # Check input
         valid_keys = ('top', 'center', 'middle', 'baseline', 'bottom')
@@ -438,6 +446,7 @@ class TextVisual(Visual):
         self.line_height = line_height
         self.pos = pos
         self.rotation = rotation
+        self.scaling = True
         self._text_scale = STTransform()
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
@@ -610,6 +619,7 @@ class TextVisual(Visual):
         px_scale = (tr.map((1, 0)) - tr.map((0, 1)))[:2]
         self._text_scale.scale = px_scale * n_pix
         self.shared_program.vert['text_scale'] = self._text_scale
+        self.shared_program['u_scaling'] = self._scaling
         self.shared_program['u_npix'] = n_pix
         self.shared_program['u_kernel'] = self._font._kernel
         self.shared_program['u_color'] = self._color.rgba
@@ -655,6 +665,15 @@ class TextVisual(Visual):
 
     def _update_font(self):
         self._font = self._font_manager.get_font(self._face, self._bold, self._italic)
+        self.update()
+
+    @property
+    def scaling(self):
+        return self._scaling
+
+    @scaling.setter
+    def scaling(self, value):
+        self._scaling = bool(value)
         self.update()
 
 

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -552,13 +552,13 @@ class TextVisual(Visual):
         if coord.shape[0] == 2:
             coord = np.array([coord[0], coord[1], 0.0])
         p = coord
-        # jacobian by finite differences along the world x and y axes (the
-        # screen plane); e is a small step
+        # jacobian by finite differences along the world x, y and z axes
         e = 1e-6
         pts = np.array([
-            [p[0],     p[1], p[2], 1],
-            [p[0] + e, p[1], p[2], 1],
-            [p[0],     p[1] + e, p[2], 1],
+            [p[0],     p[1],     p[2],     1],
+            [p[0] + e, p[1],     p[2],     1],
+            [p[0],     p[1] + e, p[2],     1],
+            [p[0],     p[1],     p[2] + e, 1],
         ])
         # map from screen coords to world coords
         clip = tr.map(pts)
@@ -571,13 +571,11 @@ class TextVisual(Visual):
 
         # ndc coordinates to account for zoom and FOV
         ndc = clip[:, :2] / w[:, None]
-        # subtracting the original points gives us the displacement in each axis direction,
-        # which gives us the full "stretch" of the unit in this position
-        disp_x = (ndc[1] - ndc[0]) / e
-        disp_y = (ndc[2] - ndc[0]) / e
+        # subtracting the original points gives us the displacement in each axis
+        # direction, which gives us the full "stretch" of the unit in this position
+        disp = (ndc[1:] - ndc[0]) / e
         # good ol' pythagoras
-        return float(np.sqrt(np.linalg.norm(disp_x) ** 2 +
-                             np.linalg.norm(disp_y) ** 2))
+        return float(np.sqrt(np.sum(np.linalg.norm(disp) ** 2)))
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -446,7 +446,6 @@ class TextVisual(Visual):
         self.rotation = rotation
         self.scaling = scaling
         self._text_scale = STTransform()
-        self._scaling_reference_scale = None
         self._draw_mode = 'triangles'
         self.set_gl_state(blend=True, depth_test=depth_test, cull_face=False,
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
@@ -488,7 +487,6 @@ class TextVisual(Visual):
     @font_size.setter
     def font_size(self, size):
         self._font_size = max(0.0, float(size))
-        self._scaling_reference_scale = None
         self.update()
 
     @property
@@ -554,13 +552,14 @@ class TextVisual(Visual):
         if coord.shape[0] == 2:
             coord = np.array([coord[0], coord[1], 0.0])
         p = coord
-        # jacobian by finite differences: step 1 unit in each axis direction, then
+        # jacobian by finite differences: step a small amount unit in each axis direction, then
         # apply the transform which gives us the clip coordinates
+        e = 1e-6
         pts = np.array([
             [p[0],     p[1],     p[2],     1],
-            [p[0] + 1, p[1],     p[2],     1],
-            [p[0],     p[1] + 1, p[2],     1],
-            [p[0],     p[1],     p[2] + 1, 1],
+            [p[0] + e, p[1],     p[2],     1],
+            [p[0],     p[1] + e, p[2],     1],
+            [p[0],     p[1],     p[2] + e, 1],
         ])
         clip = tr.map(pts)
         w = clip[:, 3]
@@ -568,7 +567,7 @@ class TextVisual(Visual):
         # non-positive clip.w means the anchor is on/behind the camera's
         # focal plane; there is no well-defined on-screen size, so report 0.
         if np.any(w <= 0):
-            return 0.0
+            return 0
 
         # ndc coordinates to account for FOV
         ndc = clip[:, :2] / w[:, None]
@@ -576,7 +575,7 @@ class TextVisual(Visual):
         # which gives us the full "stretch" of the unit in this position
         disp = ndc[1:] - ndc[0]
         s = np.linalg.norm(disp, axis=1)
-        return float(np.sqrt(np.sum(s * s)))
+        return float(np.sqrt(np.sum(s**2)))
 
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
@@ -671,7 +670,6 @@ class TextVisual(Visual):
                 if camera is not None:
                     break
                 node = getattr(node, 'parent', None)
-
             ref_point = getattr(camera, 'center', None)
             if ref_point is None:
                 ref_point = anchor_point
@@ -684,9 +682,11 @@ class TextVisual(Visual):
             view_scale = self._world_scale(tr_full, anchor_point)
             ref_scale = self._world_scale(tr_full, ref_point)
 
-            self._scaling_reference_scale = self._scaling_reference_scale or ref_scale
-            if self._scaling_reference_scale and view_scale:
-                scale = scale * (view_scale / self._scaling_reference_scale)
+            if ref_scale and view_scale:
+                scale = scale * (view_scale / ref_scale)
+            else:
+                # we're behind the camera, just drop it
+                scale = 0
         self._text_scale.scale = scale
         self.shared_program.vert['text_scale'] = self._text_scale
         self.shared_program['u_npix'] = n_pix
@@ -743,7 +743,6 @@ class TextVisual(Visual):
     @scaling.setter
     def scaling(self, value):
         self._scaling = bool(value)
-        self._scaling_reference_scale = None
         self.update()
 
 

--- a/vispy/visuals/text/text.py
+++ b/vispy/visuals/text/text.py
@@ -657,6 +657,8 @@ class TextVisual(Visual):
         px_scale = (tr.map((1, 0)) - tr.map((0, 1)))[:2]
         scale = px_scale * n_pix
         if self._scaling:
+            # we need to rescale text based on camera zoom and fov;
+            # we do everything relative to the anchor point
             anchor = self.pos
             anchor_point = (anchor.mean(axis=0) if anchor.shape[0] > 1
                             else anchor[0])
@@ -667,10 +669,14 @@ class TextVisual(Visual):
             tr_full = transforms.get_transform('visual', 'render')
             view_scale = self._world_scale(tr_full, anchor_point)
 
-            if view_scale:
-                scale = scale * view_scale
+            # normalize the jacobian by the px scale (since at neutral framing
+            # they are equal); necessary to get the font size to have absolute
+            # meaning in screen pixels.
+            px_scale_mag = np.linalg.norm(px_scale)
+            if view_scale and px_scale_mag:
+                scale = scale * (view_scale / px_scale_mag)
             else:
-                # we're behind the camera, just drop it
+                # we're behind the camera or some other degenerate case, just drop it
                 scale = 0
         self._text_scale.scale = scale
         self.shared_program.vert['text_scale'] = self._text_scale


### PR DESCRIPTION
Similar issue to #2773. To test, try out the example at `examples/scene/text.py`. If you change FOV using shift+right click drag, you'll see the text rescale in weird ways, and then *pop* to the correct font_size when FOV=0. This PR makes it behave as you instead would expect (constant screen size, no weirdnesses).

Closes napari/napari#8872.
