### PR TITLE
Add opt-in GLIR texture upload metering

### DIFF
--- a/vispy/gloo/__init__.py
+++ b/vispy/gloo/__init__.py
@@ -45,6 +45,7 @@ Example::
 from __future__ import division
 
 from . import gl  # noqa
+from . import glir_metering  # noqa
 from .wrappers import *  # noqa
 from .context import (GLContext, get_default_config,  # noqa
                       get_current_canvas)  # noqa

--- a/vispy/gloo/context.py
+++ b/vispy/gloo/context.py
@@ -153,13 +153,17 @@ class GLContext(BaseGlooFunctions):
         """The OpenGL capabilities"""
         return deepcopy(self.shared.parser.capabilities)
 
-    def flush_commands(self, event=None):
+    def flush_commands(self, event=None, force=False):
         """Flush
 
         Parameters
         ----------
         event : instance of Event
             The event.
+        force : bool
+            Execute all currently executable queued work. Automatic draw
+            flushes leave this false so optional command scheduling can apply
+            a per-draw budget.
         """
         if self._do_CURRENT_command:
             self._do_CURRENT_command = False
@@ -169,7 +173,11 @@ class GLContext(BaseGlooFunctions):
             else:
                 fbo = 0
             self.shared.parser.parse([('CURRENT', 0, fbo)])
-        self.glir.flush(self.shared.parser)
+        if force:
+            self.glir.flush(self.shared.parser, force=True)
+        else:
+            # Preserve the long-standing one-argument call for normal draws.
+            self.glir.flush(self.shared.parser)
 
     def set_viewport(self, *args):
         BaseGlooFunctions.set_viewport(self, *args)

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -501,8 +501,11 @@ class _GlirQueueShare(object):
     def flush(self, parser, force=False):
         """Flush current commands to the GLIR interpreter.
 
-        When *force* is true, optional command scheduling must execute all
-        currently executable work instead of applying a per-draw budget.
+        When ``force=False``, any configured command scheduling policy, such
+        as texture-upload metering, is respected. When ``force=True``, such
+        scheduling limits are bypassed and all currently executable commands
+        are processed. If no scheduling policy is enabled, *force* has no
+        effect and commands are flushed immediately as usual.
         """
         from . import glir_metering
 

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -499,7 +499,7 @@ class _GlirQueueShare(object):
         return commands
 
     def flush(self, parser, force=False):
-        """Flush all current commands to the GLIR interpreter.
+        """Flush current commands to the GLIR interpreter.
 
         When *force* is true, optional command scheduling must execute all
         currently executable work instead of applying a per-draw budget.

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -498,15 +498,19 @@ class _GlirQueueShare(object):
         self._commands = []
         return commands
 
-    def flush(self, parser):
-        """Flush all current commands to the GLIR interpreter."""
+    def flush(self, parser, force=False):
+        """Flush all current commands to the GLIR interpreter.
+
+        When *force* is true, optional command scheduling must execute all
+        currently executable work instead of applying a per-draw budget.
+        """
         from . import glir_metering
 
         if (
             glir_metering.is_installed()
             and getattr(parser, 'supports_texture_upload_metering', False)
         ):
-            glir_metering._flush(self, parser)
+            glir_metering._flush(self, parser, force=force)
             return
         if self._verbose:
             show = self._verbose if isinstance(self._verbose, str) else None
@@ -587,9 +591,9 @@ class GlirQueue(object):
             self._shared._associations[ch] = None
         queue._shared = self._shared
 
-    def flush(self, parser):
+    def flush(self, parser, force=False):
         """Flush all current commands to the GLIR interpreter."""
-        self._shared.flush(parser)
+        self._shared.flush(parser, force=force)
 
 
 def _convert_es2_shader(shader):
@@ -758,6 +762,9 @@ class GlirParser(BaseGlirParser):
 
         if cmd == 'CURRENT':
             # This context is made current
+            from . import glir_metering
+
+            glir_metering._on_parser_current(self)
             self.env.clear()
             self._gl_initialize()
             self.env['fbo'] = args[0]

--- a/vispy/gloo/glir.py
+++ b/vispy/gloo/glir.py
@@ -500,6 +500,14 @@ class _GlirQueueShare(object):
 
     def flush(self, parser):
         """Flush all current commands to the GLIR interpreter."""
+        from . import glir_metering
+
+        if (
+            glir_metering.is_installed()
+            and getattr(parser, 'supports_texture_upload_metering', False)
+        ):
+            glir_metering._flush(self, parser)
+            return
         if self._verbose:
             show = self._verbose if isinstance(self._verbose, str) else None
             self.show(show)
@@ -671,6 +679,8 @@ def as_es2_command(command):
 class BaseGlirParser(object):
     """Base class for GLIR parsers that can be attached to a GLIR queue."""
 
+    supports_texture_upload_metering = False
+
     def __init__(self):
         self.capabilities = dict(
             gl_version='Unknown',
@@ -703,6 +713,8 @@ class GlirParser(BaseGlirParser):
     dictionary so that commands like ACTIVATE and DATA can easily
     be executed on the corresponding objects.
     """
+
+    supports_texture_upload_metering = True
 
     def __init__(self):
         super(GlirParser, self).__init__()

--- a/vispy/gloo/glir_metering.py
+++ b/vispy/gloo/glir_metering.py
@@ -29,6 +29,13 @@ shared OpenGL context that receives the uploads. The budget resets at the
 start of each canvas draw. Offscreen users without draw events receive a
 time-based reset so a carry queue cannot remain stalled indefinitely.
 
+While metering is enabled, two related sources of GL stalls are also paced.
+Repeated idempotent ``FUNC`` state setters with unchanged arguments are
+skipped; this cache is cleared whenever a ``CURRENT`` command makes the
+context current. ``DELETE`` commands are held until a flush with no upload
+work, then executed in small batches. These behaviors apply only to the local
+parser path selected by :func:`install`.
+
 Metering is process-wide and opt-in through :func:`install`. It applies only
 to local OpenGL parsers; remote GLIR parsers and the default disabled path are
 unchanged.
@@ -98,10 +105,11 @@ _OBJECT_COMMANDS = frozenset(
 # the same arguments is semantically a no-op, but on a busy GPU each
 # call can block on pipeline synchronization (profiled at ~6ms average
 # on macOS GL-over-Metal; 271 calls cost 1.6s in one short session).
-# Consecutive duplicates are skipped. glEnable/glDisable are handled
-# per capability. Deliberately NOT listed: glClear*, glViewport,
-# glScissor, glFinish, glFlush (must always run or are
-# framebuffer-dependent).
+# Repeated duplicates are skipped. glEnable/glDisable are handled per
+# capability. State setters such as glViewport, glScissor, and glClearColor
+# are included because repeating them with identical arguments leaves the
+# context state unchanged. Commands that perform work, including glClear,
+# glFinish, and glFlush, are deliberately excluded and must always run.
 _IDEMPOTENT_FUNCS = frozenset(
     {
         'glBlendFunc',
@@ -141,15 +149,21 @@ _hooked_canvases: weakref.WeakSet = weakref.WeakSet()
 # carried without execution. Non-upload commands continue to execute.
 _upload_hold_until = 0.0
 
-# GLIR texture ids whose DATA commands bypass the byte budget. This is useful
-# when an application writes a complete staging texture before atomically
-# making it visible: splitting that write across draws could expose partially
-# initialized texture contents if the application switches textures too soon.
+# GLIR texture ids whose DATA commands bypass the byte budget. A typical use is
+# double buffering: an application fills a back texture, then makes it the
+# front texture only after the upload completes. The exemption makes the DATA
+# command synchronous; it neither swaps the textures nor coordinates when the
+# application makes the back texture visible.
 _unmetered_ids: set = set()
 
 
 def add_unmetered_texture(glir_id) -> None:
     """Make DATA commands for one GLIR texture bypass the byte budget.
+
+    This is useful for a staging or back texture that must be initialized in
+    one synchronous upload before an application makes it visible. VisPy does
+    not perform or schedule that visibility change; the application remains
+    responsible for it.
 
     Parameters
     ----------

--- a/vispy/gloo/glir_metering.py
+++ b/vispy/gloo/glir_metering.py
@@ -1,0 +1,654 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""Per-frame metering of vispy GLIR texture uploads.
+
+vispy drains its entire GLIR command queue inside whichever draw happens
+next — including interaction frames. With progressive loading, dozens of
+megabytes of ``glTexSubImage3D`` traffic can accumulate between draws and
+the drain then blocks the main thread for hundreds of milliseconds to
+seconds (macOS GL-over-Metal is the worst case: ~125 MB/s effective with
+multi-second outliers for large single uploads).
+
+When enabled, VisPy's GLIR queue dispatches through this module so that
+
+- a single large texture ``DATA`` command is split into small slab
+  sub-uploads (contiguous views along the leading axes, no copies), and
+- each frame spends at most ``frame_budget_bytes`` on texture uploads;
+  the remainder is carried to the *next* frame and a redraw is scheduled
+  so the carry keeps draining even without interaction.
+
+GLIR ordering semantics are preserved per object: once a command for a
+texture is deferred, every later command for that same texture id is
+deferred behind it. ``SIZE`` (re-specification) and ``DELETE`` commands
+cancel any earlier carried uploads for their id, mirroring vispy's own
+queue filtering.
+
+Metering is opt-in through :func:`install`; the default GLIR behavior is
+unchanged.
+
+Examples
+--------
+Enable a 4 MiB per-frame budget with 1 MiB upload slabs::
+
+    from vispy.gloo import glir_metering
+
+    glir_metering.install(
+        frame_budget_bytes=4 * 2**20,
+        slab_bytes=1 * 2**20,
+    )
+
+Run ``python -m vispy.gloo.glir_metering`` for a standalone
+vispy-only benchmark of draw time vs. texture upload size,
+with and without metering.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+import weakref
+
+import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    'DEFAULT_FRAME_BUDGET_BYTES',
+    'DEFAULT_SLAB_BYTES',
+    'add_drain_callback',
+    'add_unmetered_texture',
+    'discard_unmetered_texture',
+    'hold_uploads_until',
+    'install',
+    'is_installed',
+    'pending_upload_bytes',
+    'remove_drain_callback',
+    'uninstall',
+]
+
+_FACTORY_FRAME_BUDGET_BYTES = 4 * 2**20
+_FACTORY_SLAB_BYTES = 1 * 2**20
+DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
+DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
+#: Deferred GL object deletions executed per quiet flush. Deletion can
+#: sync the GPU pipeline, so the backlog drains a few per frame instead
+#: of all at once.
+DELETE_DRAIN_PER_FLUSH = 4
+#: 2D texture DATA at or above this size is metered like 3D uploads.
+#: Small 2D textures (colormap LUTs, interpolation kernels) MUST stay
+#: synchronous: deferring them leaves a shader sampling an unwritten
+#: texture for however long the carry takes to drain.
+TEX2D_MIN_METERED_BYTES = 256 * 1024
+
+# Commands that operate on a specific GLIR object id and therefore must
+# stay ordered behind any deferred command for the same id.
+_OBJECT_COMMANDS = frozenset(
+    {'DATA', 'SIZE', 'WRAPPING', 'INTERPOLATION', 'DELETE'},
+)
+
+# GL state setters that are idempotent: re-issuing the same call with
+# the same arguments is semantically a no-op, but on a busy GPU each
+# call can block on pipeline synchronization (profiled at ~6ms average
+# on macOS GL-over-Metal; 271 calls cost 1.6s in one short session).
+# Consecutive duplicates are skipped. glEnable/glDisable are handled
+# per capability. Deliberately NOT listed: glClear*, glViewport,
+# glScissor, glFinish, glFlush (must always run or are
+# framebuffer-dependent).
+_IDEMPOTENT_FUNCS = frozenset(
+    {
+        'glBlendFunc',
+        'glBlendFuncSeparate',
+        'glBlendEquation',
+        'glBlendEquationSeparate',
+        'glBlendColor',
+        'glDepthFunc',
+        'glDepthMask',
+        'glDepthRange',
+        'glCullFace',
+        'glFrontFace',
+        'glLineWidth',
+        'glPolygonOffset',
+        'glColorMask',
+        'glStencilFunc',
+        'glStencilFuncSeparate',
+        'glStencilMask',
+        'glStencilMaskSeparate',
+        'glStencilOp',
+        'glStencilOpSeparate',
+        'glHint',
+        'glSampleCoverage',
+        # value-state setters: global GL state, idempotent by args.
+        # glClear itself must always run and is never cached.
+        'glViewport',
+        'glScissor',
+        'glClearColor',
+        'glClearDepth',
+        'glClearStencil',
+    }
+)
+
+_enabled = False
+_hooked_canvases: weakref.WeakSet = weakref.WeakSet()
+# while time.monotonic() < this, defer ALL metered texture uploads
+# (interaction hold: see ProgressiveLoader._on_interaction)
+_upload_hold_until = 0.0
+
+# GLIR ids whose uploads are never metered. Double-buffered textures
+# register here: their writes always target an unbound texture and the
+# swap that makes them visible is atomic — deferring those uploads
+# would present a partially written texture (a black flash), the exact
+# artifact the buffering exists to prevent.
+_unmetered_ids: set = set()
+
+
+def add_unmetered_texture(glir_id) -> None:
+    """Exempt a texture's GLIR id from upload metering."""
+    _unmetered_ids.add(glir_id)
+
+
+def discard_unmetered_texture(glir_id) -> None:
+    """Remove a previously registered exemption (id may be absent)."""
+    _unmetered_ids.discard(glir_id)
+
+
+# weak callbacks invoked (on the GL/main thread) when a parser's upload
+# carry fully drains; used to restore interactive render LOD without a
+# polling timer
+_drain_callbacks: list = []
+
+
+def add_drain_callback(method) -> None:
+    """Register a bound method to call when an upload carry drains."""
+    ref = weakref.WeakMethod(method)
+    if all(ref != existing for existing in _drain_callbacks):
+        _drain_callbacks.append(ref)
+
+
+def remove_drain_callback(method) -> None:
+    """Remove a previously registered drain callback."""
+    _drain_callbacks[:] = [
+        ref
+        for ref in _drain_callbacks
+        if (cb := ref()) is not None and cb != method
+    ]
+
+
+def _notify_drained() -> None:
+    alive = []
+    for ref in _drain_callbacks:
+        cb = ref()
+        if cb is None:
+            continue
+        alive.append(ref)
+        try:
+            cb()
+        except Exception:  # pragma: no cover - callback bug
+            LOGGER.warning('drain callback failed', exc_info=True)
+    _drain_callbacks[:] = alive
+
+
+def pending_upload_bytes() -> int:
+    """Total bytes of carried (not yet executed) texture uploads.
+
+    Lets callers couple behavior to the upload backlog — e.g. keep the
+    interactive render LOD degraded until a level switch's full-tile
+    upload has fully drained into the GPU.
+    """
+    return sum(
+        sum(c[3].nbytes for c in state.carry if c[0] == 'DATA')
+        for state in _states.values()
+    )
+
+
+def hold_uploads_until(deadline: float) -> None:
+    """Defer all metered texture uploads until ``time.monotonic()`` >= deadline.
+
+    Called on every interaction event; the deadline only ever extends.
+    Carried uploads keep scheduling redraws, so draining resumes by
+    itself once the hold expires.
+    """
+    global _upload_hold_until
+    _upload_hold_until = max(_upload_hold_until, float(deadline))
+
+
+class _ParserState:
+    """Per-GlirParser metering state (carry survives across flushes)."""
+
+    def __init__(self, frame_budget_bytes: int, slab_bytes: int):
+        self.frame_budget = int(frame_budget_bytes)
+        self.slab_bytes = min(int(slab_bytes), self.frame_budget)
+        self.budget_left = self.frame_budget
+        self.carry: list[tuple] = []
+        self.last_reset = time.perf_counter()
+        # last-applied GL state for the redundant-FUNC filter; cleared
+        # whenever the context is made current
+        self.gl_state: dict = {}
+        # DELETE commands held until a quiet flush: each delete
+        # synchronizes with pending GPU work (~25ms profiled), so they
+        # run only in flushes with no uploads and no interaction hold.
+        # Safe to defer arbitrarily: GLIR ids are never reused.
+        self.deferred_deletes: list[tuple] = []
+        # ids whose deferred DELETE has executed. Deferral reorders
+        # deletes past later flushes, so commands for these ids can
+        # still arrive (e.g. from another canvas's queue on a shared
+        # context) — they are void and must be dropped, exactly as an
+        # inline delete would have voided them. Ids are never reused,
+        # so membership stays valid for the parser's lifetime.
+        self.dead_ids: set = set()
+        # whether the current flush executed any metered DATA command;
+        # drives drain notification for uploads small enough to never
+        # have been carried
+        self.executed_metered = False
+
+    def reset_budget(self):
+        self.budget_left = self.frame_budget
+        self.last_reset = time.perf_counter()
+
+
+# keyed by GlirParser so canvases sharing a context share one budget
+_states: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+def _state_for(parser) -> _ParserState:
+    state = _states.get(parser)
+    if state is None:
+        # read the module globals at call time: install() retunes them
+        state = _ParserState(DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES)
+        _states[parser] = state
+    return state
+
+
+def _is_metered_texture(ob, data=None) -> bool:
+    """Whether uploads to this GLIR object count against the budget.
+
+    All 3D textures are metered (the pathological path on macOS). 2D
+    textures are metered only for payloads of at least
+    ``TEX2D_MIN_METERED_BYTES`` — image tiles, not colormap LUTs or
+    interpolation kernels, which must upload synchronously so shaders
+    never sample an unwritten texture.
+    """
+    from vispy.gloo import glir
+
+    if isinstance(ob, glir.GlirTexture3D):
+        return True
+    return (
+        TEX2D_MIN_METERED_BYTES > 0
+        and isinstance(ob, glir.GlirTexture2D)
+        and data is not None
+        and getattr(data, 'nbytes', 0) >= TEX2D_MIN_METERED_BYTES
+    )
+
+
+def _split_slabs(offset, data, slab_bytes):
+    """Split a texture DATA payload into <= slab_bytes sub-uploads.
+
+    Splits along the leading texel axis first (contiguous views of a
+    C-contiguous source), recursing into the second axis when a single
+    leading slice is itself too large. Yields ``(offset, subarray)``.
+    """
+    if data.nbytes <= slab_bytes or data.ndim < 2 or data.shape[0] == 0:
+        yield tuple(offset), data
+        return
+    bytes_per_slice = data.nbytes // data.shape[0]
+    step = max(1, int(slab_bytes // max(1, bytes_per_slice)))
+    for start in range(0, data.shape[0], step):
+        sub = data[start:start + step]
+        sub_offset = list(offset)
+        sub_offset[0] += start
+        if sub.nbytes > slab_bytes and sub.shape[0] == 1 and sub.ndim >= 3:
+            # one leading slice is still too big: split its rows
+            for in_off, in_sub in _split_slabs(
+                offset=list(sub_offset[1:]),
+                data=sub[0],
+                slab_bytes=slab_bytes,
+            ):
+                yield (sub_offset[0], *in_off), in_sub[np.newaxis]
+        else:
+            yield tuple(sub_offset), sub
+
+
+def _drop_deleted_carry(carry, new_commands):
+    """Drop carried uploads whose texture is deleted in this flush.
+
+    The carry only ever holds commands for metered textures, so this
+    cannot affect other object types (notably shaders, whose DATA must
+    survive even though vispy DELETEs them right after LINK).
+    """
+    deleted = {c[1] for c in new_commands if c[0] == 'DELETE'}
+    if not deleted:
+        return carry
+    return [c for c in carry if c[1] not in deleted]
+
+
+def _metered_parse(parser, commands, state, force_defer=False):
+    """Execute commands under the upload budget; return the leftovers.
+
+    With ``force_defer`` every metered texture upload is deferred
+    regardless of budget (interaction hold); other commands still run.
+    """
+    # mirror GlirParser.parse's deferred deletion bookkeeping, which we
+    # bypass by calling _parse directly
+    from vispy.gloo.glir import JUST_DELETED
+
+    for id_ in [
+        id_ for id_, val in parser._objects.items() if val == JUST_DELETED
+    ]:
+        parser._objects.pop(id_)
+
+    deferred_ids = set()
+    leftover = []
+    gl_state = state.gl_state
+    for command in commands:
+        cmd = command[0]
+        id_ = command[1] if len(command) > 1 else None
+        if id_ in deferred_ids and cmd in _OBJECT_COMMANDS:
+            leftover.append(command)
+            continue
+        if cmd == 'FUNC':
+            # skip GL state calls that match the last-applied state: on
+            # a busy GPU even redundant glEnable/glBlendFunc calls
+            # block on pipeline sync
+            if id_ in ('glEnable', 'glDisable') and len(command) == 3:
+                key = ('cap', command[2])
+                if gl_state.get(key) == id_:
+                    continue
+                gl_state[key] = id_
+            elif id_ in _IDEMPOTENT_FUNCS:
+                key = ('fn', id_)
+                if gl_state.get(key) == command[2:]:
+                    continue
+                gl_state[key] = command[2:]
+        elif cmd == 'CURRENT':
+            # context switch: cached GL state is no longer trustworthy
+            gl_state.clear()
+        elif cmd == 'DELETE':
+            # run deletes only in quiet flushes (see _ParserState):
+            # ordering is safe because anything queued for this id
+            # earlier either already executed or was dropped with it
+            state.deferred_deletes.append(command)
+            continue
+        if cmd == 'DATA':
+            ob = parser._objects.get(id_, None)
+            if id_ not in _unmetered_ids and _is_metered_texture(
+                ob,
+                command[3],
+            ):
+                offset, data = command[2], command[3]
+                executed_any = False
+                for sub_offset, sub in _split_slabs(
+                    offset,
+                    data,
+                    state.slab_bytes,
+                ):
+                    # always make progress: with a full budget, upload at
+                    # least one slab even if it alone exceeds the budget
+                    fresh = state.budget_left >= state.frame_budget
+                    if (
+                        force_defer
+                        or state.budget_left <= 0
+                        or (
+                            sub.nbytes > state.budget_left
+                            and not (fresh and not executed_any)
+                        )
+                    ):
+                        deferred_ids.add(id_)
+                        leftover.append(('DATA', id_, sub_offset, sub))
+                        continue
+                    if not sub.flags['C_CONTIGUOUS']:
+                        sub = np.ascontiguousarray(sub)
+                    parser._parse(('DATA', id_, sub_offset, sub))
+                    state.budget_left -= sub.nbytes
+                    executed_any = True
+                    state.executed_metered = True
+                continue
+        try:
+            parser._parse(command)
+        except RuntimeError as exc:
+            if 'does not exist' not in str(exc):
+                raise
+            # the deferred DELETE drain reorders deletes past later
+            # flushes, so a command can arrive for an object that no
+            # longer exists (or does not exist YET, when its CREATE
+            # sits in another queue of a shared context)
+            if id_ in state.dead_ids:
+                continue  # deleted: the command is void, drop it
+            # not created yet: keep it (and everything ordered behind
+            # it) in the carry until its CREATE arrives
+            LOGGER.debug('deferring %s for missing object %s', cmd, id_)
+            deferred_ids.add(id_)
+            leftover.append(command)
+    return leftover
+
+
+def _attach_reset_hook(canvas):
+    """Reset the upload budget at the start of each canvas draw."""
+    if canvas is None or canvas in _hooked_canvases:
+        return
+    canvas_ref = weakref.ref(canvas)
+
+    def _on_draw(event=None):
+        if not _enabled:
+            return
+        c = canvas_ref()
+        if c is None:
+            return
+        try:
+            parser = c.context.shared.parser
+        except (AttributeError, RuntimeError):
+            return
+        _state_for(parser).reset_budget()
+
+    # position='first': run before the scene draw issues any flushes
+    try:
+        canvas.events.draw.connect(_on_draw, position='first')
+    except RuntimeError:
+        return
+    _hooked_canvases.add(canvas)
+
+
+def _flush(queue, parser):
+    """Flush a GLIR queue with per-frame upload metering."""
+    from vispy.gloo.context import get_current_canvas
+
+    if queue._verbose:
+        show = queue._verbose if isinstance(queue._verbose, str) else None
+        queue.show(show)
+
+    state = _state_for(parser)
+    canvas = get_current_canvas()
+    _attach_reset_hook(canvas)
+    # fallback when no canvas draw hook fires (offscreen / bare gloo):
+    # never let the carry starve for more than 0.25 s
+    if (
+        state.budget_left < state.frame_budget
+        and time.perf_counter() - state.last_reset > 0.25
+    ):
+        state.reset_budget()
+
+    carry, state.carry = state.carry, []
+    new_commands = queue.clear()
+    carry = _drop_deleted_carry(carry, new_commands)
+    commands = queue._filter(carry + new_commands, parser)
+    holding = time.monotonic() < _upload_hold_until
+    had_carry = bool(carry)
+    state.executed_metered = False
+    state.carry = _metered_parse(parser, commands, state, force_defer=holding)
+
+    if state.carry and canvas is not None:
+        with contextlib.suppress(RuntimeError):
+            canvas.update()
+    elif (had_carry or state.executed_metered) and not state.carry:
+        # notify on any flush that landed metered uploads and ended
+        # clean — not only when a carry drained: uploads small enough
+        # to fit one frame budget are never carried, but a present
+        # (texture swap) may still be waiting on them
+        _notify_drained()
+
+    if (
+        state.deferred_deletes
+        and not holding
+        and not state.carry
+        and state.budget_left >= state.frame_budget
+    ):
+        # a quiet flush (no uploads this frame, no interaction): run
+        # held GL object deletions now, off the busy periods. PACED:
+        # each delete can sync the GPU pipeline (~10-25ms on busy macOS
+        # GL-over-Metal), so draining hundreds in one flush is itself a
+        # multi-second stall — exactly at pass end, when the queue is
+        # deepest. The remainder drains over subsequent redraws.
+        n = DELETE_DRAIN_PER_FLUSH
+        deletes = state.deferred_deletes[:n]
+        state.deferred_deletes = state.deferred_deletes[n:]
+        for command in deletes:
+            parser._parse(command)
+            state.dead_ids.add(command[1])
+        if state.deferred_deletes and canvas is not None:
+            with contextlib.suppress(RuntimeError):
+                canvas.update()
+
+
+def install(
+    frame_budget_bytes: int | None = None,
+    slab_bytes: int | None = None,
+) -> bool:
+    """Enable GLIR texture-upload metering (idempotent).
+
+    Returns True if metering is active after the call.
+    """
+    global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
+
+    frame_budget_bytes = int(
+        DEFAULT_FRAME_BUDGET_BYTES
+        if frame_budget_bytes is None
+        else frame_budget_bytes
+    )
+    slab_bytes = int(DEFAULT_SLAB_BYTES if slab_bytes is None else slab_bytes)
+    if frame_budget_bytes <= 0:
+        raise ValueError('frame_budget_bytes must be positive')
+    if slab_bytes <= 0:
+        raise ValueError('slab_bytes must be positive')
+
+    # re-parameterize existing states (and set defaults for new ones)
+    DEFAULT_FRAME_BUDGET_BYTES = frame_budget_bytes
+    DEFAULT_SLAB_BYTES = slab_bytes
+    for state in _states.values():
+        state.frame_budget = frame_budget_bytes
+        state.slab_bytes = min(slab_bytes, frame_budget_bytes)
+
+    if not _enabled:
+        _enabled = True
+        LOGGER.info(
+            'GLIR texture upload metering enabled '
+            '(budget=%d B/frame, slab=%d B)',
+            frame_budget_bytes,
+            slab_bytes,
+        )
+    return True
+
+
+def uninstall():
+    """Disable metering and synchronously flush deferred commands."""
+    global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
+    DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
+    DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
+    if not _enabled:
+        return
+    _enabled = False
+    # re-queue carried uploads and held deletions so they are not lost
+    for parser, state in list(_states.items()):
+        if state.carry:
+            commands, state.carry = state.carry, []
+            parser.parse(commands)
+        if state.deferred_deletes:
+            commands, state.deferred_deletes = state.deferred_deletes, []
+            parser.parse(commands)
+    _states.clear()
+
+
+def is_installed() -> bool:
+    return _enabled
+
+
+def _benchmark():  # pragma: no cover - manual profiling tool
+    """Pure-vispy benchmark: draw time vs. 3D texture upload size.
+
+    Renders a vispy Volume and times the draw immediately after
+    ``set_data`` calls of increasing size, with metering off and on.
+    This is the minimal repro for the macOS GL-over-Metal upload stalls
+    (run on Apple Silicon and compare the two curves).
+    """
+    import argparse
+
+    parser_ = argparse.ArgumentParser(description=__doc__)
+    parser_.add_argument('--size', type=int, default=512, help='volume edge')
+    parser_.add_argument('--repeats', type=int, default=5)
+    parser_.add_argument(
+        '--budget',
+        type=int,
+        default=DEFAULT_FRAME_BUDGET_BYTES,
+    )
+    parser_.add_argument('--slab', type=int, default=DEFAULT_SLAB_BYTES)
+    args = parser_.parse_args()
+
+    from vispy import app, scene
+
+    canvas = scene.SceneCanvas(keys=None, size=(800, 600), show=True)
+    view = canvas.central_widget.add_view()
+    n = args.size
+    rng = np.random.default_rng(0)
+    base = rng.random((n, n, n), dtype=np.float32)
+    volume = scene.visuals.Volume(base, parent=view.scene)
+    view.camera = scene.cameras.TurntableCamera(parent=view.scene, fov=60.0)
+
+    def timed_draw():
+        t0 = time.perf_counter()
+        canvas.render()  # forces a full draw + flush
+        return time.perf_counter() - t0
+
+    sub_mb_sizes = [1, 2, 4, 8, 16, 32, 64]
+    for label, metered in (('unmetered', False), ('metered', True)):
+        if metered:
+            install(frame_budget_bytes=args.budget, slab_bytes=args.slab)
+        else:
+            uninstall()
+        # warm up
+        for _ in range(3):
+            timed_draw()
+        print(f'--- {label} ---')  # noqa: T201
+        for mb in sub_mb_sizes:
+            nz = max(1, int(mb * 2**20 // (n * n * base.itemsize)))
+            if nz > n:
+                break
+            sub = rng.random((nz, n, n), dtype=np.float32)
+            times = []
+            for i in range(args.repeats):
+                z = (i * nz) % max(1, n - nz)
+                t0 = time.perf_counter()
+                volume._texture.set_data(sub, offset=(z, 0, 0))
+                t_set = time.perf_counter() - t0
+                t_draw = timed_draw()
+                # with metering, drain the carry and count total time.
+                # canvas.render() bypasses the draw event, so emulate the
+                # per-frame budget reset a real paint event would trigger.
+                t_drain = 0.0
+                if metered:
+                    while _states and any(s.carry for s in _states.values()):
+                        for s in _states.values():
+                            s.reset_budget()
+                        t_drain += timed_draw()
+                times.append((t_set, t_draw, t_drain))
+            worst = max(t[1] for t in times)
+            total = max(t[1] + t[2] for t in times)
+            print(  # noqa: T201
+                f'{mb:>4} MB sub-upload: worst single draw '
+                f'{worst * 1e3:7.1f} ms, total incl. drain '
+                f'{total * 1e3:7.1f} ms',
+            )
+    app.process_events()
+    canvas.close()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    _benchmark()

--- a/vispy/gloo/glir_metering.py
+++ b/vispy/gloo/glir_metering.py
@@ -40,6 +40,10 @@ Metering is process-wide and opt-in through :func:`install`. It applies only
 to local OpenGL parsers; remote GLIR parsers and the default disabled path are
 unchanged.
 
+Automatic canvas draws apply the configured byte budget. Explicit
+``gloo.flush()`` and ``gloo.finish()`` calls preserve their usual synchronous
+queue semantics by executing all currently executable deferred uploads.
+
 Examples
 --------
 Enable a 4 MiB per-frame budget with 1 MiB upload slabs::
@@ -301,6 +305,13 @@ def _state_for(parser) -> _ParserState:
     return state
 
 
+def _on_parser_current(parser) -> None:
+    """Invalidate cached applied state when *parser* changes GL context."""
+    state = _states.get(parser)
+    if state is not None:
+        state.gl_state.clear()
+
+
 def _is_metered_texture(ob, data=None) -> bool:
     """Whether uploads to this GLIR object count against the budget.
 
@@ -363,12 +374,21 @@ def _drop_deleted_carry(carry, new_commands):
     return [c for c in carry if c[1] not in deleted]
 
 
-def _metered_parse(parser, commands, state, force_defer=False):
+def _metered_parse(
+    parser,
+    commands,
+    state,
+    force_defer=False,
+    force_uploads=False,
+    defer_deletes=True,
+):
     """Execute commands under the upload budget; return the leftovers.
 
     With ``force_defer`` every metered texture upload is deferred
     regardless of budget; other commands still run. This implements the
-    deadline configured by :func:`hold_uploads_until`.
+    deadline configured by :func:`hold_uploads_until`. ``force_uploads``
+    bypasses both that deadline and the byte budget. ``defer_deletes``
+    controls whether DELETE commands are paced or executed inline.
     """
     # mirror GlirParser.parse's deferred deletion bookkeeping, which we
     # bypass by calling _parse directly
@@ -405,7 +425,7 @@ def _metered_parse(parser, commands, state, force_defer=False):
         elif cmd == 'CURRENT':
             # context switch: cached GL state is no longer trustworthy
             gl_state.clear()
-        elif cmd == 'DELETE':
+        elif cmd == 'DELETE' and defer_deletes:
             # run deletes only in quiet flushes (see _ParserState):
             # ordering is safe because anything queued for this id
             # earlier either already executed or was dropped with it
@@ -428,11 +448,14 @@ def _metered_parse(parser, commands, state, force_defer=False):
                     # least one slab even if it alone exceeds the budget
                     fresh = state.budget_left >= state.frame_budget
                     if (
-                        force_defer
-                        or state.budget_left <= 0
-                        or (
-                            sub.nbytes > state.budget_left
-                            and not (fresh and not executed_any)
+                        not force_uploads
+                        and (
+                            force_defer
+                            or state.budget_left <= 0
+                            or (
+                                sub.nbytes > state.budget_left
+                                and not (fresh and not executed_any)
+                            )
                         )
                     ):
                         deferred_ids.add(id_)
@@ -490,7 +513,16 @@ def _attach_reset_hook(canvas):
     _hooked_canvases.add(canvas)
 
 
-def _flush(queue, parser):
+def _drain_deletes(parser, state, limit=None):
+    """Execute up to *limit* previously deferred DELETE commands."""
+    deletes = state.deferred_deletes[:limit]
+    del state.deferred_deletes[:len(deletes)]
+    for command in deletes:
+        parser._parse(command)
+        state.dead_ids.add(command[1])
+
+
+def _flush(queue, parser, force=False):
     """Flush a GLIR queue with per-frame upload metering."""
     from vispy.gloo.context import get_current_canvas
 
@@ -501,6 +533,10 @@ def _flush(queue, parser):
     state = _state_for(parser)
     canvas = get_current_canvas()
     _attach_reset_hook(canvas)
+    if force:
+        # These commands predate the new queue contents, including the
+        # glFlush/glFinish command that requested this forced drain.
+        _drain_deletes(parser, state)
     # fallback when no canvas draw hook fires (offscreen / bare gloo):
     # never let the carry starve for more than 0.25 s
     if (
@@ -513,10 +549,21 @@ def _flush(queue, parser):
     new_commands = queue.clear()
     carry = _drop_deleted_carry(carry, new_commands)
     commands = queue._filter(carry + new_commands, parser)
-    holding = time.monotonic() < _upload_hold_until
+    holding = not force and time.monotonic() < _upload_hold_until
     had_carry = bool(carry)
     state.executed_metered = False
-    state.carry = _metered_parse(parser, commands, state, force_defer=holding)
+    state.carry = _metered_parse(
+        parser,
+        commands,
+        state,
+        force_defer=holding,
+        force_uploads=force,
+        defer_deletes=not force,
+    )
+    if force:
+        # A forced drain is outside the per-draw allowance. Start the next
+        # automatic draw with a fresh budget rather than a negative balance.
+        state.reset_budget()
 
     if state.carry and canvas is not None:
         with contextlib.suppress(RuntimeError):
@@ -529,7 +576,8 @@ def _flush(queue, parser):
         _notify_drained()
 
     if (
-        state.deferred_deletes
+        not force
+        and state.deferred_deletes
         and not holding
         and not state.carry
         and state.budget_left >= state.frame_budget
@@ -541,12 +589,7 @@ def _flush(queue, parser):
         # multi-second stall after a burst of object creation, when the
         # deletion queue is deepest. The remainder drains over subsequent
         # redraws.
-        n = DELETE_DRAIN_PER_FLUSH
-        deletes = state.deferred_deletes[:n]
-        state.deferred_deletes = state.deferred_deletes[n:]
-        for command in deletes:
-            parser._parse(command)
-            state.dead_ids.add(command[1])
+        _drain_deletes(parser, state, DELETE_DRAIN_PER_FLUSH)
         if state.deferred_deletes and canvas is not None:
             with contextlib.suppress(RuntimeError):
                 canvas.update()

--- a/vispy/gloo/glir_metering.py
+++ b/vispy/gloo/glir_metering.py
@@ -3,20 +3,20 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 """Per-frame metering of vispy GLIR texture uploads.
 
-vispy drains its entire GLIR command queue inside whichever draw happens
-next — including interaction frames. With progressive loading, dozens of
-megabytes of ``glTexSubImage3D`` traffic can accumulate between draws and
-the drain then blocks the main thread for hundreds of milliseconds to
-seconds (macOS GL-over-Metal is the worst case: ~125 MB/s effective with
-multi-second outliers for large single uploads).
+VisPy normally drains its entire GLIR command queue during the next draw.
+Applications that update large textures incrementally can therefore queue
+many megabytes of ``glTexSubImage2D`` or ``glTexSubImage3D`` work between
+draws. Executing it all at once blocks the thread performing the draw and
+can make input handling visibly stall. This is especially costly on macOS
+when OpenGL calls are translated to Metal.
 
 When enabled, VisPy's GLIR queue dispatches through this module so that
 
 - a single large texture ``DATA`` command is split into small slab
   sub-uploads (contiguous views along the leading axes, no copies), and
-- each frame spends at most ``frame_budget_bytes`` on texture uploads;
-  the remainder is carried to the *next* frame and a redraw is scheduled
-  so the carry keeps draining even without interaction.
+- each canvas draw spends at most ``frame_budget_bytes`` on texture uploads;
+  the unexecuted commands are retained in a per-context carry queue and a
+  redraw is requested until that queue is empty.
 
 GLIR ordering semantics are preserved per object: once a command for a
 texture is deferred, every later command for that same texture id is
@@ -24,7 +24,13 @@ deferred behind it. ``SIZE`` (re-specification) and ``DELETE`` commands
 cancel any earlier carried uploads for their id, mirroring vispy's own
 queue filtering.
 
-Metering is opt-in through :func:`install`; the default GLIR behavior is
+The byte budget is shared by canvases that share a GLIR parser, matching the
+shared OpenGL context that receives the uploads. The budget resets at the
+start of each canvas draw. Offscreen users without draw events receive a
+time-based reset so a carry queue cannot remain stalled indefinitely.
+
+Metering is process-wide and opt-in through :func:`install`. It applies only
+to local OpenGL parsers; remote GLIR parsers and the default disabled path are
 unchanged.
 
 Examples
@@ -72,9 +78,9 @@ _FACTORY_FRAME_BUDGET_BYTES = 4 * 2**20
 _FACTORY_SLAB_BYTES = 1 * 2**20
 DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
 DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
-#: Deferred GL object deletions executed per quiet flush. Deletion can
-#: sync the GPU pipeline, so the backlog drains a few per frame instead
-#: of all at once.
+#: Deferred GL object deletions executed per quiet flush (a flush with no
+#: texture uploads and no active upload hold). Deletion can synchronize the
+#: GPU pipeline, so only a small batch executes in each such flush.
 DELETE_DRAIN_PER_FLUSH = 4
 #: 2D texture DATA at or above this size is metered like 3D uploads.
 #: Small 2D textures (colormap LUTs, interpolation kernels) MUST stay
@@ -131,43 +137,63 @@ _IDEMPOTENT_FUNCS = frozenset(
 
 _enabled = False
 _hooked_canvases: weakref.WeakSet = weakref.WeakSet()
-# while time.monotonic() < this, defer ALL metered texture uploads
-# (interaction hold: see ProgressiveLoader._on_interaction)
+# Absolute ``time.monotonic`` deadline before which metered DATA commands are
+# carried without execution. Non-upload commands continue to execute.
 _upload_hold_until = 0.0
 
-# GLIR ids whose uploads are never metered. Double-buffered textures
-# register here: their writes always target an unbound texture and the
-# swap that makes them visible is atomic — deferring those uploads
-# would present a partially written texture (a black flash), the exact
-# artifact the buffering exists to prevent.
+# GLIR texture ids whose DATA commands bypass the byte budget. This is useful
+# when an application writes a complete staging texture before atomically
+# making it visible: splitting that write across draws could expose partially
+# initialized texture contents if the application switches textures too soon.
 _unmetered_ids: set = set()
 
 
 def add_unmetered_texture(glir_id) -> None:
-    """Exempt a texture's GLIR id from upload metering."""
+    """Make DATA commands for one GLIR texture bypass the byte budget.
+
+    Parameters
+    ----------
+    glir_id : int
+        The texture object's GLIR identifier.
+    """
     _unmetered_ids.add(glir_id)
 
 
 def discard_unmetered_texture(glir_id) -> None:
-    """Remove a previously registered exemption (id may be absent)."""
+    """Remove a texture exemption if it is present.
+
+    Parameters
+    ----------
+    glir_id : int
+        The texture object's GLIR identifier.
+    """
     _unmetered_ids.discard(glir_id)
 
 
-# weak callbacks invoked (on the GL/main thread) when a parser's upload
-# carry fully drains; used to restore interactive render LOD without a
-# polling timer
+# Weakly referenced bound methods invoked on the drawing thread after a flush
+# executes metered DATA commands and leaves no deferred upload commands. A
+# consumer can use this notification instead of polling pending_upload_bytes().
 _drain_callbacks: list = []
 
 
 def add_drain_callback(method) -> None:
-    """Register a bound method to call when an upload carry drains."""
+    """Register a bound method to call after metered uploads drain.
+
+    The callback is weakly referenced, so registration does not extend the
+    lifetime of its object.
+
+    Parameters
+    ----------
+    method : bound method
+        A no-argument method. It runs on the thread performing the GLIR flush.
+    """
     ref = weakref.WeakMethod(method)
     if all(ref != existing for existing in _drain_callbacks):
         _drain_callbacks.append(ref)
 
 
 def remove_drain_callback(method) -> None:
-    """Remove a previously registered drain callback."""
+    """Remove a previously registered bound method if it is present."""
     _drain_callbacks[:] = [
         ref
         for ref in _drain_callbacks
@@ -190,12 +216,7 @@ def _notify_drained() -> None:
 
 
 def pending_upload_bytes() -> int:
-    """Total bytes of carried (not yet executed) texture uploads.
-
-    Lets callers couple behavior to the upload backlog — e.g. keep the
-    interactive render LOD degraded until a level switch's full-tile
-    upload has fully drained into the GPU.
-    """
+    """Return bytes in deferred texture DATA commands across all contexts."""
     return sum(
         sum(c[3].nbytes for c in state.carry if c[0] == 'DATA')
         for state in _states.values()
@@ -205,9 +226,15 @@ def pending_upload_bytes() -> int:
 def hold_uploads_until(deadline: float) -> None:
     """Defer all metered texture uploads until ``time.monotonic()`` >= deadline.
 
-    Called on every interaction event; the deadline only ever extends.
-    Carried uploads keep scheduling redraws, so draining resumes by
-    itself once the hold expires.
+    Non-upload GLIR commands continue to execute during the hold. Calling this
+    function with an earlier deadline does not shorten an existing hold.
+    Deferred uploads request redraws, so they resume without another external
+    event after the deadline passes.
+
+    Parameters
+    ----------
+    deadline : float
+        Absolute deadline in the clock domain used by ``time.monotonic()``.
     """
     global _upload_hold_until
     _upload_hold_until = max(_upload_hold_until, float(deadline))
@@ -227,7 +254,7 @@ class _ParserState:
         self.gl_state: dict = {}
         # DELETE commands held until a quiet flush: each delete
         # synchronizes with pending GPU work (~25ms profiled), so they
-        # run only in flushes with no uploads and no interaction hold.
+        # run only in flushes that execute no uploads and have no active hold.
         # Safe to defer arbitrarily: GLIR ids are never reused.
         self.deferred_deletes: list[tuple] = []
         # ids whose deferred DELETE has executed. Deferral reorders
@@ -263,11 +290,11 @@ def _state_for(parser) -> _ParserState:
 def _is_metered_texture(ob, data=None) -> bool:
     """Whether uploads to this GLIR object count against the budget.
 
-    All 3D textures are metered (the pathological path on macOS). 2D
+    All 3D textures are metered (the highest-volume path on macOS). 2D
     textures are metered only for payloads of at least
-    ``TEX2D_MIN_METERED_BYTES`` — image tiles, not colormap LUTs or
-    interpolation kernels, which must upload synchronously so shaders
-    never sample an unwritten texture.
+    ``TEX2D_MIN_METERED_BYTES``. Smaller payloads commonly initialize lookup
+    tables or interpolation kernels; they execute synchronously so a draw does
+    not sample those textures before initialization is complete.
     """
     from vispy.gloo import glir
 
@@ -326,7 +353,8 @@ def _metered_parse(parser, commands, state, force_defer=False):
     """Execute commands under the upload budget; return the leftovers.
 
     With ``force_defer`` every metered texture upload is deferred
-    regardless of budget (interaction hold); other commands still run.
+    regardless of budget; other commands still run. This implements the
+    deadline configured by :func:`hold_uploads_until`.
     """
     # mirror GlirParser.parse's deferred deletion bookkeeping, which we
     # bypass by calling _parse directly
@@ -481,9 +509,9 @@ def _flush(queue, parser):
             canvas.update()
     elif (had_carry or state.executed_metered) and not state.carry:
         # notify on any flush that landed metered uploads and ended
-        # clean — not only when a carry drained: uploads small enough
-        # to fit one frame budget are never carried, but a present
-        # (texture swap) may still be waiting on them
+        # clean. This includes an upload that fit entirely within one budget
+        # and therefore never entered the carry queue; consumers may still
+        # need notification that the DATA command has reached the parser.
         _notify_drained()
 
     if (
@@ -492,12 +520,13 @@ def _flush(queue, parser):
         and not state.carry
         and state.budget_left >= state.frame_budget
     ):
-        # a quiet flush (no uploads this frame, no interaction): run
+        # A quiet flush executes no uploads and has no active hold. Run
         # held GL object deletions now, off the busy periods. PACED:
         # each delete can sync the GPU pipeline (~10-25ms on busy macOS
         # GL-over-Metal), so draining hundreds in one flush is itself a
-        # multi-second stall — exactly at pass end, when the queue is
-        # deepest. The remainder drains over subsequent redraws.
+        # multi-second stall after a burst of object creation, when the
+        # deletion queue is deepest. The remainder drains over subsequent
+        # redraws.
         n = DELETE_DRAIN_PER_FLUSH
         deletes = state.deferred_deletes[:n]
         state.deferred_deletes = state.deferred_deletes[n:]
@@ -513,9 +542,23 @@ def install(
     frame_budget_bytes: int | None = None,
     slab_bytes: int | None = None,
 ) -> bool:
-    """Enable GLIR texture-upload metering (idempotent).
+    """Enable GLIR texture-upload metering for local OpenGL parsers.
 
-    Returns True if metering is active after the call.
+    Parameters
+    ----------
+    frame_budget_bytes : int | None
+        Maximum texture DATA bytes executed per canvas draw. ``None`` uses the
+        current module default.
+    slab_bytes : int | None
+        Maximum target size of each sub-upload. A texel row or slice that
+        cannot be divided further may exceed this value. ``None`` uses the
+        current module default.
+
+    Returns
+    -------
+    enabled : bool
+        ``True`` after successful configuration. Repeated calls are safe and
+        update both existing parser states and defaults for future parsers.
     """
     global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
 
@@ -549,7 +592,10 @@ def install(
 
 
 def uninstall():
-    """Disable metering and synchronously flush deferred commands."""
+    """Disable metering and synchronously execute all deferred commands.
+
+    This restores factory byte defaults and clears per-parser metering state.
+    """
     global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
     DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
     DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
@@ -568,6 +614,7 @@ def uninstall():
 
 
 def is_installed() -> bool:
+    """Return whether local GLIR parsers currently use upload metering."""
     return _enabled
 
 

--- a/vispy/gloo/glir_metering.py
+++ b/vispy/gloo/glir_metering.py
@@ -15,7 +15,7 @@ When enabled, VisPy's GLIR queue dispatches through this module so that
 - a single large texture ``DATA`` command is split into small slab
   sub-uploads (contiguous views along the leading axes, no copies), and
 - each canvas draw spends at most ``frame_budget_bytes`` on texture uploads;
-  the unexecuted commands are retained in a per-context carry queue and a
+  the unexecuted commands are retained in a per-context deferred queue and a
   redraw is requested until that queue is empty.
 
 GLIR ordering semantics are preserved per object: once a command for a
@@ -27,7 +27,7 @@ queue filtering.
 The byte budget is shared by canvases that share a GLIR parser, matching the
 shared OpenGL context that receives the uploads. The budget resets at the
 start of each canvas draw. Offscreen users without draw events receive a
-time-based reset so a carry queue cannot remain stalled indefinitely.
+time-based reset so a deferred queue cannot remain stalled indefinitely.
 
 While metering is enabled, two related sources of GL stalls are also paced.
 Repeated idempotent ``FUNC`` state setters with unchanged arguments are
@@ -63,6 +63,7 @@ with and without metering.
 from __future__ import annotations
 
 import contextlib
+import enum
 import logging
 import time
 import weakref
@@ -72,8 +73,6 @@ import numpy as np
 LOGGER = logging.getLogger(__name__)
 
 __all__ = [
-    'DEFAULT_FRAME_BUDGET_BYTES',
-    'DEFAULT_SLAB_BYTES',
     'add_drain_callback',
     'add_unmetered_texture',
     'discard_unmetered_texture',
@@ -85,10 +84,10 @@ __all__ = [
     'uninstall',
 ]
 
-_FACTORY_FRAME_BUDGET_BYTES = 4 * 2**20
-_FACTORY_SLAB_BYTES = 1 * 2**20
-DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
-DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
+_DEFAULT_FRAME_BUDGET_BYTES = 4 * 2**20
+_DEFAULT_SLAB_BYTES = 1 * 2**20
+_frame_budget_bytes = _DEFAULT_FRAME_BUDGET_BYTES
+_slab_bytes = _DEFAULT_SLAB_BYTES
 #: Deferred GL object deletions executed per quiet flush (a flush with no
 #: texture uploads and no active upload hold). Deletion can synchronize the
 #: GPU pipeline, so only a small batch executes in each such flush.
@@ -96,7 +95,7 @@ DELETE_DRAIN_PER_FLUSH = 4
 #: 2D texture DATA at or above this size is metered like 3D uploads.
 #: Small 2D textures (colormap LUTs, interpolation kernels) MUST stay
 #: synchronous: deferring them leaves a shader sampling an unwritten
-#: texture for however long the carry takes to drain.
+#: texture for however long deferred uploads take to drain.
 TEX2D_MIN_METERED_BYTES = 256 * 1024
 
 # Commands that operate on a specific GLIR object id and therefore must
@@ -236,7 +235,11 @@ def _notify_drained() -> None:
 def pending_upload_bytes() -> int:
     """Return bytes in deferred texture DATA commands across all contexts."""
     return sum(
-        sum(c[3].nbytes for c in state.carry if c[0] == 'DATA')
+        sum(
+            c[3].nbytes
+            for c in state.deferred_commands
+            if c[0] == 'DATA'
+        )
         for state in _states.values()
     )
 
@@ -259,13 +262,13 @@ def hold_uploads_until(deadline: float) -> None:
 
 
 class _ParserState:
-    """Per-GlirParser metering state (carry survives across flushes)."""
+    """Per-GlirParser metering state (deferred work survives flushes)."""
 
     def __init__(self, frame_budget_bytes: int, slab_bytes: int):
         self.frame_budget = int(frame_budget_bytes)
         self.slab_bytes = min(int(slab_bytes), self.frame_budget)
         self.budget_left = self.frame_budget
-        self.carry: list[tuple] = []
+        self.deferred_commands: list[tuple] = []
         self.last_reset = time.perf_counter()
         # last-applied GL state for the redundant-FUNC filter; cleared
         # whenever the context is made current
@@ -299,8 +302,8 @@ _states: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 def _state_for(parser) -> _ParserState:
     state = _states.get(parser)
     if state is None:
-        # read the module globals at call time: install() retunes them
-        state = _ParserState(DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES)
+        # Read the runtime settings at call time: install() retunes them.
+        state = _ParserState(_frame_budget_bytes, _slab_bytes)
         _states[parser] = state
     return state
 
@@ -361,34 +364,37 @@ def _split_slabs(offset, data, slab_bytes):
             yield tuple(sub_offset), sub
 
 
-def _drop_deleted_carry(carry, new_commands):
-    """Drop carried uploads whose texture is deleted in this flush.
+def _drop_deleted_commands(deferred_commands, new_commands):
+    """Drop deferred uploads whose texture is deleted in this flush.
 
-    The carry only ever holds commands for metered textures, so this
+    The deferred queue only ever holds commands for metered textures, so this
     cannot affect other object types (notably shaders, whose DATA must
     survive even though vispy DELETEs them right after LINK).
     """
     deleted = {c[1] for c in new_commands if c[0] == 'DELETE'}
     if not deleted:
-        return carry
-    return [c for c in carry if c[1] not in deleted]
+        return deferred_commands
+    return [c for c in deferred_commands if c[1] not in deleted]
+
+
+class _FlushMode(enum.Enum):
+    SCHEDULED = enum.auto()
+    UPLOAD_HOLD = enum.auto()
+    FORCE_DRAIN = enum.auto()
 
 
 def _metered_parse(
     parser,
     commands,
     state,
-    force_defer=False,
-    force_uploads=False,
-    defer_deletes=True,
+    mode=_FlushMode.SCHEDULED,
 ):
     """Execute commands under the upload budget; return the leftovers.
 
-    With ``force_defer`` every metered texture upload is deferred
-    regardless of budget; other commands still run. This implements the
-    deadline configured by :func:`hold_uploads_until`. ``force_uploads``
-    bypasses both that deadline and the byte budget. ``defer_deletes``
-    controls whether DELETE commands are paced or executed inline.
+    ``UPLOAD_HOLD`` defers every metered upload while allowing other commands
+    to run. ``FORCE_DRAIN`` bypasses both the hold and byte budget and executes
+    DELETE commands inline. ``SCHEDULED`` applies normal upload and deletion
+    pacing.
     """
     # mirror GlirParser.parse's deferred deletion bookkeeping, which we
     # bypass by calling _parse directly
@@ -425,7 +431,7 @@ def _metered_parse(
         elif cmd == 'CURRENT':
             # context switch: cached GL state is no longer trustworthy
             gl_state.clear()
-        elif cmd == 'DELETE' and defer_deletes:
+        elif cmd == 'DELETE' and mode is not _FlushMode.FORCE_DRAIN:
             # run deletes only in quiet flushes (see _ParserState):
             # ordering is safe because anything queued for this id
             # earlier either already executed or was dropped with it
@@ -448,9 +454,9 @@ def _metered_parse(
                     # least one slab even if it alone exceeds the budget
                     fresh = state.budget_left >= state.frame_budget
                     if (
-                        not force_uploads
+                        mode is not _FlushMode.FORCE_DRAIN
                         and (
-                            force_defer
+                            mode is _FlushMode.UPLOAD_HOLD
                             or state.budget_left <= 0
                             or (
                                 sub.nbytes > state.budget_left
@@ -480,7 +486,7 @@ def _metered_parse(
             if id_ in state.dead_ids:
                 continue  # deleted: the command is void, drop it
             # not created yet: keep it (and everything ordered behind
-            # it) in the carry until its CREATE arrives
+            # it) in the deferred queue until its CREATE arrives
             LOGGER.debug('deferring %s for missing object %s', cmd, id_)
             deferred_ids.add(id_)
             leftover.append(command)
@@ -522,6 +528,28 @@ def _drain_deletes(parser, state, limit=None):
         state.dead_ids.add(command[1])
 
 
+def _collect_glir_commands(queue, parser, state):
+    """Merge previously deferred and newly queued GLIR commands."""
+    deferred, state.deferred_commands = state.deferred_commands, []
+    new_commands = queue.clear()
+    deferred = _drop_deleted_commands(deferred, new_commands)
+    commands = queue._filter(deferred + new_commands, parser)
+    return commands, bool(deferred)
+
+
+def _request_redraw_or_notify(canvas, state, had_deferred):
+    """Schedule remaining work or notify consumers that uploads drained."""
+    if state.deferred_commands and canvas is not None:
+        with contextlib.suppress(RuntimeError):
+            canvas.update()
+    elif (
+        had_deferred or state.executed_metered
+    ) and not state.deferred_commands:
+        # Notify even when an upload fit within one budget and was never
+        # deferred; consumers may still need to know it reached the parser.
+        _notify_drained()
+
+
 def _flush(queue, parser, force=False):
     """Flush a GLIR queue with per-frame upload metering."""
     from vispy.gloo.context import get_current_canvas
@@ -538,48 +566,36 @@ def _flush(queue, parser, force=False):
         # glFlush/glFinish command that requested this forced drain.
         _drain_deletes(parser, state)
     # fallback when no canvas draw hook fires (offscreen / bare gloo):
-    # never let the carry starve for more than 0.25 s
+    # Never let deferred work starve for more than 0.25 s.
     if (
-        state.budget_left < state.frame_budget
+        not force
+        and state.budget_left < state.frame_budget
         and time.perf_counter() - state.last_reset > 0.25
     ):
         state.reset_budget()
 
-    carry, state.carry = state.carry, []
-    new_commands = queue.clear()
-    carry = _drop_deleted_carry(carry, new_commands)
-    commands = queue._filter(carry + new_commands, parser)
-    holding = not force and time.monotonic() < _upload_hold_until
-    had_carry = bool(carry)
+    commands, had_deferred = _collect_glir_commands(queue, parser, state)
+    holding = time.monotonic() < _upload_hold_until
+    if force:
+        mode = _FlushMode.FORCE_DRAIN
+    elif holding:
+        mode = _FlushMode.UPLOAD_HOLD
+    else:
+        mode = _FlushMode.SCHEDULED
     state.executed_metered = False
-    state.carry = _metered_parse(
-        parser,
-        commands,
-        state,
-        force_defer=holding,
-        force_uploads=force,
-        defer_deletes=not force,
-    )
+    state.deferred_commands = _metered_parse(parser, commands, state, mode)
     if force:
         # A forced drain is outside the per-draw allowance. Start the next
         # automatic draw with a fresh budget rather than a negative balance.
         state.reset_budget()
 
-    if state.carry and canvas is not None:
-        with contextlib.suppress(RuntimeError):
-            canvas.update()
-    elif (had_carry or state.executed_metered) and not state.carry:
-        # notify on any flush that landed metered uploads and ended
-        # clean. This includes an upload that fit entirely within one budget
-        # and therefore never entered the carry queue; consumers may still
-        # need notification that the DATA command has reached the parser.
-        _notify_drained()
+    _request_redraw_or_notify(canvas, state, had_deferred)
 
     if (
         not force
         and state.deferred_deletes
         and not holding
-        and not state.carry
+        and not state.deferred_commands
         and state.budget_left >= state.frame_budget
     ):
         # A quiet flush executes no uploads and has no active hold. Run
@@ -605,11 +621,11 @@ def install(
     ----------
     frame_budget_bytes : int | None
         Maximum texture DATA bytes executed per canvas draw. ``None`` uses the
-        current module default.
+        current runtime setting.
     slab_bytes : int | None
         Maximum target size of each sub-upload. A texel row or slice that
         cannot be divided further may exceed this value. ``None`` uses the
-        current module default.
+        current runtime setting.
 
     Returns
     -------
@@ -617,22 +633,22 @@ def install(
         ``True`` after successful configuration. Repeated calls are safe and
         update both existing parser states and defaults for future parsers.
     """
-    global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
+    global _enabled, _frame_budget_bytes, _slab_bytes
 
     frame_budget_bytes = int(
-        DEFAULT_FRAME_BUDGET_BYTES
+        _frame_budget_bytes
         if frame_budget_bytes is None
         else frame_budget_bytes
     )
-    slab_bytes = int(DEFAULT_SLAB_BYTES if slab_bytes is None else slab_bytes)
+    slab_bytes = int(_slab_bytes if slab_bytes is None else slab_bytes)
     if frame_budget_bytes <= 0:
         raise ValueError('frame_budget_bytes must be positive')
     if slab_bytes <= 0:
         raise ValueError('slab_bytes must be positive')
 
     # re-parameterize existing states (and set defaults for new ones)
-    DEFAULT_FRAME_BUDGET_BYTES = frame_budget_bytes
-    DEFAULT_SLAB_BYTES = slab_bytes
+    _frame_budget_bytes = frame_budget_bytes
+    _slab_bytes = slab_bytes
     for state in _states.values():
         state.frame_budget = frame_budget_bytes
         state.slab_bytes = min(slab_bytes, frame_budget_bytes)
@@ -651,18 +667,18 @@ def install(
 def uninstall():
     """Disable metering and synchronously execute all deferred commands.
 
-    This restores factory byte defaults and clears per-parser metering state.
+    This restores the built-in byte defaults and clears per-parser state.
     """
-    global _enabled, DEFAULT_FRAME_BUDGET_BYTES, DEFAULT_SLAB_BYTES
-    DEFAULT_FRAME_BUDGET_BYTES = _FACTORY_FRAME_BUDGET_BYTES
-    DEFAULT_SLAB_BYTES = _FACTORY_SLAB_BYTES
+    global _enabled, _frame_budget_bytes, _slab_bytes
+    _frame_budget_bytes = _DEFAULT_FRAME_BUDGET_BYTES
+    _slab_bytes = _DEFAULT_SLAB_BYTES
     if not _enabled:
         return
     _enabled = False
-    # re-queue carried uploads and held deletions so they are not lost
+    # Re-queue deferred uploads and held deletions so they are not lost.
     for parser, state in list(_states.items()):
-        if state.carry:
-            commands, state.carry = state.carry, []
+        if state.deferred_commands:
+            commands, state.deferred_commands = state.deferred_commands, []
             parser.parse(commands)
         if state.deferred_deletes:
             commands, state.deferred_deletes = state.deferred_deletes, []
@@ -691,9 +707,9 @@ def _benchmark():  # pragma: no cover - manual profiling tool
     parser_.add_argument(
         '--budget',
         type=int,
-        default=DEFAULT_FRAME_BUDGET_BYTES,
+        default=_frame_budget_bytes,
     )
-    parser_.add_argument('--slab', type=int, default=DEFAULT_SLAB_BYTES)
+    parser_.add_argument('--slab', type=int, default=_slab_bytes)
     args = parser_.parse_args()
 
     from vispy import app, scene
@@ -733,12 +749,14 @@ def _benchmark():  # pragma: no cover - manual profiling tool
                 volume._texture.set_data(sub, offset=(z, 0, 0))
                 t_set = time.perf_counter() - t0
                 t_draw = timed_draw()
-                # with metering, drain the carry and count total time.
+                # With metering, drain deferred work and count total time.
                 # canvas.render() bypasses the draw event, so emulate the
                 # per-frame budget reset a real paint event would trigger.
                 t_drain = 0.0
                 if metered:
-                    while _states and any(s.carry for s in _states.values()):
+                    while _states and any(
+                        s.deferred_commands for s in _states.values()
+                    ):
                         for s in _states.values():
                             s.reset_budget()
                         t_drain += timed_draw()

--- a/vispy/gloo/tests/test_glir_metering.py
+++ b/vispy/gloo/tests/test_glir_metering.py
@@ -116,7 +116,7 @@ def test_budget_defers_remainder(parser):
     assert data_bytes(parser.executed) == 512 * 2**10
     assert data_bytes(leftover) == 512 * 2**10
     assert state.budget_left == 0
-    # next frame: fresh budget drains the carry
+    # next frame: fresh budget drains the deferred commands
     state.reset_budget()
     leftover2 = gm._metered_parse(parser, leftover, state)
     assert leftover2 == []
@@ -146,7 +146,7 @@ def test_non_texture_commands_run_past_deferred_uploads(parser):
 def test_oversized_single_slab_still_makes_progress(parser):
     parser.add_texture3d(1)
     # a slab that alone exceeds the whole budget: with a fresh budget it
-    # must execute anyway, otherwise the carry never drains
+    # must execute anyway, otherwise the deferred command never drains
     data = np.zeros((1, 64, 64), dtype=np.uint8)
     state = make_state(budget=1024, slab=1024)
     state.slab_bytes = data.nbytes  # force a single indivisible slab
@@ -157,7 +157,7 @@ def test_oversized_single_slab_still_makes_progress(parser):
 
 def test_delete_drops_carried_uploads():
     data = np.zeros((4, 4, 4), dtype=np.uint8)
-    carry = [
+    deferred_commands = [
         ('DATA', 1, (0, 0, 0), data),
         ('DATA', 2, (0, 0, 0), data),
     ]
@@ -168,7 +168,7 @@ def test_delete_drops_carried_uploads():
         ('DATA', 3, 0, 'shader code'),
         ('DELETE', 3),
     ]
-    out = gm._drop_deleted_carry(carry, new_commands)
+    out = gm._drop_deleted_commands(deferred_commands, new_commands)
     assert out == [('DATA', 2, (0, 0, 0), data)]
     assert new_commands == [
         ('DELETE', 1),
@@ -229,6 +229,21 @@ def test_install_uninstall_idempotent():
     gm.uninstall()  # second uninstall is a no-op
 
 
+def test_install_updates_runtime_settings_and_uninstall_restores_defaults():
+    gm.uninstall()
+    try:
+        gm.install(frame_budget_bytes=8 * 2**20, slab_bytes=2 * 2**20)
+        gm.install()
+
+        assert gm._frame_budget_bytes == 8 * 2**20
+        assert gm._slab_bytes == 2 * 2**20
+    finally:
+        gm.uninstall()
+
+    assert gm._frame_budget_bytes == gm._DEFAULT_FRAME_BUDGET_BYTES
+    assert gm._slab_bytes == gm._DEFAULT_SLAB_BYTES
+
+
 def test_install_rejects_nonpositive_limits():
     with pytest.raises(ValueError, match='frame_budget_bytes'):
         gm.install(frame_budget_bytes=0)
@@ -258,6 +273,17 @@ def test_remote_parser_uses_default_flush():
     assert parser.commands[0][0] == 'DATA'
 
 
+def test_force_false_without_metering_uses_default_flush(parser):
+    gm.uninstall()
+    queue = glir.GlirQueue()
+    command = ('FUNC', 'glFlush')
+    queue.command(*command)
+
+    queue.flush(parser, force=False)
+
+    assert parser.executed == [command]
+
+
 def test_metered_flush_carries_and_drains(monkeypatch):
     monkeypatch.setattr(
         'vispy.gloo.context.get_current_canvas',
@@ -276,18 +302,18 @@ def test_metered_flush_carries_and_drains(monkeypatch):
         queue.flush(parser)
         assert data_bytes(parser.executed) == 512 * 2**10
         state = gm._states[parser]
-        assert data_bytes(state.carry) == 512 * 2**10
+        assert data_bytes(state.deferred_commands) == 512 * 2**10
         # next frame: budget reset (simulating the canvas draw hook),
-        # empty queue still drains the carry
+        # empty queue still drains deferred commands
         state.reset_budget()
         queue.flush(parser)
         assert data_bytes(parser.executed) == data.nbytes
-        assert state.carry == []
+        assert state.deferred_commands == []
     finally:
         gm.uninstall()
 
 
-def test_metered_flush_new_size_cancels_carry(monkeypatch):
+def test_metered_flush_new_size_cancels_deferred_commands(monkeypatch):
     monkeypatch.setattr(
         'vispy.gloo.context.get_current_canvas',
         lambda: None,
@@ -304,14 +330,14 @@ def test_metered_flush_new_size_cancels_carry(monkeypatch):
         queue.command('DATA', 1, (0, 0, 0), data)
         queue.flush(parser)
         state = gm._states[parser]
-        assert state.carry
+        assert state.deferred_commands
         # a SIZE re-specification supersedes the carried uploads
         state.reset_budget()
         small = np.zeros((4, 4, 4), dtype=np.uint8)
         queue.command('SIZE', 1, (4, 4, 4), 'luminance', None)
         queue.command('DATA', 1, (0, 0, 0), small)
         queue.flush(parser)
-        assert state.carry == []
+        assert state.deferred_commands == []
         kinds = [c[0] for c in parser.executed]
         assert kinds[-2:] == ['SIZE', 'DATA']
         assert parser.executed[-1][3] is small
@@ -409,14 +435,14 @@ def test_forced_flush_drains_uploads_and_deletes(monkeypatch):
         queue.flush(parser)
 
         state = gm._states[parser]
-        assert state.carry
+        assert state.deferred_commands
         assert state.deferred_deletes == [('DELETE', 7)]
 
         queue.command('FUNC', 'glFlush')
         queue.flush(parser, force=True)
 
         assert data_bytes(parser.executed) == data.nbytes
-        assert state.carry == []
+        assert state.deferred_commands == []
         assert state.deferred_deletes == []
         assert state.budget_left == state.frame_budget
         assert parser.executed[-1] == ('FUNC', 'glFlush')
@@ -466,14 +492,14 @@ def test_deletes_deferred_to_quiet_flush(monkeypatch):
         queue.command('DELETE', 7)  # unrelated object
         queue.flush(parser)
         state = gm._states[parser]
-        # busy flush (uploads executed, carry pending): delete held
-        assert state.carry
+        # busy flush (uploads executed, deferred work pending): delete held
+        assert state.deferred_commands
         assert state.deferred_deletes == [('DELETE', 7)]
         assert all(c[0] != 'DELETE' for c in parser.executed)
-        # drain the carry across quiet-less flushes
+        # drain deferred commands across quiet-less flushes
         state.reset_budget()
         queue.flush(parser)
-        assert not state.carry
+        assert not state.deferred_commands
         # this flush still spent budget on uploads: delete still held
         assert state.deferred_deletes == [('DELETE', 7)]
         # a genuinely quiet flush executes it
@@ -506,8 +532,8 @@ def test_delete_drain_is_paced(monkeypatch):
         queue.flush(parser)  # busy: uploads spent, deletes held
         state = gm._states[parser]
         assert len(state.deferred_deletes) == n_deletes
-        # drain the upload carry
-        while state.carry:
+        # drain deferred uploads
+        while state.deferred_commands:
             state.reset_budget()
             queue.flush(parser)
         executed_deletes = lambda: sum(  # noqa: E731
@@ -577,10 +603,10 @@ def test_glir_flush_never_exceeds_frame_budget(monkeypatch):
                 f'(> budget {budget} + slab {slab})'
             )
             total += flushed
-            if not state.carry:
+            if not state.deferred_commands:
                 break
         # metering bounds each frame but loses nothing overall
-        assert state.carry == []
+        assert state.deferred_commands == []
         assert total == volume.nbytes + image.nbytes
     finally:
         gm.uninstall()
@@ -597,12 +623,12 @@ class _DrainSpy:
 
 
 def test_metered_upload_within_budget_still_notifies_drain(monkeypatch):
-    """A clean flush that landed metered uploads notifies, carry or not.
+    """A clean flush that landed metered uploads notifies after completion.
 
     Uploads small enough to fit one frame budget are never carried, but a
     consumer may still wait for notification that their DATA commands reached
-    the parser. Notification must therefore not depend on a carry queue having
-    existed.
+    the parser. Notification must therefore not depend on commands having
+    been deferred.
     """
     monkeypatch.setattr(
         'vispy.gloo.context.get_current_canvas',
@@ -629,20 +655,20 @@ def test_metered_upload_within_budget_still_notifies_drain(monkeypatch):
         queue.flush(parser)
         assert spy.drains == 1
 
-        # over-budget upload: no notification while the carry drains,
+        # over-budget upload: no notification while deferred work drains,
         # exactly one when the flush that empties it ends clean
         big = np.zeros((32, 512, 512), dtype=np.uint8)  # 8 MiB
         queue.command('DATA', 1, (0, 0, 0), big)
         state.reset_budget()
         queue.flush(parser)
-        assert state.carry
+        assert state.deferred_commands
         assert spy.drains == 1
         for _ in range(8):
             state.reset_budget()
             queue.flush(parser)
-            if not state.carry:
+            if not state.deferred_commands:
                 break
-        assert state.carry == []
+        assert state.deferred_commands == []
         assert spy.drains == 2
     finally:
         gm.remove_drain_callback(spy.on_drain)
@@ -700,7 +726,7 @@ def test_deferred_delete_voids_later_commands(monkeypatch):
         # a late command for the dead object: dropped, no crash
         queue.command('SIZE', 5, 1024)
         queue.flush(parser)
-        assert state.carry == []
+        assert state.deferred_commands == []
         assert all(c[:2] != ('SIZE', 5) for c in parser.executed)
     finally:
         gm.uninstall()
@@ -720,12 +746,12 @@ def test_command_before_create_carried_until_create(monkeypatch):
         queue.command('SIZE', 9, 1024)
         queue.flush(parser)  # would previously raise
         state = gm._states[parser]
-        assert state.carry == [('SIZE', 9, 1024)]
+        assert state.deferred_commands == [('SIZE', 9, 1024)]
         queue.command('CREATE', 9, 'VertexBuffer')
         queue.flush(parser)  # carried SIZE precedes CREATE: retried
         state.reset_budget()
         queue.flush(parser)  # object now exists: the SIZE lands
-        assert state.carry == []
+        assert state.deferred_commands == []
         assert ('SIZE', 9, 1024) in parser.executed
     finally:
         gm.uninstall()

--- a/vispy/gloo/tests/test_glir_metering.py
+++ b/vispy/gloo/tests/test_glir_metering.py
@@ -1,0 +1,657 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""Tests for per-frame GLIR texture upload metering.
+
+These run without a GL context: a fake parser records what would be
+executed and real ``GlirTexture3D`` instances are created via ``__new__``
+(no GL calls) purely so isinstance checks pass.
+"""
+
+import numpy as np
+import pytest
+from vispy.gloo import glir
+
+from vispy.gloo import glir_metering as gm
+
+
+class FakeParser:
+    """Records parsed commands instead of touching GL."""
+
+    supports_texture_upload_metering = True
+
+    def __init__(self):
+        self._objects = {}
+        self.executed = []
+
+    def add_texture3d(self, id_):
+        tex = glir.GlirTexture3D.__new__(glir.GlirTexture3D)
+        self._objects[id_] = tex
+        return tex
+
+    def add_texture2d(self, id_):
+        tex = glir.GlirTexture2D.__new__(glir.GlirTexture2D)
+        self._objects[id_] = tex
+        return tex
+
+    def _parse(self, command):
+        self.executed.append(command)
+
+    def parse(self, commands):
+        for c in commands:
+            self._parse(c)
+
+
+@pytest.fixture
+def parser():
+    return FakeParser()
+
+
+def make_state(budget, slab):
+    return gm._ParserState(frame_budget_bytes=budget, slab_bytes=slab)
+
+
+def data_bytes(commands):
+    return sum(c[3].nbytes for c in commands if c[0] == 'DATA')
+
+
+def test_small_commands_pass_through_in_order(parser):
+    parser.add_texture3d(1)
+    state = make_state(budget=2**20, slab=2**20)
+    small = np.zeros((4, 4, 4), dtype=np.uint8)
+    commands = [
+        ('UNIFORM', 7, 'u_x', 'float', 1.0),
+        ('DATA', 1, (0, 0, 0), small),
+        ('DRAW', 7, 'triangles', None, 1),
+    ]
+    leftover = gm._metered_parse(parser, commands, state)
+    assert leftover == []
+    assert [c[0] for c in parser.executed] == ['UNIFORM', 'DATA', 'DRAW']
+
+
+def test_large_data_split_into_slabs(parser):
+    parser.add_texture3d(1)
+    # 64 z-slices of 64 KiB each = 4 MiB total, 256 KiB slabs
+    data = (
+        np.arange(64 * 256 * 256, dtype=np.uint8)
+        .reshape(64, 256, 256)
+        .copy()  # own the buffer so the .base view check below holds
+    )
+    state = make_state(budget=64 * 2**20, slab=256 * 2**10)
+    leftover = gm._metered_parse(parser, [('DATA', 1, (8, 0, 0), data)], state)
+    assert leftover == []
+    executed = parser.executed
+    assert all(c[0] == 'DATA' for c in executed)
+    assert len(executed) == 16  # 4 MiB / 256 KiB
+    # offsets advance along z from the original offset
+    assert [c[2][0] for c in executed] == [8 + 4 * i for i in range(16)]
+    assert all(c[2][1:] == (0, 0) for c in executed)
+    # reassembly reproduces the original payload
+    reassembled = np.concatenate([c[3] for c in executed], axis=0)
+    np.testing.assert_array_equal(reassembled, data)
+    # slabs are views, not copies
+    assert all(c[3].base is data for c in executed)
+
+
+def test_single_slice_too_large_splits_rows(parser):
+    parser.add_texture3d(1)
+    # one z-slice of 1 MiB with a 256 KiB slab limit -> split along y
+    data = np.zeros((1, 1024, 1024), dtype=np.uint8)
+    state = make_state(budget=64 * 2**20, slab=256 * 2**10)
+    leftover = gm._metered_parse(parser, [('DATA', 1, (3, 0, 0), data)], state)
+    assert leftover == []
+    assert len(parser.executed) == 4
+    assert [c[2] for c in parser.executed] == [
+        (3, 256 * i, 0) for i in range(4)
+    ]
+    assert all(c[3].shape == (1, 256, 1024) for c in parser.executed)
+
+
+def test_budget_defers_remainder(parser):
+    parser.add_texture3d(1)
+    data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+    state = make_state(budget=512 * 2**10, slab=128 * 2**10)
+    leftover = gm._metered_parse(parser, [('DATA', 1, (0, 0, 0), data)], state)
+    assert data_bytes(parser.executed) == 512 * 2**10
+    assert data_bytes(leftover) == 512 * 2**10
+    assert state.budget_left == 0
+    # next frame: fresh budget drains the carry
+    state.reset_budget()
+    leftover2 = gm._metered_parse(parser, leftover, state)
+    assert leftover2 == []
+    assert data_bytes(parser.executed) == data.nbytes
+
+
+def test_non_texture_commands_run_past_deferred_uploads(parser):
+    parser.add_texture3d(1)
+    data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+    state = make_state(budget=256 * 2**10, slab=256 * 2**10)
+    commands = [
+        ('DATA', 1, (0, 0, 0), data),
+        ('UNIFORM', 7, 'u_x', 'float', 1.0),
+        ('DRAW', 7, 'triangles', None, 1),
+        # but same-id commands stay ordered behind the deferred upload
+        ('WRAPPING', 1, ('clamp_to_edge',) * 3),
+    ]
+    leftover = gm._metered_parse(parser, commands, state)
+    executed_kinds = [c[0] for c in parser.executed]
+    assert 'UNIFORM' in executed_kinds
+    assert 'DRAW' in executed_kinds
+    assert 'WRAPPING' not in executed_kinds
+    assert leftover[-1][0] == 'WRAPPING'
+    assert all(c[0] == 'DATA' for c in leftover[:-1])
+
+
+def test_oversized_single_slab_still_makes_progress(parser):
+    parser.add_texture3d(1)
+    # a slab that alone exceeds the whole budget: with a fresh budget it
+    # must execute anyway, otherwise the carry never drains
+    data = np.zeros((1, 64, 64), dtype=np.uint8)
+    state = make_state(budget=1024, slab=1024)
+    state.slab_bytes = data.nbytes  # force a single indivisible slab
+    leftover = gm._metered_parse(parser, [('DATA', 1, (0, 0, 0), data)], state)
+    assert leftover == []
+    assert data_bytes(parser.executed) == data.nbytes
+
+
+def test_delete_drops_carried_uploads():
+    data = np.zeros((4, 4, 4), dtype=np.uint8)
+    carry = [
+        ('DATA', 1, (0, 0, 0), data),
+        ('DATA', 2, (0, 0, 0), data),
+    ]
+    new_commands = [
+        ('DELETE', 1),
+        # shader-style DATA-then-DELETE in the new commands must be
+        # left alone (vispy deletes shaders right after LINK)
+        ('DATA', 3, 0, 'shader code'),
+        ('DELETE', 3),
+    ]
+    out = gm._drop_deleted_carry(carry, new_commands)
+    assert out == [('DATA', 2, (0, 0, 0), data)]
+    assert new_commands == [
+        ('DELETE', 1),
+        ('DATA', 3, 0, 'shader code'),
+        ('DELETE', 3),
+    ]
+
+
+def test_unknown_object_data_unmetered(parser):
+    # DATA for buffers/shaders (not metered textures) passes through
+    state = make_state(budget=1, slab=1)
+    big = np.zeros((1024, 1024), dtype=np.float32)
+    leftover = gm._metered_parse(parser, [('DATA', 99, 0, big)], state)
+    assert leftover == []
+    assert parser.executed == [('DATA', 99, 0, big)]
+
+
+def test_large_2d_texture_metered(parser):
+    parser.add_texture2d(1)
+    # 4 MiB image upload, 256 KiB slabs, 1 MiB budget: 4 slabs run,
+    # the rest carries to the next frame
+    data = np.zeros((1024, 4096), dtype=np.uint8)
+    state = make_state(budget=2**20, slab=256 * 2**10)
+    leftover = gm._metered_parse(parser, [('DATA', 1, (0, 0), data)], state)
+    assert data_bytes(parser.executed) == 2**20
+    assert data_bytes(leftover) == data.nbytes - 2**20
+    # offsets advance along rows
+    assert [c[2][0] for c in parser.executed] == [64 * i for i in range(4)]
+
+
+def test_small_2d_texture_not_metered(parser):
+    # colormap-LUT-sized uploads must run synchronously even with an
+    # exhausted budget: a deferred LUT leaves the shader sampling an
+    # unwritten texture
+    parser.add_texture2d(1)
+    state = make_state(budget=2**20, slab=256 * 2**10)
+    state.budget_left = 0
+    lut = np.zeros((256, 4), dtype=np.float32)  # 4 KiB
+    leftover = gm._metered_parse(parser, [('DATA', 1, (0, 0), lut)], state)
+    assert leftover == []
+    assert parser.executed == [('DATA', 1, (0, 0), lut)]
+
+
+def test_install_uninstall_idempotent():
+    # Metering is dispatched natively by the queue, so enabling it does
+    # not replace the flush method.
+    gm.uninstall()
+    original = glir._GlirQueueShare.flush
+    try:
+        assert gm.install()
+        assert gm.is_installed()
+        assert gm.install()  # second install is a no-op
+        assert glir._GlirQueueShare.flush is original
+    finally:
+        gm.uninstall()
+    assert glir._GlirQueueShare.flush is original
+    assert not gm.is_installed()
+    gm.uninstall()  # second uninstall is a no-op
+
+
+def test_install_rejects_nonpositive_limits():
+    with pytest.raises(ValueError, match='frame_budget_bytes'):
+        gm.install(frame_budget_bytes=0)
+    with pytest.raises(ValueError, match='slab_bytes'):
+        gm.install(slab_bytes=-1)
+
+
+def test_remote_parser_uses_default_flush():
+    class RemoteParser:
+        supports_texture_upload_metering = False
+
+        def __init__(self):
+            self.commands = []
+
+        def parse(self, commands):
+            self.commands.extend(commands)
+
+    parser = RemoteParser()
+    queue = glir.GlirQueue()
+    queue.command('DATA', 1, 0, np.zeros(8, dtype=np.uint8))
+    try:
+        gm.install()
+        queue.flush(parser)
+    finally:
+        gm.uninstall()
+    assert len(parser.commands) == 1
+    assert parser.commands[0][0] == 'DATA'
+
+
+def test_metered_flush_carries_and_drains(monkeypatch):
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    try:
+        assert gm.install(
+            frame_budget_bytes=512 * 2**10,
+            slab_bytes=128 * 2**10,
+        )
+        queue = glir.GlirQueue()
+        data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+        queue.command('DATA', 1, (0, 0, 0), data)
+        queue.flush(parser)
+        assert data_bytes(parser.executed) == 512 * 2**10
+        state = gm._states[parser]
+        assert data_bytes(state.carry) == 512 * 2**10
+        # next frame: budget reset (simulating the canvas draw hook),
+        # empty queue still drains the carry
+        state.reset_budget()
+        queue.flush(parser)
+        assert data_bytes(parser.executed) == data.nbytes
+        assert state.carry == []
+    finally:
+        gm.uninstall()
+
+
+def test_metered_flush_new_size_cancels_carry(monkeypatch):
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    try:
+        assert gm.install(
+            frame_budget_bytes=512 * 2**10,
+            slab_bytes=128 * 2**10,
+        )
+        queue = glir.GlirQueue()
+        data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+        queue.command('DATA', 1, (0, 0, 0), data)
+        queue.flush(parser)
+        state = gm._states[parser]
+        assert state.carry
+        # a SIZE re-specification supersedes the carried uploads
+        state.reset_budget()
+        small = np.zeros((4, 4, 4), dtype=np.uint8)
+        queue.command('SIZE', 1, (4, 4, 4), 'luminance', None)
+        queue.command('DATA', 1, (0, 0, 0), small)
+        queue.flush(parser)
+        assert state.carry == []
+        kinds = [c[0] for c in parser.executed]
+        assert kinds[-2:] == ['SIZE', 'DATA']
+        assert parser.executed[-1][3] is small
+        # none of the stale 1 MiB payload was uploaded after the SIZE
+        assert data_bytes(parser.executed) == 512 * 2**10 + small.nbytes
+    finally:
+        gm.uninstall()
+
+
+def test_redundant_gl_state_calls_skipped(parser):
+    state = make_state(budget=2**20, slab=2**20)
+    commands = [
+        ('FUNC', 'glEnable', 'blend'),
+        ('FUNC', 'glBlendFunc', 'src_alpha', 'one_minus_src_alpha'),
+        ('FUNC', 'glEnable', 'blend'),  # duplicate: skipped
+        ('FUNC', 'glBlendFunc', 'src_alpha', 'one_minus_src_alpha'),  # dup
+        ('FUNC', 'glEnable', 'depth_test'),  # different capability: kept
+        ('FUNC', 'glDisable', 'blend'),  # state transition: kept
+        ('FUNC', 'glEnable', 'blend'),  # transition back: kept
+        ('FUNC', 'glBlendFunc', 'one', 'one'),  # changed args: kept
+        ('FUNC', 'glClear', 17664),  # never cached
+        ('FUNC', 'glClear', 17664),
+    ]
+    leftover = gm._metered_parse(parser, commands, state)
+    assert leftover == []
+    executed = [c[1:] for c in parser.executed]
+    assert executed == [
+        ('glEnable', 'blend'),
+        ('glBlendFunc', 'src_alpha', 'one_minus_src_alpha'),
+        ('glEnable', 'depth_test'),
+        ('glDisable', 'blend'),
+        ('glEnable', 'blend'),
+        ('glBlendFunc', 'one', 'one'),
+        ('glClear', 17664),
+        ('glClear', 17664),
+    ]
+    # the cache persists across flushes (GL state is per-context)
+    leftover = gm._metered_parse(
+        parser, [('FUNC', 'glBlendFunc', 'one', 'one')], state
+    )
+    assert leftover == []
+    assert len(parser.executed) == 8
+
+
+def test_viewport_and_clearcolor_deduped(parser):
+    state = make_state(budget=2**20, slab=2**20)
+    commands = [
+        ('FUNC', 'glViewport', 0, 0, 800, 600),
+        ('FUNC', 'glClearColor', 0.0, 0.0, 0.0, 1.0),
+        ('FUNC', 'glViewport', 0, 0, 800, 600),  # duplicate: skipped
+        ('FUNC', 'glClearColor', 0.0, 0.0, 0.0, 1.0),  # dup: skipped
+        ('FUNC', 'glViewport', 0, 0, 400, 300),  # changed: kept
+        ('FUNC', 'glViewport', 0, 0, 800, 600),  # changed back: kept
+    ]
+    leftover = gm._metered_parse(parser, commands, state)
+    assert leftover == []
+    assert [c[2:] for c in parser.executed if c[1] == 'glViewport'] == [
+        (0, 0, 800, 600),
+        (0, 0, 400, 300),
+        (0, 0, 800, 600),
+    ]
+    assert len([c for c in parser.executed if c[1] == 'glClearColor']) == 1
+
+
+def test_deletes_deferred_to_quiet_flush(monkeypatch):
+
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    try:
+        assert gm.install(
+            frame_budget_bytes=512 * 2**10, slab_bytes=128 * 2**10
+        )
+        queue = glir.GlirQueue()
+        data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+        queue.command('DATA', 1, (0, 0, 0), data)
+        queue.command('DELETE', 7)  # unrelated object
+        queue.flush(parser)
+        state = gm._states[parser]
+        # busy flush (uploads executed, carry pending): delete held
+        assert state.carry
+        assert state.deferred_deletes == [('DELETE', 7)]
+        assert all(c[0] != 'DELETE' for c in parser.executed)
+        # drain the carry across quiet-less flushes
+        state.reset_budget()
+        queue.flush(parser)
+        assert not state.carry
+        # this flush still spent budget on uploads: delete still held
+        assert state.deferred_deletes == [('DELETE', 7)]
+        # a genuinely quiet flush executes it
+        state.reset_budget()
+        queue.flush(parser)
+        assert state.deferred_deletes == []
+        assert parser.executed[-1] == ('DELETE', 7)
+    finally:
+        gm.uninstall()
+
+
+def test_delete_drain_is_paced(monkeypatch):
+    """A big delete backlog drains a few per quiet flush, not all at
+    once — each deletion can sync the GPU pipeline, so a bulk drain is
+    itself a multi-second stall at pass end.
+    """
+
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    try:
+        assert gm.install(
+            frame_budget_bytes=512 * 2**10, slab_bytes=128 * 2**10
+        )
+        queue = glir.GlirQueue()
+        data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+        queue.command('DATA', 1, (0, 0, 0), data)
+        n_deletes = gm.DELETE_DRAIN_PER_FLUSH * 2 + 3
+        for i in range(n_deletes):
+            queue.command('DELETE', 100 + i)
+        queue.flush(parser)  # busy: uploads spent, deletes held
+        state = gm._states[parser]
+        assert len(state.deferred_deletes) == n_deletes
+        # drain the upload carry
+        while state.carry:
+            state.reset_budget()
+            queue.flush(parser)
+        executed_deletes = lambda: sum(  # noqa: E731
+            c[0] == 'DELETE' for c in parser.executed
+        )
+        before = executed_deletes()
+        state.reset_budget()
+        queue.flush(parser)  # quiet: paced batch only
+        assert executed_deletes() - before == gm.DELETE_DRAIN_PER_FLUSH
+        assert len(state.deferred_deletes) == (
+            n_deletes - gm.DELETE_DRAIN_PER_FLUSH
+        )
+        # subsequent quiet flushes drain the rest
+        for _ in range(3):
+            state.reset_budget()
+            queue.flush(parser)
+        assert not state.deferred_deletes
+        assert executed_deletes() == n_deletes
+    finally:
+        gm.uninstall()
+
+
+def test_uninstall_flushes_deferred_deletes(monkeypatch):
+
+    parser = FakeParser()
+    try:
+        assert gm.install()
+        state = gm._state_for(parser)
+        state.deferred_deletes.append(('DELETE', 3))
+    finally:
+        gm.uninstall()
+    assert parser.executed == [('DELETE', 3)]
+
+
+def test_glir_flush_never_exceeds_frame_budget(monkeypatch):
+    """No single flush uploads more than one frame budget of texture data.
+
+    This is the mechanism bound behind "one draw can't stall for seconds
+    on a giant upload": however much DATA accumulates between draws (a
+    level switch stages a whole tile at once), each flush lands at most
+    ``frame_budget_bytes`` (plus at most one indivisible slab) and
+    carries the rest — for 3D volumes and large 2D image tiles alike.
+    """
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    parser.add_texture2d(2)
+    budget, slab = 4 * 2**20, 2**20
+    try:
+        assert gm.install(frame_budget_bytes=budget, slab_bytes=slab)
+        state = gm._state_for(parser)
+        queue = glir.GlirQueue()
+        volume = np.zeros((128, 512, 512), dtype=np.uint8)  # 32 MiB
+        image = np.zeros((2048, 4096), dtype=np.uint8)  # 8 MiB
+        queue.command('DATA', 1, (0, 0, 0), volume)
+        queue.command('DATA', 2, (0, 0), image)
+
+        total = 0
+        for _ in range(64):
+            executed_before = len(parser.executed)
+            state.reset_budget()  # what the per-draw canvas hook does
+            queue.flush(parser)
+            flushed = data_bytes(parser.executed[executed_before:])
+            assert flushed <= budget + slab, (
+                f'one flush uploaded {flushed} bytes '
+                f'(> budget {budget} + slab {slab})'
+            )
+            total += flushed
+            if not state.carry:
+                break
+        # metering bounds each frame but loses nothing overall
+        assert state.carry == []
+        assert total == volume.nbytes + image.nbytes
+    finally:
+        gm.uninstall()
+
+
+class _DrainSpy:
+    """Bound-method holder for add_drain_callback (WeakMethod target)."""
+
+    def __init__(self):
+        self.drains = 0
+
+    def on_drain(self):
+        self.drains += 1
+
+
+def test_metered_upload_within_budget_still_notifies_drain(monkeypatch):
+    """A clean flush that landed metered uploads notifies, carry or not.
+
+    Uploads small enough to fit one frame budget are never carried, but
+    a present (texture swap) may still be gated on them; if the drain
+    notification only fired when a carry emptied, that present would
+    wait for the next interaction — the "stops loading tiles until I
+    touch the viewer" stall.
+    """
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    spy = _DrainSpy()
+    try:
+        assert gm.install(frame_budget_bytes=4 * 2**20, slab_bytes=2**20)
+        gm.add_drain_callback(spy.on_drain)
+        state = gm._state_for(parser)
+        queue = glir.GlirQueue()
+
+        # no metered uploads at all: no notification
+        queue.command('UNIFORM', 7, 'u_x', 'float', 1.0)
+        queue.flush(parser)
+        assert spy.drains == 0
+
+        # within-budget upload: executed immediately, never carried —
+        # the flush ends clean and MUST still notify
+        small = np.zeros((4, 64, 64), dtype=np.uint8)
+        queue.command('DATA', 1, (0, 0, 0), small)
+        queue.flush(parser)
+        assert spy.drains == 1
+
+        # over-budget upload: no notification while the carry drains,
+        # exactly one when the flush that empties it ends clean
+        big = np.zeros((32, 512, 512), dtype=np.uint8)  # 8 MiB
+        queue.command('DATA', 1, (0, 0, 0), big)
+        state.reset_budget()
+        queue.flush(parser)
+        assert state.carry
+        assert spy.drains == 1
+        for _ in range(8):
+            state.reset_budget()
+            queue.flush(parser)
+            if not state.carry:
+                break
+        assert state.carry == []
+        assert spy.drains == 2
+    finally:
+        gm.remove_drain_callback(spy.on_drain)
+        gm.uninstall()
+
+
+class StrictParser(FakeParser):
+    """FakeParser that enforces vispy's object-existence invariant.
+
+    Real ``GlirParser._parse`` raises ``RuntimeError(... does not
+    exist)`` for object commands whose id was never created (or was
+    deleted); mimic that so ordering regressions surface.
+    """
+
+    def _parse(self, command):
+        cmd, id_ = command[0], command[1]
+        if cmd == 'CREATE':
+            self._objects[id_] = object()
+        elif cmd == 'DELETE':
+            self._objects.pop(id_, None)
+        elif (
+            cmd in ('SIZE', 'DATA', 'WRAPPING', 'INTERPOLATION')
+            and id_ not in self._objects
+        ):
+            raise RuntimeError(
+                f'Cannot {cmd} object {id_} because it does not exist',
+            )
+        super()._parse(command)
+
+
+def test_deferred_delete_voids_later_commands(monkeypatch):
+    """Commands arriving after a deferred DELETE executed must be
+    dropped, not crash.
+
+    The deferred-DELETE drain reorders deletes past later flushes, so a
+    SIZE/DATA for the dead object (e.g. from another canvas's queue on
+    a shared context) can reach the parser after the object is gone —
+    vanilla vispy would have voided it inline. Regression test for
+    ``RuntimeError: Cannot SIZE object N because it does not exist``.
+    """
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = StrictParser()
+    try:
+        assert gm.install(frame_budget_bytes=2**20, slab_bytes=2**20)
+        queue = glir.GlirQueue()
+        queue.command('CREATE', 5, 'VertexBuffer')
+        queue.command('DELETE', 5)
+        queue.flush(parser)  # quiet flush: the deferred delete drains
+        state = gm._states[parser]
+        assert state.deferred_deletes == []
+        assert 5 in state.dead_ids
+        # a late command for the dead object: dropped, no crash
+        queue.command('SIZE', 5, 1024)
+        queue.flush(parser)
+        assert state.carry == []
+        assert all(c[:2] != ('SIZE', 5) for c in parser.executed)
+    finally:
+        gm.uninstall()
+
+
+def test_command_before_create_carried_until_create(monkeypatch):
+    """A command for a not-yet-created object defers instead of crashing
+    and executes once its CREATE has arrived."""
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = StrictParser()
+    try:
+        assert gm.install(frame_budget_bytes=2**20, slab_bytes=2**20)
+        queue = glir.GlirQueue()
+        queue.command('SIZE', 9, 1024)
+        queue.flush(parser)  # would previously raise
+        state = gm._states[parser]
+        assert state.carry == [('SIZE', 9, 1024)]
+        queue.command('CREATE', 9, 'VertexBuffer')
+        queue.flush(parser)  # carried SIZE precedes CREATE: retried
+        state.reset_budget()
+        queue.flush(parser)  # object now exists: the SIZE lands
+        assert state.carry == []
+        assert ('SIZE', 9, 1024) in parser.executed
+    finally:
+        gm.uninstall()

--- a/vispy/gloo/tests/test_glir_metering.py
+++ b/vispy/gloo/tests/test_glir_metering.py
@@ -13,6 +13,7 @@ import pytest
 from vispy.gloo import glir
 
 from vispy.gloo import glir_metering as gm
+from vispy.gloo.wrappers import BaseGlooFunctions
 
 
 class FakeParser:
@@ -355,6 +356,20 @@ def test_redundant_gl_state_calls_skipped(parser):
     assert len(parser.executed) == 8
 
 
+def test_current_invalidates_applied_gl_state_cache(monkeypatch):
+    parser = glir.GlirParser()
+    state = gm._state_for(parser)
+    state.gl_state[('fn', 'glBlendFunc')] = ('one', 'one')
+    monkeypatch.setattr(parser, '_gl_initialize', lambda: None)
+    monkeypatch.setattr(glir.gl, 'glBindFramebuffer', lambda *args: None)
+
+    try:
+        parser._parse(('CURRENT', 0, 0))
+        assert state.gl_state == {}
+    finally:
+        gm._states.pop(parser, None)
+
+
 def test_viewport_and_clearcolor_deduped(parser):
     state = make_state(budget=2**20, slab=2**20)
     commands = [
@@ -373,6 +388,68 @@ def test_viewport_and_clearcolor_deduped(parser):
         (0, 0, 800, 600),
     ]
     assert len([c for c in parser.executed if c[1] == 'glClearColor']) == 1
+
+
+def test_forced_flush_drains_uploads_and_deletes(monkeypatch):
+    monkeypatch.setattr(
+        'vispy.gloo.context.get_current_canvas',
+        lambda: None,
+    )
+    parser = FakeParser()
+    parser.add_texture3d(1)
+    try:
+        assert gm.install(
+            frame_budget_bytes=256 * 2**10,
+            slab_bytes=128 * 2**10,
+        )
+        queue = glir.GlirQueue()
+        data = np.zeros((16, 256, 256), dtype=np.uint8)  # 1 MiB
+        queue.command('DATA', 1, (0, 0, 0), data)
+        queue.command('DELETE', 7)
+        queue.flush(parser)
+
+        state = gm._states[parser]
+        assert state.carry
+        assert state.deferred_deletes == [('DELETE', 7)]
+
+        queue.command('FUNC', 'glFlush')
+        queue.flush(parser, force=True)
+
+        assert data_bytes(parser.executed) == data.nbytes
+        assert state.carry == []
+        assert state.deferred_deletes == []
+        assert state.budget_left == state.frame_budget
+        assert parser.executed[-1] == ('FUNC', 'glFlush')
+        assert parser.executed.index(('DELETE', 7)) < len(parser.executed) - 1
+    finally:
+        gm.uninstall()
+
+
+def test_explicit_flush_and_finish_request_forced_drain():
+    class Queue:
+        def __init__(self):
+            self.commands = []
+
+        def command(self, *command):
+            self.commands.append(command)
+
+    class Context:
+        def __init__(self):
+            self.glir = Queue()
+            self.force_args = []
+
+        def flush_commands(self, *, force=False):
+            self.force_args.append(force)
+
+    context = Context()
+    BaseGlooFunctions.flush(context)
+    BaseGlooFunctions.finish(context)
+
+    assert context.glir.commands == [
+        ('FUNC', 'glFlush'),
+        ('FUNC', 'glFinish'),
+    ]
+    assert context.force_args == [True, True]
 
 
 def test_deletes_deferred_to_quiet_flush(monkeypatch):

--- a/vispy/gloo/tests/test_glir_metering.py
+++ b/vispy/gloo/tests/test_glir_metering.py
@@ -468,11 +468,9 @@ def test_uninstall_flushes_deferred_deletes(monkeypatch):
 def test_glir_flush_never_exceeds_frame_budget(monkeypatch):
     """No single flush uploads more than one frame budget of texture data.
 
-    This is the mechanism bound behind "one draw can't stall for seconds
-    on a giant upload": however much DATA accumulates between draws (a
-    level switch stages a whole tile at once), each flush lands at most
-    ``frame_budget_bytes`` (plus at most one indivisible slab) and
-    carries the rest — for 3D volumes and large 2D image tiles alike.
+    However much DATA accumulates between draws, each flush executes at most
+    ``frame_budget_bytes`` (plus at most one indivisible slab) and carries the
+    rest. This applies to both 3D volumes and large 2D textures.
     """
     monkeypatch.setattr(
         'vispy.gloo.context.get_current_canvas',
@@ -524,11 +522,10 @@ class _DrainSpy:
 def test_metered_upload_within_budget_still_notifies_drain(monkeypatch):
     """A clean flush that landed metered uploads notifies, carry or not.
 
-    Uploads small enough to fit one frame budget are never carried, but
-    a present (texture swap) may still be gated on them; if the drain
-    notification only fired when a carry emptied, that present would
-    wait for the next interaction — the "stops loading tiles until I
-    touch the viewer" stall.
+    Uploads small enough to fit one frame budget are never carried, but a
+    consumer may still wait for notification that their DATA commands reached
+    the parser. Notification must therefore not depend on a carry queue having
+    existed.
     """
     monkeypatch.setattr(
         'vispy.gloo.context.get_current_canvas',

--- a/vispy/gloo/wrappers.py
+++ b/vispy/gloo/wrappers.py
@@ -557,7 +557,7 @@ class BaseGlooFunctions(object):
         else:
             context = get_current_canvas().context
         context.glir.command('FUNC', 'glFinish')
-        context.flush_commands()  # Process GLIR commands
+        context.flush_commands(force=True)  # Process all GLIR commands
 
     def flush(self):
         """Flush GL commands
@@ -570,7 +570,7 @@ class BaseGlooFunctions(object):
         else:
             context = get_current_canvas().context
         context.glir.command('FUNC', 'glFlush')
-        context.flush_commands()  # Process GLIR commands
+        context.flush_commands(force=True)  # Process all GLIR commands
 
     def set_hint(self, target, mode):
         """Set OpenGL drawing hint


### PR DESCRIPTION
## Summary

Add native, opt-in GLIR texture-upload metering for applications that update large textures incrementally.

- split large 2-D and 3-D texture `DATA` commands into bounded slabs
- enforce a configurable per-draw upload budget while preserving per-object GLIR ordering
- retain deferred commands in a per-context carry queue and schedule redraws until it is empty
- support explicit upload holds, weak drain callbacks, and exemptions for textures that must be initialized atomically
- deduplicate redundant GL state commands
- leave default queue behavior and remote GLIR parsers unchanged

Metering is dispatched natively by `_GlirQueueShare.flush`; enabling it does not replace or monkey-patch VisPy methods. The public entry point is `vispy.gloo.glir_metering.install(...)`.

## Motivation

A regular VisPy flush executes every queued texture upload during the next draw. Applications can accumulate tens of megabytes of `glTexSubImage2D` or `glTexSubImage3D` work between draws, turning that draw into a long blocking operation and delaying input handling, particularly on macOS when OpenGL calls are translated to Metal. A per-draw byte budget spreads that work over multiple draws.

## Validation

- focused GLIR suite: 25 passed, 6 skipped
- complete gloo suite: 153 passed
- isolated no-backend suite: 444 passed, 64 skipped, 1 expected failure
- Flake8 and `git diff --check` pass

The tests use fake parsers and require no GL context. They cover slab reconstruction, byte bounds, command ordering, SIZE/DELETE cancellation, remote-parser fallback, upload holds, and callbacks.

## Related work

This API is intended to replace the GLIR monkey-patch currently carried by napari in napari/napari#9067.

GLIR object-deletion pacing was removed from this PR to keep upload metering focused. It is preserved provisionally in draft #2790 and should be evaluated only after this PR merges and downstream napari testing can determine whether it provides a measurable benefit.