### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -179,25 +179,25 @@ jobs:
       matrix:
         include:
           - test_number: 1
-            python_version: "3.9"
+            python_version: "3.10"
             deps: "min"
             test: "standard"
             new_qt: false
           - test_number: 2
-            python_version: "3.9"
+            python_version: "3.10"
             deps: "full"
             test: "standard"
             new_qt: false
-          - test_number: 3
-            python_version: "3.9"
-            deps: "osmesa"
-            test: "osmesa"
-            new_qt: false
-          - test_number: 4
+          - test_number: 2
             python_version: "3.10"
             deps: "full"
             test: "standard"
             new_qt: true
+          - test_number: 3
+            python_version: "3.10"
+            deps: "osmesa"
+            test: "osmesa"
+            new_qt: false
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,7 @@ jobs:
             deps: "full"
             test: "standard"
             new_qt: false
-          - test_number: 2
+          - test_number: 3
             python_version: "3.10"
             deps: "full"
             test: "standard"
@@ -198,6 +198,16 @@ jobs:
             deps: "osmesa"
             test: "osmesa"
             new_qt: false
+          - test_number: 4
+            python_version: "3.12"
+            deps: "full"
+            test: "standard"
+            new_qt: false
+          - test_number: 5
+            python_version: "3.12"
+            deps: "full"
+            test: "standard"
+            new_qt: true
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-version: latest
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
         channels: conda-forge
         conda-remove-defaults: true
         channel-priority: strict

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,17 +195,17 @@ jobs:
             deps: "full"
             test: "standard"
             new_qt: true
-          - test_number: 3
+          - test_number: 4
             python_version: "3.10"
             deps: "osmesa"
             test: "osmesa"
             new_qt: false
-          - test_number: 4
+          - test_number: 5
             python_version: "3.12"
             deps: "full"
             test: "standard"
             new_qt: false
-          - test_number: 5
+          - test_number: 6
             python_version: "3.12"
             deps: "full"
             test: "standard"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Prepare System Environment
       id: vars
       # This is added because lately it happened more than once that ubuntu mirrors are slow and run for more than 2h
-      timeout-minutes: 2
+      timeout-minutes: 10
       run: |
         # opengl system libraries
         sudo apt-get update;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,8 @@ jobs:
           ${{ runner.os }}-data-${{ env.cache-name }}-
     - name: Prepare System Environment
       id: vars
+      # This is added because lately it happened more than once that ubuntu mirrors are slow and run for more than 2h
+      timeout-minutes: 2
       run: |
         # opengl system libraries
         sudo apt-get update;
@@ -226,6 +228,8 @@ jobs:
           ${{ runner.os }}-data-${{ env.cache-name }}-
     - name: Prepare System Environment
       id: vars
+      # This is added because lately it happened more than once that ubuntu mirrors are slow and run for more than 2h
+      timeout-minutes: 2
       run: |
         # opengl system libraries
         if [ "${{ matrix.deps }}" == 'full' ]; then

--- a/ci/requirements/linux_full_newqtdeps_apt.txt
+++ b/ci/requirements/linux_full_newqtdeps_apt.txt
@@ -10,6 +10,7 @@ libxkbcommon-x11-dev
 libxcb1
 libxcb1-dev
 libxcb-randr0
+libxcb-cursor0
 libxcb-render-util0
 libxcb-xinerama0
 libxcb-icccm4-dev

--- a/ci/requirements/linux_full_newqtdeps_pip.txt
+++ b/ci/requirements/linux_full_newqtdeps_pip.txt
@@ -1,3 +1,3 @@
 pyopengltk
-pyqt6 <6.4.0
-pyqt6-qt6 <6.4.0
+pyqt6
+pyqt6-qt6

--- a/ci/requirements/linux_osmesa_deps_conda.txt
+++ b/ci/requirements/linux_osmesa_deps_conda.txt
@@ -1,7 +1,7 @@
 coveralls
 cython
 libglu
-mesalib
+mesalib >=25.0.5,<25.1.0
 meshio
 numpy
 pillow

--- a/ci/requirements/py312.yml
+++ b/ci/requirements/py312.yml
@@ -1,0 +1,6 @@
+name: vispy-tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - pip

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,6 @@ extensions = [Extension('vispy.visuals.text._sdf_cpu',
               ]
 
 install_requires = ['numpy', 'freetype-py', 'hsluv', 'kiwisolver', 'packaging']
-if sys.version_info < (3, 9):
-    install_requires.append("importlib-resources")
 
 readme = open('README.rst', 'r').read()
 setup(
@@ -96,7 +94,7 @@ setup(
     long_description_content_type='text/x-rst',
     platforms='any',
     provides=['vispy'],
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=install_requires,
     extras_require={
         'ipython-static': ['ipython'],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ Announcing:
 """
 
 import os
-import sys
 from os import path as op
 from setuptools import setup, find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/vispy/app/tests/test_app.py
+++ b/vispy/app/tests/test_app.py
@@ -155,7 +155,18 @@ def test_run():
             @c.events.draw.connect
             def draw(event):
                 print(event)  # test event __repr__
-                c.app.quit()
+                if c.app.backend_name.lower() in (
+                        "pyqt4",
+                        "pyqt5",
+                        "pyqt6",
+                        "pyside",
+                        "pyside2",
+                        "pyside6",
+                ):
+                    from vispy.app.backends._qt import QtCore
+                    QtCore.QTimer.singleShot(0, c.app.quit)
+                else:
+                    c.app.quit()
             c.update()
             c.app.run()
         c.app.quit()  # make sure it doesn't break if a user quits twice


### PR DESCRIPTION
# Reference
closes #2767 

# Description
Python 3.9 is out of its lifecycle. This PR drops the official support for python 3.9 so the range becomes 3.10-3.12. The build is adjusted accordingly and the ci jobs have been updated. Initially, to fix the osmesa job, a pin has been added for the mesalib libary in the environment file for the osmesa job. 

Additionally, python 3.12 is added to the CI jobs and the pyqt6 pin here is removed. I also added a timeout of 2m for setting up the system environment. Recently, ubuntu mirrors can be slow. This has nothing to do with the code. A timeout ensures the job doesn't hang for more than 2 hours, allowing quick restart of failed jobs.

A follow up PR will adjust the python versions supported to include up to python 3.14