### PR TITLE
ci: update upload jobs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,7 +66,7 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         # upload to Test PyPI for every commit on main branch
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
         with:
@@ -88,7 +88,7 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         # upload to PyPI on every tag starting with 'v'
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
         with:


### PR DESCRIPTION
I saw that the CI failed upon merging my PR to main. Looking into it I saw the following warning:
```
You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.

Checking dist/vispy-0.16.3.dev18-cp310-cp310-macosx_10_9_x86_64.whl: ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a     
         valid metadata version   
```
This PR just applies the suggested fix. Reading up I believe this also fix the metadata version issue. We just need the publish action to use a sufficient version of Twine: https://twine.readthedocs.io/en/latest/changelog.html#deprecations-and-removals