### PR TITLE
prevent quitting app while draw event in progress

### DIFF
--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -155,7 +155,19 @@ def test_run():
             @c.events.draw.connect
             def draw(event):
                 print(event)  # test event __repr__
-                c.app.quit()
+                if c.app.backend_name.lower() in (
+                        "pyqt4",
+                        "pyqt5",
+                        "pyqt6",
+                        "pyside",
+                        "pyside2",
+                        "pyside6",
+                ):
+                    from vispy.app.backends._qt import QtCore
+                    QtCore.QTimer.singleShot(0, c.app.quit)
+                else:
+                    c.app.quit()
+
             c.update()
             c.app.run()
         c.app.quit()  # make sure it doesn't break if a user quits twice


### PR DESCRIPTION
Quitting the app while a draw is in progress, as done in test_app.py might lead to events being send after the app is already destroyed. While not having been a problem so far, this became a problem in #2769 as it led to segfaults. In order to test whether this solution works on its own, without being convoluted by other changes, I create this separate PR.

The main thing is that the use of `SingleShotTimer` here forces the quit to only happen after we return to the event loop, thereby preventing teardown of the app until the draw event has completed. This is similar to the use of `SingleShotTimer` in @kephale progressive loading PR.