### PR TITLE
Fix clipping for direct children of ViewBox

### DIFF
--- a/vispy/scene/tests/test_viewbox.py
+++ b/vispy/scene/tests/test_viewbox.py
@@ -3,15 +3,17 @@ from vispy.testing import requires_application, TestingCanvas
 
 
 @requires_application()
-def test_viewbox_clips_direct_children():
-    """Direct children of a viewbox should be clipped."""
+def test_viewbox_clips_direct_children_only():
     with TestingCanvas(size=(200, 200)) as c:
         grid = c.central_widget.add_grid()
         view = grid.add_view(row=0, col=0)
         view.size = (100, 100)  # simulate grid layout
         ell = scene.Ellipse(center=(0, 0), radius=20, parent=view)
 
-        # the direct child must inherit the ViewBox clipper
         assert view in ell._clippers
-        # bounds should track the viewbox rect
         assert ell._clippers[view].bounds is not None
+
+        line = scene.Line(pos=[[0, 0], [1, 1]], parent=view.scene)
+
+        assert view._scene in line._clippers
+        assert view not in line._clippers

--- a/vispy/scene/tests/test_viewbox.py
+++ b/vispy/scene/tests/test_viewbox.py
@@ -1,0 +1,17 @@
+from vispy import scene
+from vispy.testing import requires_application, TestingCanvas
+
+
+@requires_application()
+def test_viewbox_clips_direct_children():
+    """Direct children of a viewbox should be clipped."""
+    with TestingCanvas(size=(200, 200)) as c:
+        grid = c.central_widget.add_grid()
+        view = grid.add_view(row=0, col=0)
+        view.size = (100, 100)  # simulate grid layout
+        ell = scene.Ellipse(center=(0, 0), radius=20, parent=view)
+
+        # the direct child must inherit the ViewBox clipper
+        assert view in ell._clippers
+        # bounds should track the viewbox rect
+        assert ell._clippers[view].bounds is not None

--- a/vispy/scene/widgets/viewbox.py
+++ b/vispy/scene/widgets/viewbox.py
@@ -56,6 +56,11 @@ class ViewBox(Widget):
         self._scene.clip_children = True
         self.transforms.changed.connect(self._update_scene_clipper)
 
+        # we also want to clip direct children of viewbox (not just its scene),
+        # such as screen-space overlays
+        self.clip_children = True
+        self._update_clipper()
+
         # Camera is a helper object that handles scene transformation
         # and user interaction.
         if camera is None:

--- a/vispy/scene/widgets/viewbox.py
+++ b/vispy/scene/widgets/viewbox.py
@@ -58,7 +58,7 @@ class ViewBox(Widget):
 
         # we also want to clip direct children of viewbox (not just its scene),
         # such as screen-space overlays
-        self.clip_children = True
+        self._clipper = Clipper()
         self._update_clipper()
 
         # Camera is a helper object that handles scene transformation
@@ -198,7 +198,28 @@ class ViewBox(Widget):
             # happens during init
             return
         self._update_scene_clipper()
+        self._update_clipper()
 
     def _update_scene_clipper(self, event=None):
+        if self._scene is None:
+            return
         tr = self.get_transform('visual', 'framebuffer')
         self._scene._clipper.bounds = tr.map(self.inner_rect)
+
+    def _update_clipper(self, event=None):
+        # override the base Widget._update_clipper to work regardless of clip_children;
+        # if we used clip_children it would clip all the way down to the scene
+        if self._clipper is None:
+            self._clipper = Clipper()
+        self._clipper.bounds = self.inner_rect
+        self._clipper.transform = self.get_transform('framebuffer', 'visual')
+
+    def _add_child(self, node):
+        super()._add_child(node)
+        if node is not self._scene:
+            node._set_clipper(self, self._clipper)
+
+    def _remove_child(self, node):
+        if node is not self._scene:
+            node._set_clipper(self, None)
+        super()._remove_child(node)

--- a/vispy/scene/widgets/widget.py
+++ b/vispy/scene/widgets/widget.py
@@ -297,7 +297,7 @@ class Widget(Compound):
 
         if self._clipper is None:
             return
-        self._clipper.rect = self.inner_rect
+        self._clipper.bounds = self.inner_rect
         self._clipper.transform = self.get_transform('framebuffer', 'visual')
 
     @property


### PR DESCRIPTION
This issue cropped (HAH!) up in several places in the past:

- https://github.com/napari/napari/pull/9083#issuecomment-4795114872
- https://github.com/napari/napari/issues/8802

I finally tracked down the issue:
- clip_children should be True (I don't see why it shouldn't default to True)
- since it was never True, we never even noticed the fact that the clipper setter was setting the wrong attribute name (`rect` instead of `bounds`).

To see the difference, check out this code on main vs here; note how on main how the ellipse "spills" into the neighbouring viewbox when approaching the middle line (on left or right depending which viewbox is parented).

```py
from vispy import scene, app
import numpy as np

canvas = scene.SceneCanvas(keys='interactive')
canvas.size = 600, 600
canvas.show()

grid = canvas.central_widget.add_grid()

b1 = grid.add_view(row=0, col=0)
b1.border_color = (0.5, 0.5, 0.5, 1)
b1.camera = scene.PanZoomCamera(rect=(-0.5, -5, 11, 10))

b2 = grid.add_view(row=0, col=1)
b2.camera = 'turntable'
b2.border_color = (0.5, 0.5, 0.5, 1)

ellipse = scene.Ellipse(center=(0, 0), color='white', border_width=5, radius=20, parent=b1)

@canvas.events.mouse_move.connect
def on_mouse_move(event):
    viewbox_size = np.array(canvas.size) / (2, 1)
    viewbox_pos = event.pos % viewbox_size
    ellipse.center = viewbox_pos

@canvas.events.key_press.connect
def on_key(event):
    if event.text == '1':
        # switch viewbox
        ellipse.parent = b2 if ellipse.parent is b1 else b1

if __name__ == '__main__':
    app.run()
```

main:

<img width="602" height="602" alt="image" src="https://github.com/user-attachments/assets/275142d9-5efb-4d38-af33-cacc4852c714" />


this PR:

<img width="602" height="602" alt="image" src="https://github.com/user-attachments/assets/15066289-06d6-4127-b290-68a99993e711" />

